### PR TITLE
Update old code

### DIFF
--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -665,8 +665,8 @@ impl<'a> Index<'a> {
     /// # client.delete_index("movies_get_all_updates").await.unwrap();
     /// # });
     /// ```
-    pub async fn get_all_updates(&self) -> Result<Vec<ProcessedStatus>, Error> {
-        request::<(), Vec<ProcessedStatus>>(
+    pub async fn get_all_updates(&self) -> Result<Vec<UpdateStatus>, Error> {
+        request::<(), Vec<UpdateStatus>>(
             &format!(
                 "{}/indexes/{}/updates",
                 self.client.host, self.uid

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -338,7 +338,7 @@ impl<'a> Index<'a> {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// let mut movie_index = client.get_or_create("movies_add_or_replace").await.unwrap();
     ///
-    /// movie_index.add_or_replace(&[
+    /// let progress = movie_index.add_or_replace(&[
     ///     Movie{
     ///         name: String::from("Interstellar"),
     ///         description: String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")
@@ -354,6 +354,7 @@ impl<'a> Index<'a> {
     ///     },
     /// ], Some("name")).await.unwrap();
     /// sleep(Duration::from_secs(1)); // MeiliSearch may take some time to execute the request
+    /// # progress.get_status().await.unwrap();
     ///
     /// // retrieve movies (you have to put some movies in the index before)
     /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
@@ -425,7 +426,7 @@ impl<'a> Index<'a> {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// let mut movie_index = client.get_or_create("movies_add_or_update").await.unwrap();
     ///
-    /// movie_index.add_or_update(&[
+    /// let progress = movie_index.add_or_update(&[
     ///     Movie{
     ///         name: String::from("Interstellar"),
     ///         description: String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")
@@ -441,6 +442,7 @@ impl<'a> Index<'a> {
     ///     },
     /// ], Some("name")).await.unwrap();
     /// sleep(Duration::from_secs(1)); // MeiliSearch may take some time to execute the request
+    /// # progress.get_status().await.unwrap();
     ///
     /// // retrieve movies (you have to put some movies in the index before)
     /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
@@ -495,7 +497,9 @@ impl<'a> Index<'a> {
     ///
     /// // add some documents
     ///
-    /// movie_index.delete_all_documents().await.unwrap();
+    /// let progress = movie_index.delete_all_documents().await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(1));
+    /// # progress.get_status().await.unwrap();
     /// # let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
     /// # assert_eq!(movies.len(), 0);
     /// # });
@@ -541,7 +545,8 @@ impl<'a> Index<'a> {
     /// # std::thread::sleep(std::time::Duration::from_secs(1));
     /// // add a document with id = Interstellar
     ///
-    /// movies.delete_document("Interstellar").await.unwrap();
+    /// let progress = movies.delete_document("Interstellar").await.unwrap();
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn delete_document<T: Display>(&'a self, uid: T) -> Result<Progress<'a>, Error> {
@@ -589,7 +594,8 @@ impl<'a> Index<'a> {
     /// # std::thread::sleep(std::time::Duration::from_secs(1));
     ///
     /// // delete some documents
-    /// movies.delete_documents(&["Interstellar", "Unknown"]).await.unwrap();
+    /// let progress = movies.delete_documents(&["Interstellar", "Unknown"]).await.unwrap();
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn delete_documents<T: Display + Serialize + std::fmt::Debug>(

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -2,8 +2,7 @@
 
 use crate::{errors::Error, indexes::Index, request::*};
 use serde::Deserialize;
-use serde_json::{from_value, Value};
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -39,8 +38,8 @@ impl<'a> Progress<'a> {
     /// let status = progress.get_status().await.unwrap();
     /// # });
     /// ```
-    pub async fn get_status(&self) -> Result<Status, Error> {
-        let value = request::<(), Value>(
+    pub async fn get_status(&self) -> Result<UpdateStatus, Error> {
+        request::<(), UpdateStatus>(
             &format!(
                 "{}/indexes/{}/updates/{}",
                 self.index.client.host, self.index.uid, self.id
@@ -49,17 +48,7 @@ impl<'a> Progress<'a> {
             Method::Get,
             200,
         )
-        .await?;
-
-        if let Ok(status) = from_value::<ProcessedStatus>(value.clone()) {
-            Ok(Status::Processed(status))
-        } else {
-            let result = from_value::<EnqueuedStatus>(value);
-            match result {
-                Ok(status) => Ok(Status::Enqueued(status)),
-                Err(e) => Err(Error::ParseError(e)),
-            }
-        }
+        .await
     }
 }
 
@@ -72,7 +61,7 @@ pub enum RankingRule {
     WordsPosition,
     Exactness,
     Asc(String),
-    Dsc(String),
+    Desc(String),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -83,53 +72,69 @@ pub enum UpdateState<T> {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SettingsUpdate {
     pub ranking_rules: UpdateState<Vec<RankingRule>>,
     pub distinct_attribute: UpdateState<String>,
-    pub identifier: UpdateState<String>,
+    pub primary_key: UpdateState<String>,
     pub searchable_attributes: UpdateState<Vec<String>>,
-    pub displayed_attributes: UpdateState<HashSet<String>>,
+    pub displayed_attributes: UpdateState<BTreeSet<String>>,
     pub stop_words: UpdateState<BTreeSet<String>>,
     pub synonyms: UpdateState<BTreeMap<String, Vec<String>>>,
+    pub attributes_for_faceting: UpdateState<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "name")]
-#[allow(clippy::large_enum_variant)] // would be great to correct but it's not my code it's from meilisearch/Meilisearch
 pub enum UpdateType {
     ClearAll,
     Customs,
     DocumentsAddition { number: usize },
     DocumentsPartial { number: usize },
     DocumentsDeletion { number: usize },
-    Settings { settings: SettingsUpdate },
+    Settings { settings: Box<SettingsUpdate> },
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ProcessedStatus {
+pub struct ProcessedUpdateResult {
     pub update_id: u64,
     #[serde(rename = "type")]
     pub update_type: UpdateType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_link: Option<String>,
     pub duration: f64,        // in seconds
-    pub enqueued_at: String,  // TODO deserialize to datatime
-    pub processed_at: String, // TODO deserialize to datatime
+    pub enqueued_at: String,  // TODO deserialize to datetime
+    pub processed_at: String, // TODO deserialize to datetime
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct EnqueuedStatus {
+pub struct EnqueuedUpdateResult {
     pub update_id: u64,
     #[serde(rename = "type")]
     pub update_type: UpdateType,
-    pub enqueued_at: String, // TODO deserialize to datatime
+    pub enqueued_at: String, // TODO deserialize to datetime
 }
 
-#[derive(Debug)]
-pub enum Status {
-    Processed(ProcessedStatus),
-    Enqueued(EnqueuedStatus),
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum UpdateStatus {
+    Enqueued {
+        #[serde(flatten)]
+        content: EnqueuedUpdateResult,
+    },
+    Failed {
+        #[serde(flatten)]
+        content: ProcessedUpdateResult,
+    },
+    Processed {
+        #[serde(flatten)]
+        content: ProcessedUpdateResult,
+    },
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -75,7 +75,6 @@ pub enum UpdateState<T> {
 pub struct SettingsUpdate {
     pub ranking_rules: UpdateState<Vec<RankingRule>>,
     pub distinct_attribute: UpdateState<String>,
-    pub primary_key: UpdateState<String>,
     pub searchable_attributes: UpdateState<Vec<String>>,
     pub displayed_attributes: UpdateState<BTreeSet<String>>,
     pub stop_words: UpdateState<BTreeSet<String>>,
@@ -100,13 +99,9 @@ pub struct ProcessedUpdateResult {
     pub update_id: u64,
     #[serde(rename = "type")]
     pub update_type: UpdateType,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_link: Option<String>,
     pub duration: f64,        // in seconds
     pub enqueued_at: String,  // TODO deserialize to datetime

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -279,6 +279,8 @@ impl<'a> Index<'a> {
     ///     .with_stop_words(stop_words.clone());
     ///
     /// let progress = movie_index.set_settings(&settings).await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn set_settings(&'a self, settings: &Settings) -> Result<Progress<'a>, Error> {
@@ -307,6 +309,8 @@ impl<'a> Index<'a> {
     /// synonyms.insert(String::from("wow"), vec![String::from("world of warcraft")]);
     ///
     /// let progress = movie_index.set_synonyms(&synonyms).await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn set_synonyms(&'a self, synonyms: &HashMap<String, Vec<String>>) -> Result<Progress<'a>, Error> {
@@ -331,6 +335,8 @@ impl<'a> Index<'a> {
     ///
     /// let stop_words = &["the", "of", "to"];
     /// let progress = movie_index.set_stop_words(stop_words).await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn set_stop_words(&'a self, stop_words: &[&str]) -> Result<Progress<'a>, Error> {
@@ -364,6 +370,8 @@ impl<'a> Index<'a> {
     ///     "desc(rank)",
     /// ];
     /// let progress = movie_index.set_ranking_rules(ranking_rules).await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn set_ranking_rules(&'a self, ranking_rules: &[&str]) -> Result<Progress<'a>, Error> {
@@ -388,6 +396,8 @@ impl<'a> Index<'a> {
     ///
     /// let attributes_for_faceting = &["genre", "director"];
     /// let progress = movie_index.set_attributes_for_faceting(attributes_for_faceting).await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn set_attributes_for_faceting(&'a self, attributes_for_faceting: &[&str]) -> Result<Progress<'a>, Error> {
@@ -411,6 +421,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.set_distinct_attribute("movie_id").await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn set_distinct_attribute(&'a self, distinct_attribute: &str) -> Result<Progress<'a>, Error> {
@@ -434,6 +446,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.set_searchable_attributes(&["title", "description", "uid"]).await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn set_searchable_attributes(&'a self, searchable_attributes: &[&str]) -> Result<Progress<'a>, Error> {
@@ -457,6 +471,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.set_displayed_attributes(&["title", "description", "release_date", "rank", "poster"]).await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn set_displayed_attributes(&'a self, displayed_attributes: &[&str]) -> Result<Progress<'a>, Error> {
@@ -481,6 +497,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.reset_settings().await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn reset_settings(&'a self) -> Result<Progress<'a>, Error> {
@@ -504,6 +522,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.reset_synonyms().await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn reset_synonyms(&'a self) -> Result<Progress<'a>, Error> {
@@ -527,6 +547,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.reset_stop_words().await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn reset_stop_words(&'a self) -> Result<Progress<'a>, Error> {
@@ -551,6 +573,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.reset_ranking_rules().await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn reset_ranking_rules(&'a self) -> Result<Progress<'a>, Error> {
@@ -574,6 +598,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.reset_attributes_for_faceting().await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn reset_attributes_for_faceting(&'a self) -> Result<Progress<'a>, Error> {
@@ -597,6 +623,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.reset_distinct_attribute().await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn reset_distinct_attribute(&'a self) -> Result<Progress<'a>, Error> {
@@ -620,6 +648,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.reset_searchable_attributes().await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn reset_searchable_attributes(&'a self) -> Result<Progress<'a>, Error> {
@@ -643,6 +673,8 @@ impl<'a> Index<'a> {
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
     /// let progress = movie_index.reset_displayed_attributes().await.unwrap();
+    /// # std::thread::sleep(std::time::Duration::from_secs(2));
+    /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
     pub async fn reset_displayed_attributes(&'a self) -> Result<Progress<'a>, Error> {


### PR DESCRIPTION
I copied a few data structures from the meilisearch core project when I started this SDK.
It seems that these structs and enums were modified during the last months and that breaking changes were introduced.
It would be useful if GitHub allowed me to subscribe to the changes on the 2 concerned files but it's not possible.

### TODO

- [x] Update the outdated code
- [x] Add new tests so that we can detect breaking changes faster (note that test structure is not ideal and there will be a new PR about this)