### PR TITLE
Add pre-release CI

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -23,3 +23,5 @@ replacers:
     replace: ''
   - search: '/(?:and )?@bors(?:\[bot\])?,?/g'
     replace: ''
+  - search: '/(?:and )?@meili-bot,?/g'
+    replace: ''

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -1,0 +1,27 @@
+# Testing the code base against the MeiliSearch pre-releases
+name: Pre-Release Tests
+
+# Will only run for PRs and pushes to bump-meilisearch-v*
+on:
+  push:
+    branches: bump-meilisearch-v*
+  pull_request:
+    branches: bump-meilisearch-v*
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  integration_tests:
+    name: integration-tests-against-rc
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Get the latest MeiliSearch RC
+      run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/master/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
+    - name: MeiliSearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_VERSION }} ./meilisearch --master-key=masterKey --no-analytics=true
+    - name: Run tests
+      run: cargo test --verbose -- --test-threads=1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,16 @@ env:
 
 jobs:
   integration_tests:
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     name: integration-tests
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
-    - name: MeiliSearch setup with Docker
+    - name: MeiliSearch (latest version) setup with Docker
       run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key=masterKey
     - name: Run tests
       run: cargo test --verbose -- --test-threads=1


### PR DESCRIPTION
Add CI for the pre-release PRs = PRs to `bump-meilisearch-v*` during the pre-release week of MeiliSearch. This CI will run the tests against the MeilliSearch RC instead of the MeiliSearch `latest`.

For each PR to `bump-meilisearch-v*`:
- the `clippy-check` job will run
- the `integration-tests-against-rc` job will run
- the `integration-tests` job will be skipped
- the required jobs (for merging) in the settings will be: `clippy-check` and `integration-tests-against-rc`

For each **push** to `bump-meilisearch-v*`:
- the `clippy-check` job will run
- the `integration-tests-against-rc` job will run
- the `integration-tests` job will run
- the required jobs (for merging) in the settings will be: `clippy-check` and `integration-tests`

For any other event (PRs and pushes):
- the `clippy-check` job will run
- the `integration-tests-against-rc` job will NOT run
- the `integration-tests` job will run
- the required jobs (for merging) in the settings will be: `clippy-check` and `integration-tests`

⚠️ Bors will not work when trying to merge a PR into `bump-meilisearch-v*` since we can not apply conditional jobs for merging with Bors. 