### PR TITLE
Improve error handling and move from MeiliSearch 0.11 to MeiliSearch 0.12 errors.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -182,16 +182,18 @@ impl<'a> Client<'a> {
     /// # Example
     ///
     /// ```
-    /// # use meilisearch_sdk::{client::*, indexes::*, errors::Error};
+    /// # use meilisearch_sdk::{client::*, indexes::*, errors::{Error, ErrorCode}};
     /// #
     /// # #[tokio::main]
     /// # async fn main() {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     ///
     /// match client.get_health().await {
-    ///     Ok(()) => println!("server is operationnal"),
-    ///     Err(Error::ServerInMaintenance) => eprintln!("server is in maintenance"),
-    ///     _ => panic!("should never happen"),
+    ///     Ok(()) => println!("server is operational"),
+    ///     Err(Error::MeiliSearchError { error_code: ErrorCode::Maintenance, .. }) => {
+    ///         eprintln!("server is in maintenance")
+    ///     },
+    ///     Err(e) => panic!("should never happen: {}", e),
     /// }
     /// # }
     /// ```
@@ -203,7 +205,9 @@ impl<'a> Client<'a> {
             204,
         ).await;
         match r {
-            Err(Error::Unknown(m)) if &m == "null" => Ok(()),
+            // This shouldn't be an error; The status code is 200, but the request
+            // function only supports one successful error code for some reason
+            Err(Error::Empty) => Ok(()),
             e => e
         }
     }
@@ -236,7 +240,9 @@ impl<'a> Client<'a> {
             204,
         ).await;
         match r {
-            Err(Error::Unknown(m)) if &m == "null" => Ok(()),
+            // This shouldn't be an error; The status code is 200, but the request
+            // function only supports one successful error code for some reason
+            Err(Error::Empty) => Ok(()),
             e => e
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -203,12 +203,13 @@ impl<'a> Client<'a> {
             self.apikey,
             Method::Get,
             204,
-        ).await;
+        )
+        .await;
         match r {
             // This shouldn't be an error; The status code is 200, but the request
             // function only supports one successful error code for some reason
             Err(Error::Empty) => Ok(()),
-            e => e
+            e => e,
         }
     }
 
@@ -238,12 +239,13 @@ impl<'a> Client<'a> {
             self.apikey,
             Method::Put(HealthBody { health }),
             204,
-        ).await;
+        )
+        .await;
         match r {
             // This shouldn't be an error; The status code is 200, but the request
             // function only supports one successful error code for some reason
             Err(Error::Empty) => Ok(()),
-            e => e
+            e => e,
         }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,16 +1,18 @@
 /// The enum representing the errors that can occur
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum Error {
     MeiliSearchError {
         /// The human readable error message
         message: String,
-        /// The error code of the error.  For MeiliSearch versions before v12,
-        /// this is an approximation of the real error code, as MeiliSearch did
-        /// not send a machine readable error code.
+        /// The error code of the error.  Officially documented at
+        /// https://docs.meilisearch.com/errors.
         error_code: ErrorCode,
-        /// A link to the MeiliSearch documentation for an error.  Only exists
-        /// for MeiliSearch versions v12 and above.
-        error_link: Option<String>,
+        /// The type of error (invalid request, internal error, or authentication
+        /// error)
+        error_type: ErrorType,
+        /// A link to the MeiliSearch documentation for an error.
+        error_link: String,
     },
 
     /// There is no MeiliSearch server listening on the [specified host]
@@ -18,57 +20,181 @@ pub enum Error {
     UnreachableServer,
     /// The MeiliSearch server returned invalid JSON for a request.
     ParseError(serde_json::Error),
-    /// An unknown error
-    Unknown(String),
     /// An erroring status code, but no body
+    // This is a hack to make Client::get_health work, since the request module
+    // treats anything other than the expected status as an error.  Since 204 is
+    // specified, a successful status of 200 is treated as an error with an
+    // empty body.
     Empty,
 
     /// The http client encountered an error.
     #[cfg(not(target_arch = "wasm32"))]
     HttpError(reqwest::Error),
-    /// Can never occur on the wasm target.
+    /// The http client encountered an error.
     #[cfg(target_arch = "wasm32")]
-    HttpError(()),
+    HttpError(String),
+}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum ErrorType {
+    InvalidRequest,
+    Internal,
+    Authentication,
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorCode {
+    /// An error occurred while trying to create an index.
     IndexCreationFailed,
-    /// You tried to create an Index that already exists. You may want to use the [get_or_create method](../client/struct.Client.html#method.get_or_create).
+    /// An index with this UID already exists. You may want to use the
+    /// [`get_or_create` method](../client/struct.Client.html#method.get_or_create).
     IndexAlreadyExists,
-    /// You tried to get an Index that does not exist. You may want to use the [get_or_create method](../client/struct.Client.html#method.get_or_create).
+    /// No index was found with that UID. You may want to use the [get_or_create
+    /// method](../client/struct.Client.html#method.get_or_create).
     IndexNotFound,
-    /// You tried to use an invalid UID for an Index. Index UID can only be composed of alphanumeric characters, hyphens (-), and underscores (_).
+    /// There was an error in the provided index format. Index UIDs can only be
+    /// composed of alphanumeric characters, hyphens (-), and underscores (_).
     InvalidIndexUid,
+    /// An internal error occurred while trying to access the requested index.
     IndexNotAccessible,
-
+    /// The database is in an invalid state.  Deleting the database and
+    /// re-indexing should solve the problem.
     InvalidState,
-    /// You tried to add documents on an Index but MeiliSearch can't infer the primary key. Consider specifying the key.
+    /// MeiliSearch couldn't infer the primary key for the given documents.
+    /// Consider specifying the key manually.
     MissingPrimaryKey,
+    /// The index already has a set primary key which can't be changed.
     PrimaryKeyAlreadyPresent,
-
+    /// A document was added with more than 65,535 fields.
     MaxFieldsLimitExceeded,
+    /// A document is missing its primary key.
     MissingDocumentId,
 
+    /// The facet provided with the search was invalid.
     InvalidFacet,
+    /// The filter provided with the search was invalid.
     InvalidFilter,
 
+    /// The request contains invalid parameters, check the error message for
+    /// more information.
     BadParameter,
+    /// The request is invalid, check the error message for more information.
     BadRequest,
+    /// The requested document can't be retrieved. Either it doesn't exist, or
+    /// the database was left in an inconsistent state.
     DocumentNotFound,
+    /// MeiliSearch experienced an internal error. Check the error message and
+    /// open an issue if necessary.
     InternalError,
+    /// The provided token is invalid.
     InvalidToken,
-    /// Server is in maintenance. You can set the maintenance state by using the `set_healthy` method of a Client.
+    /// The MeiliSearch instance is under maintenance. You can set the maintenance
+    /// state by using the `set_healthy` method of a Client.
     Maintenance,
+    /// The requested resources are protected with an API key, which was not
+    /// provided in the request header.
     MissingAuthorizationHeader,
+    /// The requested resources could not be found.
     NotFound,
+    /// The payload sent to the server was too large.
     PayloadTooLarge,
+    /// The document exists in store, but there was an error retrieving it. This
+    /// is likely caused by an inconsistent state in the database.
     UnretrievableDocument,
+    /// There was an error in the search.
     SearchError,
+    /// The payload content type is not supported by MeiliSearch. Currently,
+    /// MeiliSearch only supports JSON payloads.
     UnsupportedMediaType,
 
     /// That's unexpected. Please open a GitHub issue after ensuring you are using the supported version of the MeiliSearch server.
     Unknown(String),
+}
+
+impl ErrorType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ErrorType::InvalidRequest => "invalid_request_error",
+            ErrorType::Internal => "internal_error",
+            ErrorType::Authentication => "authentication_error",
+        }
+    }
+    pub fn parse(input: &str) -> Option<Self> {
+        match input {
+            "invalid_request_error" => Some(ErrorType::InvalidRequest),
+            "internal_error" => Some(ErrorType::Internal),
+            "authentication_error" => Some(ErrorType::Authentication),
+            _ => None,
+        }
+    }
+}
+
+impl ErrorCode {
+    pub fn as_str(&self) -> &str {
+        match self {
+            ErrorCode::IndexCreationFailed => "index_creation_failed",
+            ErrorCode::IndexAlreadyExists => "index_already_exists",
+            // `index_not_found` doesn't appear on the official docs, but is
+            // used in the code. (https://docs.meilisearch.com/errors/)
+            ErrorCode::IndexNotFound => "index_not_found",
+            ErrorCode::InvalidIndexUid => "invalid_index_uid",
+            ErrorCode::IndexNotAccessible => "index_not_accessible",
+            ErrorCode::InvalidState => "invalid_state",
+            ErrorCode::MissingPrimaryKey => "missing_primary_key",
+            ErrorCode::PrimaryKeyAlreadyPresent => "primary_key_already_present",
+            ErrorCode::MaxFieldsLimitExceeded => "max_field_limit_exceeded",
+            ErrorCode::MissingDocumentId => "missing_document_id",
+            ErrorCode::InvalidFacet => "invalid_facet",
+            ErrorCode::InvalidFilter => "invalid_filter",
+            ErrorCode::BadParameter => "bad_parameter",
+            ErrorCode::BadRequest => "bad_request",
+            ErrorCode::DocumentNotFound => "document_not_found",
+            ErrorCode::InternalError => "internal",
+            ErrorCode::InvalidToken => "invalid_token",
+            ErrorCode::Maintenance => "maintenance",
+            ErrorCode::MissingAuthorizationHeader => "missing_authorization_header",
+            // The documentation also has a `missing_header` error, but
+            // that doesn't currently exist in MeiliSearch.
+            ErrorCode::NotFound => "not_found",
+            ErrorCode::PayloadTooLarge => "payload_too_large",
+            ErrorCode::UnretrievableDocument => "unretrievable_document",
+            ErrorCode::SearchError => "search_error",
+            ErrorCode::UnsupportedMediaType => "unsupported_media_type",
+            // Other than this variant, all the other `&str`s are 'static
+            ErrorCode::Unknown(inner) => inner,
+        }
+    }
+    pub fn parse(input: &str) -> Self {
+        match input {
+            "index_creation_failed" => ErrorCode::IndexCreationFailed,
+            "index_already_exists" => ErrorCode::IndexAlreadyExists,
+            "index_not_found" => ErrorCode::IndexNotFound,
+            "invalid_index_uid" => ErrorCode::InvalidIndexUid,
+            "index_not_accessible" => ErrorCode::IndexNotAccessible,
+            "invalid_state" => ErrorCode::InvalidState,
+            "missing_primary_key" => ErrorCode::MissingPrimaryKey,
+            "primary_key_already_present" => ErrorCode::PrimaryKeyAlreadyPresent,
+            "max_field_limit_exceeded" => ErrorCode::MaxFieldsLimitExceeded,
+            "missing_document_id" => ErrorCode::MissingDocumentId,
+            "invalid_facet" => ErrorCode::InvalidFacet,
+            "invalid_filter" => ErrorCode::InvalidFilter,
+            "bad_parameter" => ErrorCode::BadParameter,
+            "bad_request" => ErrorCode::BadRequest,
+            "document_not_found" => ErrorCode::DocumentNotFound,
+            "internal" => ErrorCode::InternalError,
+            "invalid_token" => ErrorCode::InvalidToken,
+            "maintenance" => ErrorCode::Maintenance,
+            "missing_authorization_header" => ErrorCode::MissingAuthorizationHeader,
+            "not_found" => ErrorCode::NotFound,
+            "payload_too_large" => ErrorCode::PayloadTooLarge,
+            "unretrievable_document" => ErrorCode::UnretrievableDocument,
+            "search_error" => ErrorCode::SearchError,
+            "unsupported_media_type" => ErrorCode::UnsupportedMediaType,
+            inner => ErrorCode::Unknown(inner.to_string()),
+        }
+    }
 }
 
 impl std::fmt::Display for ErrorCode {
@@ -77,34 +203,8 @@ impl std::fmt::Display for ErrorCode {
         formatter: &mut std::fmt::Formatter<'_>,
     ) -> std::result::Result<(), std::fmt::Error> {
         match self {
-            ErrorCode::IndexCreationFailed => write!(formatter, "index_creation_failed"),
-            ErrorCode::IndexAlreadyExists => write!(formatter, "index_already_exists"),
-            ErrorCode::IndexNotFound => write!(formatter, "index_not_found"),
-            ErrorCode::InvalidIndexUid => write!(formatter, "invalid_index_uid"),
-            ErrorCode::IndexNotAccessible => write!(formatter, "index_not_accessible"),
-            ErrorCode::InvalidState => write!(formatter, "invalid_state"),
-            ErrorCode::MissingPrimaryKey => write!(formatter, "missing_primary_key"),
-            ErrorCode::PrimaryKeyAlreadyPresent => write!(formatter, "primary_key_already_present"),
-            ErrorCode::MaxFieldsLimitExceeded => write!(formatter, "max_field_limit_exceeded"),
-            ErrorCode::MissingDocumentId => write!(formatter, "missing_document_id"),
-            ErrorCode::InvalidFacet => write!(formatter, "invalid_facet"),
-            ErrorCode::InvalidFilter => write!(formatter, "invalid_filter"),
-            ErrorCode::BadParameter => write!(formatter, "bad_parameter"),
-            ErrorCode::BadRequest => write!(formatter, "bad_request"),
-            ErrorCode::DocumentNotFound => write!(formatter, "document_not_found"),
-            ErrorCode::InternalError => write!(formatter, "internal"),
-            ErrorCode::InvalidToken => write!(formatter, "invalid_token"),
-            ErrorCode::Maintenance => write!(formatter, "maintenance"),
-            ErrorCode::MissingAuthorizationHeader => {
-                write!(formatter, "missing_authorization_header")
-            }
-            ErrorCode::NotFound => write!(formatter, "not_found"),
-            ErrorCode::PayloadTooLarge => write!(formatter, "payload_too_large"),
-            ErrorCode::UnretrievableDocument => write!(formatter, "unretrievable_document"),
-            ErrorCode::SearchError => write!(formatter, "search_error"),
-            ErrorCode::UnsupportedMediaType => write!(formatter, "unsupported_media_type"),
-
             ErrorCode::Unknown(inner) => write!(formatter, "unknown ({})", inner),
+            _ => write!(formatter, "{}", self.as_str()),
         }
     }
 }
@@ -118,20 +218,21 @@ impl std::fmt::Display for Error {
             Error::MeiliSearchError {
                 message,
                 error_code,
+                error_type,
                 error_link,
-            } => {
-                write!(formatter, "Meilisearch error {}: {}", error_code, message)?;
-                if let Some(link) = error_link {
-                    write!(formatter, ". {}", link)?;
-                }
-                Ok(())
-            }
+            } => write!(
+                formatter,
+                "Meilisearch {}: {}: {}. {}",
+                error_type.as_str(),
+                error_code,
+                message,
+                error_link,
+            ),
             Error::UnreachableServer => {
                 write!(formatter, "The MeiliSearch server can't be reached.")
             }
             Error::ParseError(e) => write!(formatter, "Error parsing response JSON: {}", e),
             Error::HttpError(e) => write!(formatter, "HTTP request failed: {}", e),
-            Error::Unknown(e) => write!(formatter, "An unknown error occurred: {}", e),
             Error::Empty => write!(formatter, "An error occured without a message"),
         }
     }
@@ -151,70 +252,31 @@ impl From<&serde_json::Value> for Error {
             .map(|s| s.to_string())
             .unwrap_or_else(|| json.to_string());
 
-        let link = json
+        let error_link = json
             .get("errorLink")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(|s| s.to_string())
+            .unwrap_or_else(String::new);
 
-        // Error codes from https://github.com/meilisearch/MeiliSearch/blob/v0.12.0/meilisearch-error/src/lib.rs
-        let error_code = match json.get("errorCode").and_then(|v| v.as_str()) {
-            Some("index_creation_failed") => ErrorCode::IndexCreationFailed,
-            Some("index_already_exists") => ErrorCode::IndexAlreadyExists,
-            Some("index_not_found") => ErrorCode::IndexNotFound,
-            Some("invalid_index_uid") => ErrorCode::InvalidIndexUid,
-            Some("index_not_accessible") => ErrorCode::IndexNotAccessible,
-            Some("invalid_state") => ErrorCode::InvalidState,
-            Some("missing_primary_key") => ErrorCode::MissingPrimaryKey,
-            Some("primary_key_already_present") => ErrorCode::PrimaryKeyAlreadyPresent,
-            Some("max_field_limit_exceeded") => ErrorCode::MaxFieldsLimitExceeded,
-            Some("missing_document_id") => ErrorCode::MissingDocumentId,
-            Some("invalid_facet") => ErrorCode::InvalidFacet,
-            Some("invalid_filter") => ErrorCode::InvalidFilter,
-            Some("bad_parameter") => ErrorCode::BadParameter,
-            Some("bad_request") => ErrorCode::BadRequest,
-            Some("document_not_found") => ErrorCode::DocumentNotFound,
-            Some("internal") => ErrorCode::InternalError,
-            Some("invalid_token") => ErrorCode::InvalidToken,
-            Some("maintenance") => ErrorCode::Maintenance,
-            Some("missing_authorization_header") => ErrorCode::MissingAuthorizationHeader,
-            Some("not_found") => ErrorCode::NotFound,
-            Some("payload_too_large") => ErrorCode::PayloadTooLarge,
-            Some("unretrievable_document") => ErrorCode::UnretrievableDocument,
-            Some("search_error") => ErrorCode::SearchError,
-            Some("unsupported_media_type") => ErrorCode::UnsupportedMediaType,
-            Some(code) => ErrorCode::Unknown(code.to_string()),
+        let error_type = json
+            .get("errorType")
+            .and_then(|v| v.as_str())
+            .and_then(|s| ErrorType::parse(s))
+            .unwrap_or(ErrorType::Internal);
+        // If the response doesn't contain an errorType field, the error type
+        // is assumed to be an internal error.
 
-            None => {
-                // Meilisearch 0.11 and below
-                match json.get("message").and_then(|v| v.as_str()) {
-                    Some("Payload to large") => ErrorCode::PayloadTooLarge,
-                    Some("Unsupported media type") => ErrorCode::UnsupportedMediaType,
-                    Some(m) if m.starts_with("impossible to search documents") => {
-                        ErrorCode::SearchError
-                    }
-                    Some(m) if m.starts_with("Url parameter") => ErrorCode::BadParameter,
-                    Some("Impossible to create index; index already exists") => {
-                        ErrorCode::IndexAlreadyExists
-                    }
-                    Some("Could not infer a primary key") => ErrorCode::MissingPrimaryKey,
-                    Some("Server is in maintenance, please try again later") => {
-                        ErrorCode::Maintenance
-                    }
-                    Some(m) if m.starts_with("Index ") && m.ends_with(" not found") => {
-                        ErrorCode::IndexNotFound
-                    }
-                    Some(m) if m.starts_with("Index must have a valid uid;") => {
-                        ErrorCode::InvalidIndexUid
-                    }
-                    _ => ErrorCode::Unknown(String::from("unknown")),
-                }
-            }
-        };
+        let error_code = json
+            .get("errorCode")
+            .and_then(|v| v.as_str())
+            .map(|s| ErrorCode::parse(s))
+            .unwrap_or_else(|| ErrorCode::Unknown(String::from("missing errorCode")));
 
         Error::MeiliSearchError {
             message,
             error_code,
-            error_link: link,
+            error_type,
+            error_link,
         }
     }
 }
@@ -228,5 +290,3 @@ impl From<reqwest::Error> for Error {
         }
     }
 }
-
-// TODO from http code https://docs.meilisearch.com/references/#error

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,40 +1,138 @@
+/// The enum representing the errors that can occur
 #[derive(Debug)]
-/// Struct representing errors.
-/// Unknow Errors are unexpected. You should consider panicking and open a GitHub issue (after ensuring you are using the supported version of the MeiliSearch server).
 pub enum Error {
-    /// There is no MeiliSearch server listening on the [specified host](../client/struct.Client.html#method.new).
+    MeiliSearchError {
+        /// The human readable error message
+        message: String,
+        /// The error code of the error.  For MeiliSearch versions before v12,
+        /// this is an approximation of the real error code, as MeiliSearch did
+        /// not send a machine readable error code.
+        error_code: ErrorCode,
+        /// A link to the MeiliSearch documentation for an error.  Only exists
+        /// for MeiliSearch versions v12 and above.
+        error_link: Option<String>,
+    },
+
+    /// There is no MeiliSearch server listening on the [specified host]
+    /// (../client/struct.Client.html#method.new).
     UnreachableServer,
+    /// The MeiliSearch server returned invalid JSON for a request.
+    ParseError(serde_json::Error),
+    /// An unknown error
+    Unknown(String),
+    /// An erroring status code, but no body
+    Empty,
+
+    /// The http client encountered an error.
+    #[cfg(not(target_arch = "wasm32"))]
+    HttpError(reqwest::Error),
+    /// Can never occur on the wasm target.
+    #[cfg(target_arch = "wasm32")]
+    HttpError(()),
+}
+
+#[derive(Debug)]
+pub enum ErrorCode {
+    IndexCreationFailed,
     /// You tried to create an Index that already exists. You may want to use the [get_or_create method](../client/struct.Client.html#method.get_or_create).
-    IndexAlreadyExist,
+    IndexAlreadyExists,
     /// You tried to get an Index that does not exist. You may want to use the [get_or_create method](../client/struct.Client.html#method.get_or_create).
     IndexNotFound,
     /// You tried to use an invalid UID for an Index. Index UID can only be composed of alphanumeric characters, hyphens (-), and underscores (_).
     InvalidIndexUid,
+    IndexNotAccessible,
+
+    InvalidState,
     /// You tried to add documents on an Index but MeiliSearch can't infer the primary key. Consider specifying the key.
-    CantInferPrimaryKey,
+    MissingPrimaryKey,
+    PrimaryKeyAlreadyPresent,
+
+    MaxFieldsLimitExceeded,
+    MissingDocumentId,
+
+    InvalidFacet,
+    InvalidFilter,
+
+    BadParameter,
+    BadRequest,
+    DocumentNotFound,
+    InternalError,
+    InvalidToken,
     /// Server is in maintenance. You can set the maintenance state by using the `set_healthy` method of a Client.
-    ServerInMaintenance,
+    Maintenance,
+    MissingAuthorizationHeader,
+    NotFound,
+    PayloadTooLarge,
+    UnretrievableDocument,
+    SearchError,
+    UnsupportedMediaType,
+
     /// That's unexpected. Please open a GitHub issue after ensuring you are using the supported version of the MeiliSearch server.
     Unknown(String),
-    /// The http client encountered an error.
-    #[cfg(not(target_arch = "wasm32"))]
-    Http(reqwest::Error),
-    #[cfg(target_arch = "wasm32")]
-    /// Never happens on wasm target.
-    Http(())
+}
+
+impl std::fmt::Display for ErrorCode {
+    fn fmt(
+        &self,
+        formatter: &mut std::fmt::Formatter<'_>,
+    ) -> std::result::Result<(), std::fmt::Error> {
+        match self {
+            ErrorCode::IndexCreationFailed => write!(formatter, "index_creation_failed"),
+            ErrorCode::IndexAlreadyExists => write!(formatter, "index_already_exists"),
+            ErrorCode::IndexNotFound => write!(formatter, "index_not_found"),
+            ErrorCode::InvalidIndexUid => write!(formatter, "invalid_index_uid"),
+            ErrorCode::IndexNotAccessible => write!(formatter, "index_not_accessible"),
+            ErrorCode::InvalidState => write!(formatter, "invalid_state"),
+            ErrorCode::MissingPrimaryKey => write!(formatter, "missing_primary_key"),
+            ErrorCode::PrimaryKeyAlreadyPresent => write!(formatter, "primary_key_already_present"),
+            ErrorCode::MaxFieldsLimitExceeded => write!(formatter, "max_field_limit_exceeded"),
+            ErrorCode::MissingDocumentId => write!(formatter, "missing_document_id"),
+            ErrorCode::InvalidFacet => write!(formatter, "invalid_facet"),
+            ErrorCode::InvalidFilter => write!(formatter, "invalid_filter"),
+            ErrorCode::BadParameter => write!(formatter, "bad_parameter"),
+            ErrorCode::BadRequest => write!(formatter, "bad_request"),
+            ErrorCode::DocumentNotFound => write!(formatter, "document_not_found"),
+            ErrorCode::InternalError => write!(formatter, "internal"),
+            ErrorCode::InvalidToken => write!(formatter, "invalid_token"),
+            ErrorCode::Maintenance => write!(formatter, "maintenance"),
+            ErrorCode::MissingAuthorizationHeader => {
+                write!(formatter, "missing_authorization_header")
+            }
+            ErrorCode::NotFound => write!(formatter, "not_found"),
+            ErrorCode::PayloadTooLarge => write!(formatter, "payload_too_large"),
+            ErrorCode::UnretrievableDocument => write!(formatter, "unretrievable_document"),
+            ErrorCode::SearchError => write!(formatter, "search_error"),
+            ErrorCode::UnsupportedMediaType => write!(formatter, "unsupported_media_type"),
+
+            ErrorCode::Unknown(inner) => write!(formatter, "unknown ({})", inner),
+        }
+    }
 }
 
 impl std::fmt::Display for Error {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(
+        &self,
+        formatter: &mut std::fmt::Formatter<'_>,
+    ) -> std::result::Result<(), std::fmt::Error> {
         match self {
-            Error::UnreachableServer => write!(formatter, "Error::UnreachableServer: The MeiliSearch server can't be reached."),
-            Error::IndexAlreadyExist => write!(formatter, "Error::IndexAlreadyExist: The creation of an index failed because it already exists."),
-            Error::IndexNotFound => write!(formatter, "Error::IndexNotFound: The requested index does not exist."),
-            Error::InvalidIndexUid => write!(formatter, "Error::InvalidIndexUid: The requested UID is invalid. Index UID can only be composed of alphanumeric characters, hyphens (-), and underscores (_)."),
-            Error::CantInferPrimaryKey => write!(formatter, "Error::CantInferPrimaryKey: MeiliSearch was unable to infer the primary key of added documents."),
-            Error::Http(error) => write!(formatter, "Error::Http: The http request failed: {:?}.", error),
-            Error::ServerInMaintenance => write!(formatter, "Error::ServerInMaintenance: Server is in maintenance, please try again later."),
-            Error::Unknown(message) => write!(formatter, "Error::Unknown: An unknown error occured. Please open an issue (https://github.com/Mubelotix/meilisearch-sdk/issues). Message: {:?}", message),
+            Error::MeiliSearchError {
+                message,
+                error_code,
+                error_link,
+            } => {
+                write!(formatter, "Meilisearch error {}: {}", error_code, message)?;
+                if let Some(link) = error_link {
+                    write!(formatter, ". {}", link)?;
+                }
+                Ok(())
+            }
+            Error::UnreachableServer => {
+                write!(formatter, "The MeiliSearch server can't be reached.")
+            }
+            Error::ParseError(e) => write!(formatter, "Error parsing response JSON: {}", e),
+            Error::HttpError(e) => write!(formatter, "HTTP request failed: {}", e),
+            Error::Unknown(e) => write!(formatter, "An unknown error occurred: {}", e),
+            Error::Empty => write!(formatter, "An error occured without a message"),
         }
     }
 }
@@ -42,28 +140,81 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {}
 
 impl From<&serde_json::Value> for Error {
-    fn from(message: &serde_json::Value) -> Error {
+    fn from(json: &serde_json::Value) -> Error {
+        if json.is_null() {
+            return Error::Empty;
+        }
+
+        let message = json
+            .get("message")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| json.to_string());
+
+        let link = json
+            .get("errorLink")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
         // Error codes from https://github.com/meilisearch/MeiliSearch/blob/v0.12.0/meilisearch-error/src/lib.rs
-        match message.get("errorCode").and_then(|v| v.as_str()) {
-            Some("index_not_found") => Error::IndexNotFound,
-            Some("index_already_exists") => Error::IndexAlreadyExist,
-            Some("invalid_index_uid") => Error::InvalidIndexUid,
-            Some("missing_primary_key") => Error::CantInferPrimaryKey,
-            Some("maintenance") => Error::ServerInMaintenance,
-            Some(_) => Error::Unknown(message.to_string()),
+        let error_code = match json.get("errorCode").and_then(|v| v.as_str()) {
+            Some("index_creation_failed") => ErrorCode::IndexCreationFailed,
+            Some("index_already_exists") => ErrorCode::IndexAlreadyExists,
+            Some("index_not_found") => ErrorCode::IndexNotFound,
+            Some("invalid_index_uid") => ErrorCode::InvalidIndexUid,
+            Some("index_not_accessible") => ErrorCode::IndexNotAccessible,
+            Some("invalid_state") => ErrorCode::InvalidState,
+            Some("missing_primary_key") => ErrorCode::MissingPrimaryKey,
+            Some("primary_key_already_present") => ErrorCode::PrimaryKeyAlreadyPresent,
+            Some("max_field_limit_exceeded") => ErrorCode::MaxFieldsLimitExceeded,
+            Some("missing_document_id") => ErrorCode::MissingDocumentId,
+            Some("invalid_facet") => ErrorCode::InvalidFacet,
+            Some("invalid_filter") => ErrorCode::InvalidFilter,
+            Some("bad_parameter") => ErrorCode::BadParameter,
+            Some("bad_request") => ErrorCode::BadRequest,
+            Some("document_not_found") => ErrorCode::DocumentNotFound,
+            Some("internal") => ErrorCode::InternalError,
+            Some("invalid_token") => ErrorCode::InvalidToken,
+            Some("maintenance") => ErrorCode::Maintenance,
+            Some("missing_authorization_header") => ErrorCode::MissingAuthorizationHeader,
+            Some("not_found") => ErrorCode::NotFound,
+            Some("payload_too_large") => ErrorCode::PayloadTooLarge,
+            Some("unretrievable_document") => ErrorCode::UnretrievableDocument,
+            Some("search_error") => ErrorCode::SearchError,
+            Some("unsupported_media_type") => ErrorCode::UnsupportedMediaType,
+            Some(code) => ErrorCode::Unknown(code.to_string()),
+
             None => {
-                // Meilisearch 0.11 and below 
-                match message.get("message").and_then(|v| v.as_str()) {
-                    Some("Impossible to create index; index already exists") => Error::IndexAlreadyExist,
-                    Some("Could not infer a primary key") => Error::CantInferPrimaryKey,
-                    Some(m) if m.starts_with("Server is in maintenance, please try again later") => Error::ServerInMaintenance,
-                    Some(m) if m.starts_with("Index ") && m.ends_with(" not found") => Error::IndexNotFound,
-                    Some(m) if m.starts_with("Index must have a valid uid;") => Error::InvalidIndexUid,
-                    _ => {
-                        Error::Unknown(message.to_string())
-                    },
+                // Meilisearch 0.11 and below
+                match json.get("message").and_then(|v| v.as_str()) {
+                    Some("Payload to large") => ErrorCode::PayloadTooLarge,
+                    Some("Unsupported media type") => ErrorCode::UnsupportedMediaType,
+                    Some(m) if m.starts_with("impossible to search documents") => {
+                        ErrorCode::SearchError
+                    }
+                    Some(m) if m.starts_with("Url parameter") => ErrorCode::BadParameter,
+                    Some("Impossible to create index; index already exists") => {
+                        ErrorCode::IndexAlreadyExists
+                    }
+                    Some("Could not infer a primary key") => ErrorCode::MissingPrimaryKey,
+                    Some("Server is in maintenance, please try again later") => {
+                        ErrorCode::Maintenance
+                    }
+                    Some(m) if m.starts_with("Index ") && m.ends_with(" not found") => {
+                        ErrorCode::IndexNotFound
+                    }
+                    Some(m) if m.starts_with("Index must have a valid uid;") => {
+                        ErrorCode::InvalidIndexUid
+                    }
+                    _ => ErrorCode::Unknown(String::from("unknown")),
                 }
             }
+        };
+
+        Error::MeiliSearchError {
+            message,
+            error_code,
+            error_link: link,
         }
     }
 }
@@ -72,10 +223,8 @@ impl From<&serde_json::Value> for Error {
 impl From<reqwest::Error> for Error {
     fn from(error: reqwest::Error) -> Error {
         match error.status() {
-            None => {
-                Error::UnreachableServer
-            }
-            Some(_e) => Error::Http(error),
+            None => Error::UnreachableServer,
+            Some(_e) => Error::HttpError(error),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
-/// The enum representing the errors that can occur
-#[non_exhaustive]
+/// An enum representing the errors that can occur.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     MeiliSearchError {
         /// The human readable error message
@@ -35,14 +35,21 @@ pub enum Error {
     HttpError(String),
 }
 
-#[non_exhaustive]
+/// The type of error that was encountered.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorType {
+    /// The submitted request was invalid.
     InvalidRequest,
+    /// The MeiliSearch instance encountered an internal error.
     Internal,
+    /// Authentication was either incorrect or missing.
     Authentication,
 }
 
+/// The error code.
+///
+/// Officially documented at https://docs.meilisearch.com/errors.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ErrorCode {
@@ -109,11 +116,14 @@ pub enum ErrorCode {
     /// MeiliSearch only supports JSON payloads.
     UnsupportedMediaType,
 
-    /// That's unexpected. Please open a GitHub issue after ensuring you are using the supported version of the MeiliSearch server.
+    /// That's unexpected. Please open a GitHub issue after ensuring you are
+    /// using the supported version of the MeiliSearch server.
     Unknown(String),
 }
 
 impl ErrorType {
+    /// Converts the error type to the string representation returned by
+    /// MeiliSearch.
     pub fn as_str(&self) -> &'static str {
         match self {
             ErrorType::InvalidRequest => "invalid_request_error",
@@ -121,6 +131,9 @@ impl ErrorType {
             ErrorType::Authentication => "authentication_error",
         }
     }
+    /// Converts the error type string returned by MeiliSearch into an
+    /// `ErrorType` enum.  If the error type input is not recognized, None is
+    /// returned.
     pub fn parse(input: &str) -> Option<Self> {
         match input {
             "invalid_request_error" => Some(ErrorType::InvalidRequest),
@@ -132,6 +145,8 @@ impl ErrorType {
 }
 
 impl ErrorCode {
+    /// Converts the error code to the string representation returned by
+    /// MeiliSearch.
     pub fn as_str(&self) -> &str {
         match self {
             ErrorCode::IndexCreationFailed => "index_creation_failed",
@@ -166,6 +181,9 @@ impl ErrorCode {
             ErrorCode::Unknown(inner) => inner,
         }
     }
+    /// Converts the error code string returned by MeiliSearch into an `ErrorCode`
+    /// enum.  If the error type input is not recognized, `ErrorCode::Unknown`
+    /// is returned.
     pub fn parse(input: &str) -> Self {
         match input {
             "index_creation_failed" => ErrorCode::IndexCreationFailed,
@@ -198,22 +216,16 @@ impl ErrorCode {
 }
 
 impl std::fmt::Display for ErrorCode {
-    fn fmt(
-        &self,
-        formatter: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         match self {
-            ErrorCode::Unknown(inner) => write!(formatter, "unknown ({})", inner),
-            _ => write!(formatter, "{}", self.as_str()),
+            ErrorCode::Unknown(inner) => write!(fmt, "unknown ({})", inner),
+            _ => write!(fmt, "{}", self.as_str()),
         }
     }
 }
 
 impl std::fmt::Display for Error {
-    fn fmt(
-        &self,
-        formatter: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         match self {
             Error::MeiliSearchError {
                 message,
@@ -221,19 +233,17 @@ impl std::fmt::Display for Error {
                 error_type,
                 error_link,
             } => write!(
-                formatter,
+                fmt,
                 "Meilisearch {}: {}: {}. {}",
                 error_type.as_str(),
                 error_code,
                 message,
                 error_link,
             ),
-            Error::UnreachableServer => {
-                write!(formatter, "The MeiliSearch server can't be reached.")
-            }
-            Error::ParseError(e) => write!(formatter, "Error parsing response JSON: {}", e),
-            Error::HttpError(e) => write!(formatter, "HTTP request failed: {}", e),
-            Error::Empty => write!(formatter, "An error occured without a message"),
+            Error::UnreachableServer => write!(fmt, "The MeiliSearch server can't be reached."),
+            Error::ParseError(e) => write!(fmt, "Error parsing response JSON: {}", e),
+            Error::HttpError(e) => write!(fmt, "HTTP request failed: {}", e),
+            Error::Empty => write!(fmt, "An error occured without a message"),
         }
     }
 }
@@ -263,6 +273,7 @@ impl From<&serde_json::Value> for Error {
             .and_then(|v| v.as_str())
             .and_then(|s| ErrorType::parse(s))
             .unwrap_or(ErrorType::Internal);
+
         // If the response doesn't contain an errorType field, the error type
         // is assumed to be an internal error.
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -50,14 +50,16 @@ impl<'a> Progress<'a> {
             Method::Get,
             200,
         ).await?;
+
         if let Ok(status) = from_value::<ProcessedStatus>(value.clone()) {
-            return Ok(Status::Processed(status));
-        } else if let Ok(status) = from_value::<EnqueuedStatus>(value) {
-            return Ok(Status::Enqueued(status));
+            Ok(Status::Processed(status))
+        } else {
+            let result = from_value::<EnqueuedStatus>(value);
+            match result {
+                Ok(status) => Ok(Status::Enqueued(status)),
+                Err(e) => Err(Error::ParseError(e)),
+            }
         }
-        Err(Error::Unknown(
-            "Invalid server response, src/progress.rs:56:9".to_string(),
-        ))
     }
 }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -49,7 +49,8 @@ impl<'a> Progress<'a> {
             self.index.client.apikey,
             Method::Get,
             200,
-        ).await?;
+        )
+        .await?;
 
         if let Ok(status) = from_value::<ProcessedStatus>(value.clone()) {
             Ok(Status::Processed(status))

--- a/src/request.rs
+++ b/src/request.rs
@@ -134,10 +134,13 @@ fn parse_response<Output: DeserializeOwned>(
             }
             Err(e) => {
                 error!("Request succeed but failed to parse response");
-                return Err(Error::from(e.to_string().as_str()));
+                return Err(Error::Unknown(e.to_string()));
             }
         };
     }
     warn!("Expected response code {}, got {}", expected_status_code, status_code);
-    Err(Error::from(body.as_str()))
+    match from_str(&body) {
+        Ok(e) => Err(Error::from(&e)),
+        Err(e) => Err(Error::Unknown(e.to_string()))
+    }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -100,12 +100,12 @@ pub(crate) async fn request<Input: Serialize + std::fmt::Debug, Output: 'static 
             Ok(text) => text,
             Err(e) => {
                 error!("Invalid response: {:?}", e);
-                return Err(Error::Unknown("Invalid response".to_string()));
+                return Err(Error::HttpError("Invalid response".to_string()));
             }
         }
         Err(e) => {
             error!("Invalid response: {:?}", e);
-            return Err(Error::Unknown("Invalid response".to_string()));
+            return Err(Error::HttpError("Invalid response".to_string()));
         }
     };
 
@@ -117,7 +117,7 @@ pub(crate) async fn request<Input: Serialize + std::fmt::Debug, Output: 'static 
         }
     } else {
         error!("Invalid response");
-        Err(Error::Unknown("Invalid utf8".to_string()))
+        Err(Error::HttpError("Invalid utf8".to_string()))
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -134,13 +134,13 @@ fn parse_response<Output: DeserializeOwned>(
             }
             Err(e) => {
                 error!("Request succeed but failed to parse response");
-                return Err(Error::Unknown(e.to_string()));
+                return Err(Error::ParseError(e));
             }
         };
     }
     warn!("Expected response code {}, got {}", expected_status_code, status_code);
     match from_str(&body) {
         Ok(e) => Err(Error::from(&e)),
-        Err(e) => Err(Error::Unknown(e.to_string()))
+        Err(e) => Err(Error::ParseError(e))
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -91,8 +91,8 @@ pub(crate) async fn request<Input: Serialize + std::fmt::Debug, Output: 'static 
         Ok(response) => Response::from(response),
         Err(e) => {
             error!("Network error: {:?}", e);
-            return Err(Error::UnreachableServer)
-        },
+            return Err(Error::UnreachableServer);
+        }
     };
     let status = response.status() as u16;
     let text = match response.text() {
@@ -102,7 +102,7 @@ pub(crate) async fn request<Input: Serialize + std::fmt::Debug, Output: 'static 
                 error!("Invalid response: {:?}", e);
                 return Err(Error::HttpError("Invalid response".to_string()));
             }
-        }
+        },
         Err(e) => {
             error!("Invalid response: {:?}", e);
             return Err(Error::HttpError("Invalid response".to_string()));
@@ -141,6 +141,6 @@ fn parse_response<Output: DeserializeOwned>(
     warn!("Expected response code {}, got {}", expected_status_code, status_code);
     match from_str(&body) {
         Ok(e) => Err(Error::from(&e)),
-        Err(e) => Err(Error::ParseError(e))
+        Err(e) => Err(Error::ParseError(e)),
     }
 }


### PR DESCRIPTION
This is a rewrite of the errors module, so it has breaking changes, and this only supports MeiliSearch 0.12 errors, so this removes support for MeiliSearch 0.11. (Fixes #23)

The error codes and error types have documentation comments loosely based around the official error code documentation (https://docs.meilisearch.com/errors/), which is incorrect in some places.  The documentation is missing the `index_not_found` error code, and has a `missing_header` error code that only existed between MeiliSearch 0.10 and 0.11 and was never released.

This changes the `HttpError` to contain a String on `wasm` so that the `Error::Unknown` variant could be removed, but a more descriptive error enum would be a better than a string.

All of the error enums (`Error`, `ErrorCode`, and `ErrorType`) are documented and marked as `#[non_exhaustive]`, although the `ErrorType` enum doesn't seem like it would change.

I have run clippy and all of the tests as specified in the contributing guidelines.  (Although the docker command for running the latest server doesn't work, as the `--no-analytics` argument requires a parameter after it.)