### PR TITLE
Adding get_all_updates route

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -62,7 +62,7 @@ search_1: |-
 get_update_1: |-
   let status: Status = progress.get_status().await.unwrap();
 get_all_updates_1: |-
-  // unavailable for now
+  let status: Vec<ProgressStatus> = index.get_all_updates().await.unwrap();
 get_keys_1: |-
   let keys: Keys = client.get_keys().await.unwrap();
 get_settings_1: |-


### PR DESCRIPTION
Resolves #39

The reason for renaming some of the indexes in the docs was because with them having the same names they were having side effects on each other and causing the doc tests to fail. Is this renaming acceptable, or is there a better way to handle this? The problem is related to issue #29.