### PR TITLE
Use isahc as replacement for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 urlencoding = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reqwest = "0.10"
+isahc = "0.9"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["RequestInit", "Headers", "Window", "Response", "console"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,16 @@ serde = { version = "1.0", features = ["derive"] }
 urlencoding = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-isahc = "0.9"
+isahc = { version = "0.9", features = ["http2", "text-decoding"], default_features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["RequestInit", "Headers", "Window", "Response", "console"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
+
+[features]
+default = ["isahc-static-curl"]
+isahc-static-curl = ["isahc/static-curl"]
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -309,7 +309,6 @@ impl From<&serde_json::Value> for Error {
     }
 }
 
-
 #[cfg(not(target_arch = "wasm32"))]
 impl From<isahc::Error> for Error {
     fn from(error: isahc::Error) -> Error {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,7 +29,7 @@ pub enum Error {
 
     /// The http client encountered an error.
     #[cfg(not(target_arch = "wasm32"))]
-    HttpError(reqwest::Error),
+    HttpError(isahc::Error),
     /// The http client encountered an error.
     #[cfg(target_arch = "wasm32")]
     HttpError(String),
@@ -309,12 +309,10 @@ impl From<&serde_json::Value> for Error {
     }
 }
 
+
 #[cfg(not(target_arch = "wasm32"))]
-impl From<reqwest::Error> for Error {
-    fn from(error: reqwest::Error) -> Error {
-        match error.status() {
-            None => Error::UnreachableServer,
-            Some(_e) => Error::HttpError(error),
-        }
+impl From<isahc::Error> for Error {
+    fn from(error: isahc::Error) -> Error {
+        Error::HttpError(error)
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -25,29 +25,29 @@ pub(crate) async fn request<Input: Serialize + std::fmt::Debug, Output: 'static 
         Method::Get => Request::get(url)
             .header("X-Meili-API-Key", apikey)
             .body(())
-            .map_err(|e| isahc::Error::InvalidHttpFormat(e))?
+            .map_err(isahc::Error::InvalidHttpFormat)?
             .send_async().await?,
         Method::Delete => Request::delete(url)
             .header("X-Meili-API-Key", apikey)
             .body(())
-            .map_err(|e| isahc::Error::InvalidHttpFormat(e))?
+            .map_err(isahc::Error::InvalidHttpFormat)?
             .send_async().await?,
         Method::Post(body) => Request::post(url)
             .header("X-Meili-API-Key", apikey)
             .header("Content-Type", "application/json")
             .body(to_string(&body).unwrap())
-            .map_err(|e| isahc::Error::InvalidHttpFormat(e))?
+            .map_err(isahc::Error::InvalidHttpFormat)?
             .send_async().await?,
         Method::Put(body) => Request::put(url)
             .header("X-Meili-API-Key", apikey)
             .header("Content-Type", "application/json")
             .body(to_string(&body).unwrap())
-            .map_err(|e| isahc::Error::InvalidHttpFormat(e))?
+            .map_err(isahc::Error::InvalidHttpFormat)?
             .send_async().await?,
     };
 
     let status = response.status().as_u16();
-    let mut body = response.text_async().await.map_err(|e| isahc::Error::Io(e))?;
+    let mut body = response.text_async().await.map_err(isahc::Error::Io)?;
     if body.is_empty() {
         body = "null".to_string();
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,7 +2,6 @@ use crate::errors::Error;
 use log::{error, trace, warn};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{from_str, to_string};
-use isahc::prelude::*;
 
 #[derive(Debug)]
 pub(crate) enum Method<T: Serialize> {
@@ -19,6 +18,8 @@ pub(crate) async fn request<Input: Serialize + std::fmt::Debug, Output: 'static 
     method: Method<Input>,
     expected_status_code: u16
 ) -> Result<Output, Error> {
+    use isahc::prelude::*;
+
     trace!("{:?} on {}", method, url);
 
     let mut response = match &method {


### PR DESCRIPTION
This PR adresses #48 by using surf instead of reqwest.

In #48 I said that surf could be used from wasm as well - turns out it's not quite there yet: https://github.com/http-rs/surf/issues/210

Marking WIP because you probably don't want to merge this before surf 2.0.

---

Switched to isahc instead of surf, see comments.