### PR TITLE
Changes about the MeiliSearch's next release (v0.16.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -193,10 +193,8 @@ get_index_stats_1: |-
 get_indexes_stats_1: |-
   let stats: ClientStats = client.get_stats().await.unwrap();
 get_health_1: |-
-  // get_health() return an Err() if the server is not healthy, so this example would panic due to the unwrap
-  client.get_health().await.unwrap();
-update_health_1: |-
-  client.set_health(false).await.unwrap();
+  // health() return an Err() if the server is not healthy, so this example would panic due to the unwrap
+  client.health().await.unwrap();
 get_version_1: |-
   let version: Version = client.get_version().await.unwrap();
 distinct_attribute_guide_1: |-
@@ -287,7 +285,7 @@ search_parameter_guide_crop_1: |-
     .execute()
     .await
     .unwrap();
-  
+
   // Get the formatted results
   let formatted_results: Vec<&Movie> = results.hits.iter().map(|r| r.formatted_result.as_ref().unwrap()).collect();
 search_parameter_guide_highlight_1: |-
@@ -297,7 +295,7 @@ search_parameter_guide_highlight_1: |-
     .execute()
     .await
     .unwrap();
-  
+
   // Get the formatted results
   let formatted_results: Vec<&Movie> = results.hits.iter().map(|r| r.formatted_result.as_ref().unwrap()).collect();
 search_parameter_guide_filter_1: |-
@@ -323,7 +321,7 @@ search_parameter_guide_matches_1: |-
     .execute()
     .await
     .unwrap();
-  
+
   // Get the matches info
   let matched_info: Vec<&HashMap<String, Vec<MatchRange>>> = results.hits.iter().map(|r| r.matches_info.as_ref().unwrap()).collect();
 settings_guide_synonyms_1: |-
@@ -426,7 +424,7 @@ getting_started_create_index_md: |-
   async fn main() {
     let client = Client::new("http://localhost:7700", "masterKey");
     // create an index if the index does not exist
-    let movies = client.get_or_create("movies").await.unwrap();  
+    let movies = client.get_or_create("movies").await.unwrap();
 
     // some code
   }
@@ -452,7 +450,7 @@ getting_started_add_documents_md: |-
     fn get_uid(&self) -> &Self::UIDType { &self.id }
   }
   ```
-  
+
   You will often need this `Movie` struct in other parts of this documentation. (you will have to change it a bit sometimes)
   You can also use schemaless values, by putting a `serde_json::Value` inside your own struct like this:
 
@@ -479,7 +477,7 @@ getting_started_add_documents_md: |-
   let mut content = String::new();
   file.read_to_string(&mut content).unwrap();
   let movies_docs: Vec<Movie> = serde_json::from_str(&content).unwrap();
-  
+
   // adding documents
   movies.add_documents(&movies_docs, None).await.unwrap();
   ```
@@ -489,10 +487,10 @@ getting_started_search_md: |-
   let query: Query = Query::new(&movies)
     .with_query("botman")
     .build();
-  
+
   let results: SearchResults<Movie> = movies.execute_query(&query).await.unwrap();
   ```
-    
+
   You can build a Query and execute it directly:
   ```rust
   let results: SearchResults<Movie> = Query::new(&movies)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ WARNING: `meilisearch-sdk` will panic if no Window is available (ex: Web extensi
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 
 ## ⚙️ Development Workflow and Contributing
 

--- a/README.tpl
+++ b/README.tpl
@@ -41,7 +41,7 @@
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 
 ## ⚙️ Development Workflow and Contributing
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{errors::*, indexes::*, request::*};
 use serde_json::{json, Value};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize};
 use std::collections::HashMap;
 
 /// The top-level struct of the SDK, representing a client containing [indexes](../indexes/struct.Index.html).
@@ -186,7 +186,7 @@ impl<'a> Client<'a> {
     /// # async fn main() {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     ///
-    /// match client.get_health().await {
+    /// match client.health().await {
     ///     Ok(()) => println!("server is operational"),
     ///     Err(Error::MeiliSearchError { error_code: ErrorCode::Maintenance, .. }) => {
     ///         eprintln!("server is in maintenance")
@@ -195,47 +195,11 @@ impl<'a> Client<'a> {
     /// }
     /// # }
     /// ```
-    pub async fn get_health(&self) -> Result<(), Error> {
+    pub async fn health(&self) -> Result<(), Error> {
         let r = request::<(), ()>(
             &format!("{}/health", self.host),
             self.apikey,
             Method::Get,
-            204,
-        )
-        .await;
-        match r {
-            // This shouldn't be an error; The status code is 200, but the request
-            // function only supports one successful error code for some reason
-            Err(Error::Empty) => Ok(()),
-            e => e,
-        }
-    }
-
-    /// Update health of MeiliSearch server.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use meilisearch_sdk::{client::*, indexes::*};
-    /// #
-    /// # #[tokio::main]
-    /// # async fn main() {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
-    ///
-    /// client.set_health(false).await.unwrap();
-    /// # client.set_health(true).await.unwrap();
-    /// # }
-    /// ```
-    pub async fn set_health(&self, health: bool) -> Result<(), Error> {
-        #[derive(Debug, Serialize)]
-        struct HealthBody {
-            health: bool
-        }
-
-        let r = request::<HealthBody, ()>(
-            &format!("{}/health", self.host),
-            self.apikey,
-            Method::Put(HealthBody { health }),
             204,
         )
         .await;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,7 +21,7 @@ pub enum Error {
     /// The MeiliSearch server returned invalid JSON for a request.
     ParseError(serde_json::Error),
     /// An erroring status code, but no body
-    // This is a hack to make Client::get_health work, since the request module
+    // This is a hack to make Client::health work, since the request module
     // treats anything other than the expected status as an error.  Since 204 is
     // specified, a successful status of 200 is treated as an error with an
     // empty body.
@@ -97,8 +97,7 @@ pub enum ErrorCode {
     InternalError,
     /// The provided token is invalid.
     InvalidToken,
-    /// The MeiliSearch instance is under maintenance. You can set the maintenance
-    /// state by using the `set_healthy` method of a Client.
+    /// The MeiliSearch instance is under maintenance.
     Maintenance,
     /// The requested resources are protected with an API key, which was not
     /// provided in the request header.


### PR DESCRIPTION
Related to this issue: https://github.com/meilisearch/integration-guides/issues/52

- [x] Update README
- [x] Remove `set_health` method and rename method `get_health` into `health` #59 

This PR:
- gathers the changes related to the next release of MeiliSearch (v0.16.0) so that this package is ready when the official release is out.
- should pass the tests against the [latest prerelease of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases). This should be tested locally.
- might eventually fail until the MeiliSearch v0.16.0 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.16.0) is out.