### PR TITLE
Add test on documentation when releasing

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -2,15 +2,24 @@
 
 # Checking if current tag matches the package version
 current_tag=$(echo $GITHUB_REF | tr -d 'refs/tags/v')
+major=$(echo $current_tag | cut -d '.' -f1 )
+minor=$(echo $current_tag | cut -d '.' -f2 )
+cropped_current_tag="$major.$minor"
 file1='Cargo.toml'
 file2='src/lib.rs'
+file3='.code-samples.meilisearch.yaml'
+file4='README.md'
 
 file_tag1=$(grep '^version = ' $file1 | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')
 file_tag2=$(grep '//! meilisearch-sdk = ' $file2 | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')
-if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" ]; then
+file_tag3=$(grep 'meilisearch-sdk = ' $file3 | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')
+file_tag4=$(grep 'meilisearch-sdk = ' $file4 | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')
+if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" || "$cropped_current_tag" != "$file_tag3" || "$cropped_current_tag" != "$file_tag4" ]; then
   echo "Error: the current tag does not match the version in package file(s)."
   echo "$file1: found $file_tag1 - expected $current_tag"
   echo "$file2: found $file_tag2 - expected $current_tag"
+  echo "$file3: found $file_tag3 - expected $cropped_current_tag"
+  echo "$file4: found $file_tag4 - expected $cropped_current_tag"
   exit 1
 fi
 


### PR DESCRIPTION
Avoid pushing a new release to crates.io if one of the version in not updated in our docs (code-samples or README)

In the CI, we received the information of the new version in the `GITHUB_REF` variable in this format: `refs/tags/vX.X.X`

<img width="552" alt="Capture d’écran 2021-02-06 à 17 12 53" src="https://user-images.githubusercontent.com/20380692/107123593-a65a7680-689e-11eb-8300-710ff3572292.png">
