### PR TITLE
Improve settings

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -69,37 +69,37 @@ get_settings_1: |-
   let settings: Settings = movies.get_settings().await.unwrap();
 update_settings_1: |-
   let mut synonyms = std::collections::HashMap::new();
-  synonyms.insert(String::from("wolverine"), vec![String::from("xmen"), String::from("logan")]);
-  synonyms.insert(String::from("logan"), vec![String::from("wolverine")]);
+  synonyms.insert(String::from("wolverine"), vec!["xmen", "logan"]);
+  synonyms.insert(String::from("logan"), vec!["wolverine"]);
 
   let settings = Settings::new()
-    .with_ranking_rules(vec![
-      "typo".to_string(),
-      "words".to_string(),
-      "proximity".to_string(),
-      "attribute".to_string(),
-      "wordsPosition".to_string(),
-      "exactness".to_string(),
-      "desc(release_date)".to_string(),
-      "desc(rank)".to_string()
-    ])
-    .with_distinct_attribute("movie_id".to_string())
-    .with_searchable_attributes(vec![
-      "title".to_string(),
-      "description".to_string(),
-      "genre".to_string()
-    ])
-    .with_displayed_attributes(vec![
-      "title".to_string(),
-      "description".to_string(),
-      "genre".to_string(),
-      "release_date".to_string()
-    ])
-    .with_stop_words(vec![
-      "the".to_string(),
-      "a".to_string(),
-      "an".to_string()
-    ])
+    .with_ranking_rules(&[
+      "typo",
+      "words",
+      "proximity",
+      "attribute",
+      "wordsPosition",
+      "exactness",
+      "desc(release_date)",
+      "desc(rank)"
+    ][..])
+    .with_distinct_attribute("movie_id")
+    .with_searchable_attributes(&[
+      "title",
+      "description",
+      "genre"
+    ][..])
+    .with_displayed_attributes(&[
+      "title",
+      "description",
+      "genre",
+      "release_date"
+    ][..])
+    .with_stop_words(&[
+      "the",
+      "a",
+      "an"
+    ][..])
     .with_synonyms(synonyms);
 
   let progress: Progress = movies.set_settings(&settings).await.unwrap();

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -119,14 +119,14 @@ reset_synonyms_1: |-
 get_stop_words_1: |-
   let stop_words: Vec<String> = movies.get_stop_words().await.unwrap();
 update_stop_words_1: |-
-  let stop_words = &["of", "the", "to"];
-  let progress: Progress = movies.set_stop_words(stop_words).await.unwrap();
+  let stop_words = ["of", "the", "to"];
+  let progress: Progress = movies.set_stop_words(&stop_words[..]).await.unwrap();
 reset_stop_words_1: |-
   let progress: Progress = movies.reset_stop_words().await.unwrap();
 get_ranking_rules_1: |-
   let ranking_rules: Vec<String> = movies.get_ranking_rules().await.unwrap();
 update_ranking_rules_1: |-
-  let ranking_rules = &[
+  let ranking_rules = [
     "typo",
     "words",
     "proximity",
@@ -137,7 +137,7 @@ update_ranking_rules_1: |-
     "desc(rank)",
   ];
 
-  let progress: Progress = movies.set_ranking_rules(ranking_rules).await.unwrap();
+  let progress: Progress = movies.set_ranking_rules(&ranking_rules[..]).await.unwrap();
 reset_ranking_rules_1: |-
   let progress: Progress = movies.reset_ranking_rules().await.unwrap();
 get_distinct_attribute_1: |-
@@ -149,37 +149,37 @@ reset_distinct_attribute_1: |-
 get_searchable_attributes_1: |-
   let searchable_attributes: Vec<String> = movies.get_searchable_attributes().await.unwrap();
 update_searchable_attributes_1: |-
-  let searchable_attributes = &[
+  let searchable_attributes = [
     "title",
     "description",
     "genre"
   ];
 
-  let progress: Progress = movies.set_searchable_attributes(searchable_attributes).await.unwrap();
+  let progress: Progress = movies.set_searchable_attributes(&searchable_attributes[..]).await.unwrap();
 reset_searchable_attributes_1: |-
   let progress: Progress = movies.reset_searchable_attributes().await.unwrap();
 get_attributes_for_faceting_1: |-
   let attributes_for_faceting: Vec<String> = movies.get_attributes_for_faceting().await.unwrap();
 update_attributes_for_faceting_1: |-
-  let attributes_for_faceting = &[
+  let attributes_for_faceting = [
     "genres",
     "director"
   ];
 
-  let progress: Progress = movies.set_attributes_for_faceting(attributes_for_faceting).await.unwrap();
+  let progress: Progress = movies.set_attributes_for_faceting(&attributes_for_faceting[..]).await.unwrap();
 reset_attributes_for_faceting_1: |-
   let progress: Progress = movies.reset_attributes_for_faceting().await.unwrap();
 get_displayed_attributes_1: |-
   let displayed_attributes: Vec<String> = movies.get_displayed_attributes().await.unwrap();
 update_displayed_attributes_1: |-
-  let displayed_attributes = &[
+  let displayed_attributes = [
     "title",
     "description",
     "genre",
     "release_date"
   ];
 
-  let progress: Progress = movies.set_displayed_attributes(displayed_attributes).await.unwrap();
+  let progress: Progress = movies.set_displayed_attributes(&displayed_attributes[..]).await.unwrap();
 reset_displayed_attributes_1: |-
   let progress: Progress = movies.reset_displayed_attributes().await.unwrap();
 get_index_stats_1: |-
@@ -195,22 +195,22 @@ distinct_attribute_guide_1: |-
   let jackets: Index = client.get_index("jackets").await.unwrap();
   let progress: Progress = jackets.set_distinct_attribute("product_id").await.unwrap();
 field_properties_guide_searchable_1: |-
-  let searchable_attributes = &[
+  let searchable_attributes = [
     "title",
     "description",
     "genre"
   ];
 
-  let progress: Progress = movies.set_searchable_attributes(searchable_attributes).await.unwrap();
+  let progress: Progress = movies.set_searchable_attributes(&searchable_attributes[..]).await.unwrap();
 field_properties_guide_displayed_1: |-
-  let displayed_attributes = &[
+  let displayed_attributes = [
     "title",
     "description",
     "genre",
     "release_date"
   ];
 
-  let progress: Progress = movies.set_displayed_attributes(displayed_attributes).await.unwrap();
+  let progress: Progress = movies.set_displayed_attributes(&displayed_attributes[..]).await.unwrap();
 filtering_guide_1: |-
   let results: SearchResults<Movie> = movies.search()
     .with_query("Avengers")
@@ -321,11 +321,11 @@ settings_guide_synonyms_1: |-
   let tops: Index = client.get_index("tops").await.unwrap();
   let progress: Progress = tops.set_synonyms(&synonyms).await.unwrap();
 settings_guide_stop_words_1: |-
-  let progress: Progress = movies.set_stop_words(&["the", "a", "an"]).await.unwrap();
+  let progress: Progress = movies.set_stop_words(&["the", "a", "an"][..]).await.unwrap();
 settings_guide_attributes_for_faceting_1: |-
-  let progress: Progress = movies.set_attributes_for_faceting(&["director", "genres"]).await.unwrap();
+  let progress: Progress = movies.set_attributes_for_faceting(&["director", "genres"][..]).await.unwrap();
 settings_guide_ranking_rules_1: |-
-  let ranking_rules = &[
+  let ranking_rules = [
     "typo",
     "words",
     "proximity",
@@ -336,27 +336,27 @@ settings_guide_ranking_rules_1: |-
     "desc(rank)",
   ];
 
-  let progress: Progress = movies.set_ranking_rules(ranking_rules).await.unwrap();
+  let progress: Progress = movies.set_ranking_rules(&ranking_rules[..]).await.unwrap();
 settings_guide_distinct_1: |-
   let jackets: Index = client.get_index("jackets").await.unwrap();
   let progress: Progress = jackets.set_distinct_attribute("product_id").await.unwrap();
 settings_guide_searchable_1: |-
-  let searchable_attributes = &[
+  let searchable_attributes = [
     "title",
     "description",
     "genre"
   ];
 
-  let progress: Progress = movies.set_searchable_attributes(searchable_attributes).await.unwrap();
+  let progress: Progress = movies.set_searchable_attributes(&searchable_attributes[..]).await.unwrap();
 settings_guide_displayed_1: |-
-  let displayed_attributes = &[
+  let displayed_attributes = [
     "title",
     "description",
     "genre",
     "release_date"
   ];
 
-  let progress: Progress = movies.set_displayed_attributes(displayed_attributes).await.unwrap();
+  let progress: Progress = movies.set_displayed_attributes(&displayed_attributes[..]).await.unwrap();
 documents_guide_add_movie_1: |-
   // Define the type of our documents
   #[derive(Serialize, Deserialize, Debug)]
@@ -500,7 +500,7 @@ getting_started_search_md: |-
 
   [About this package](https://github.com/meilisearch/meilisearch-rust/)
 faceted_search_update_settings_1: |-
-  let progress: Progress = movies.set_attributes_for_faceting(&["director", "genres"]).await.unwrap();
+  let progress: Progress = movies.set_attributes_for_faceting(&["director", "genres"][..]).await.unwrap();
 faceted_search_facet_filters_1: |-
   let results: SearchResults<Movie> = movies.search()
     .with_query("thriller")
@@ -517,7 +517,14 @@ faceted_search_facets_distribution_1: |-
     .unwrap();
   let genres: &HashMap<String, usize> = results.facets_distribution.unwrap().get("genres").unwrap();
 faceted_search_walkthrough_attributes_for_faceting_1: |-
-  let progress: Progress = movies.set_attributes_for_faceting(&["director", "producer", "genres", "production_companies"]).await.unwrap();
+  let attributes_for_faceting = [
+    "director",
+    "producer",
+    "genres",
+    "production_companies"
+  ];
+
+  let progress: Progress = movies.set_attributes_for_faceting(&attributes_for_faceting[..]).await.unwrap();
 faceted_search_walkthrough_facet_filters_1: |-
   let results: SearchResults<Movie> = movies.search()
     .with_query("thriller")

--- a/src/search.rs
+++ b/src/search.rs
@@ -322,7 +322,7 @@ mod tests {
             Document { id: 8, kind: "title".into(), value: "Harry Potter and the Half-Blood Prince".to_string() },
             Document { id: 9, kind: "title".into(), value: "Harry Potter and the Deathly Hallows".to_string() },
         ], None).await.unwrap();
-        index.set_attributes_for_faceting(&["kind"]).await.unwrap();
+        index.set_attributes_for_faceting(&["kind"][..]).await.unwrap();
         sleep(Duration::from_secs(1));
         index
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, convert, hash::Hash};
 use crate::{indexes::Index, errors::Error, request::{request, Method}, progress::{Progress, ProgressJson}};
 
 /// Struct reprensenting a set of settings.
@@ -52,6 +52,75 @@ pub struct Settings {
     pub displayed_attributes: Option<Vec<String>>,
 }
 
+pub trait IntoVecString {
+    fn convert(self) -> Vec<String>;
+}
+
+impl IntoVecString for &[&str] {
+    #[inline]
+    fn convert(self) -> Vec<String> {
+        let mut vec = Vec::new();
+        for item in self {
+            vec.push((*item).into())
+        }
+        vec
+    }
+}
+
+impl IntoVecString for Vec<&str> {
+    #[inline]
+    fn convert(self) -> Vec<String> {
+        let mut vec = Vec::new();
+        for item in self {
+            vec.push((*item).into())
+        }
+        vec
+    }
+}
+
+impl IntoVecString for Vec<String> {
+    #[inline]
+    fn convert(self) -> Vec<String> {
+        self
+    }
+}
+
+impl IntoVecString for &[String] {
+    #[inline]
+    fn convert(self) -> Vec<String> {
+        let mut vec = Vec::new();
+        for item in self {
+            vec.push(item.clone())
+        }
+        vec
+    }
+}
+
+impl IntoVecString for &[&String] {
+    #[inline]
+    fn convert(self) -> Vec<String> {
+        let mut vec = Vec::new();
+        for item in self {
+            vec.push((*item).clone())
+        }
+        vec
+    }
+}
+
+/*
+TODO: Implement IntoVecString trought const generics as soon as they are stable.
+
+impl<const N: usize> IntoVecString for &[String; N] {
+    fn convert(self) -> Vec<String> {
+        let mut vec = Vec::new();
+        for item in self {
+            vec.push((*item).clone())
+        }
+        vec
+    }
+}
+*/
+
 #[allow(missing_docs)]
 impl Settings {
     /// Create undefined settings
@@ -66,45 +135,53 @@ impl Settings {
             displayed_attributes: None,
         }
     }
-    pub fn with_synonyms(self, synonyms: HashMap<String, Vec<String>>) -> Settings {
+    pub fn with_synonyms<T: Into<String>, U: IntoVecString>(self, synonyms: HashMap<T, U>) -> Settings {
+        let mut converted_synonyms = HashMap::new();
+        for (key, array) in synonyms {
+            let key: String = key.into();
+            let array: Vec<String> = array.convert();
+            converted_synonyms.insert(key, array);
+        }
+
         Settings {
-            synonyms: Some(synonyms),
+            synonyms: Some(converted_synonyms),
             ..self
         }
     }
-    pub fn with_stop_words(self, stop_words: Vec<String>) -> Settings {
+    pub fn with_stop_words(self, stop_words: impl IntoVecString) -> Settings {
         Settings {
-            stop_words: Some(stop_words),
+            stop_words: Some(stop_words.convert()),
             ..self
         }
     }
-    pub fn with_ranking_rules(self, ranking_rules: Vec<String>) -> Settings {
+    pub fn with_ranking_rules<T: IntoVecString>(self, ranking_rules: T) -> Settings
+    {
         Settings {
-            ranking_rules: Some(ranking_rules),
+            ranking_rules: Some(ranking_rules.convert()),
             ..self
         }
     }
-    pub fn with_attributes_for_faceting(self, attributes_for_faceting: Vec<String>) -> Settings {
+    pub fn with_attributes_for_faceting<T: IntoVecString>(self, attributes_for_faceting: T) -> Settings {
         Settings {
-            attributes_for_faceting: Some(attributes_for_faceting),
+            attributes_for_faceting: Some(attributes_for_faceting.convert()),
             ..self
         }
     }
-    pub fn with_distinct_attribute(self, distinct_attribute: String) -> Settings {
+    pub fn with_distinct_attribute<T: Into<String>>(self, distinct_attribute: T) -> Settings {
         Settings {
-            distinct_attribute: Some(distinct_attribute),
+            distinct_attribute: Some(distinct_attribute.into()),
             ..self
         }
     }
-    pub fn with_searchable_attributes(self, searchable_attributes: Vec<String>) -> Settings {
+    pub fn with_searchable_attributes<T: IntoVecString>(self, searchable_attributes: T) -> Settings {
         Settings {
-            searchable_attributes: Some(searchable_attributes),
+            searchable_attributes: Some(searchable_attributes.convert()),
             ..self
         }
     }
-    pub fn with_displayed_attributes(self, displayed_attributes: Vec<String>) -> Settings {
+    pub fn with_displayed_attributes<T: IntoVecString>(self, displayed_attributes: T) -> Settings {
         Settings {
-            displayed_attributes: Some(displayed_attributes),
+            displayed_attributes: Some(displayed_attributes.convert()),
             ..self
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert, hash::Hash};
+use std::collections::HashMap;
 use crate::{indexes::Index, errors::Error, request::{request, Method}, progress::{Progress, ProgressJson}};
 
 /// Struct reprensenting a set of settings.
@@ -9,20 +9,20 @@ use crate::{indexes::Index, errors::Error, request::{request, Method}, progress:
 ///
 /// ```
 /// # use meilisearch_sdk::settings::Settings;
-/// let stop_words = vec![String::from("a"), String::from("the"), String::from("of")];
-///
 /// let settings = Settings::new()
-///     .with_stop_words(stop_words.clone());
+///     .with_stop_words(&["a", "the", "of"][..]);
 ///
 /// // OR
 ///
+/// let stop_words: Vec<String> = vec!["a".to_string(), "the".to_string(), "of".to_string()];
 /// let mut settings = Settings::new();
-/// settings.stop_words = Some(stop_words.clone());
+/// settings.stop_words = Some(stop_words);
 ///
 /// // OR
 ///
+/// let stop_words: Vec<String> = vec!["a".to_string(), "the".to_string(), "of".to_string()];
 /// let settings = Settings {
-///     stop_words: Some(stop_words.clone()),
+///     stop_words: Some(stop_words),
 ///     ..Settings::new()
 /// };
 /// ```

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -52,7 +52,7 @@ pub struct Settings {
     pub displayed_attributes: Option<Vec<String>>,
 }
 
-pub trait IntoVecString {
+pub trait IntoVecString: Sized {
     fn convert(self) -> Vec<String>;
 }
 
@@ -410,17 +410,17 @@ impl<'a> Index<'a> {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
-    /// let stop_words = &["the", "of", "to"];
-    /// let progress = movie_index.set_stop_words(stop_words).await.unwrap();
+    /// let stop_words = ["the", "of", "to"];
+    /// let progress = movie_index.set_stop_words(&stop_words[..]).await.unwrap();
     /// # std::thread::sleep(std::time::Duration::from_secs(2));
     /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
-    pub async fn set_stop_words(&'a self, stop_words: &[&str]) -> Result<Progress<'a>, Error> {
-        Ok(request::<&[&str], ProgressJson>(
+    pub async fn set_stop_words(&'a self, stop_words: impl IntoVecString) -> Result<Progress<'a>, Error> {
+        Ok(request::<Vec<String>, ProgressJson>(
             &format!("{}/indexes/{}/settings/stop-words", self.client.host, self.uid),
             self.client.apikey,
-            Method::Post(stop_words),
+            Method::Post(stop_words.convert()),
             202,
         ).await?
         .into_progress(self))
@@ -436,7 +436,7 @@ impl<'a> Index<'a> {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
-    /// let ranking_rules = &[
+    /// let ranking_rules = [
     ///     "typo",
     ///     "words",
     ///     "proximity",
@@ -446,16 +446,16 @@ impl<'a> Index<'a> {
     ///     "asc(release_date)",
     ///     "desc(rank)",
     /// ];
-    /// let progress = movie_index.set_ranking_rules(ranking_rules).await.unwrap();
+    /// let progress = movie_index.set_ranking_rules(&ranking_rules[..]).await.unwrap();
     /// # std::thread::sleep(std::time::Duration::from_secs(2));
     /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
-    pub async fn set_ranking_rules(&'a self, ranking_rules: &[&str]) -> Result<Progress<'a>, Error> {
-        Ok(request::<&[&str], ProgressJson>(
+    pub async fn set_ranking_rules(&'a self, ranking_rules: impl IntoVecString) -> Result<Progress<'a>, Error> {
+        Ok(request::<Vec<String>, ProgressJson>(
             &format!("{}/indexes/{}/settings/ranking-rules", self.client.host, self.uid),
             self.client.apikey,
-            Method::Post(ranking_rules),
+            Method::Post(ranking_rules.convert()),
             202,
         ).await?
         .into_progress(self))
@@ -471,17 +471,17 @@ impl<'a> Index<'a> {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
-    /// let attributes_for_faceting = &["genre", "director"];
-    /// let progress = movie_index.set_attributes_for_faceting(attributes_for_faceting).await.unwrap();
+    /// let attributes_for_faceting = ["genre", "director"];
+    /// let progress = movie_index.set_attributes_for_faceting(&attributes_for_faceting[..]).await.unwrap();
     /// # std::thread::sleep(std::time::Duration::from_secs(2));
     /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
-    pub async fn set_attributes_for_faceting(&'a self, attributes_for_faceting: &[&str]) -> Result<Progress<'a>, Error> {
-        Ok(request::<&[&str], ProgressJson>(
+    pub async fn set_attributes_for_faceting(&'a self, attributes_for_faceting: impl IntoVecString) -> Result<Progress<'a>, Error> {
+        Ok(request::<Vec<String>, ProgressJson>(
             &format!("{}/indexes/{}/settings/attributes-for-faceting", self.client.host, self.uid),
             self.client.apikey,
-            Method::Post(attributes_for_faceting),
+            Method::Post(attributes_for_faceting.convert()),
             202,
         ).await?
         .into_progress(self))
@@ -502,11 +502,11 @@ impl<'a> Index<'a> {
     /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
-    pub async fn set_distinct_attribute(&'a self, distinct_attribute: &str) -> Result<Progress<'a>, Error> {
-        Ok(request::<&str, ProgressJson>(
+    pub async fn set_distinct_attribute(&'a self, distinct_attribute: impl Into<String>) -> Result<Progress<'a>, Error> {
+        Ok(request::<String, ProgressJson>(
             &format!("{}/indexes/{}/settings/distinct-attribute", self.client.host, self.uid),
             self.client.apikey,
-            Method::Post(distinct_attribute),
+            Method::Post(distinct_attribute.into()),
             202,
         ).await?
         .into_progress(self))
@@ -522,16 +522,16 @@ impl<'a> Index<'a> {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
-    /// let progress = movie_index.set_searchable_attributes(&["title", "description", "uid"]).await.unwrap();
+    /// let progress = movie_index.set_searchable_attributes(&["title", "description", "uid"][..]).await.unwrap();
     /// # std::thread::sleep(std::time::Duration::from_secs(2));
     /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
-    pub async fn set_searchable_attributes(&'a self, searchable_attributes: &[&str]) -> Result<Progress<'a>, Error> {
-        Ok(request::<&[&str], ProgressJson>(
+    pub async fn set_searchable_attributes(&'a self, searchable_attributes: impl IntoVecString) -> Result<Progress<'a>, Error> {
+        Ok(request::<Vec<String>, ProgressJson>(
             &format!("{}/indexes/{}/settings/searchable-attributes", self.client.host, self.uid),
             self.client.apikey,
-            Method::Post(searchable_attributes),
+            Method::Post(searchable_attributes.convert()),
             202,
         ).await?
         .into_progress(self))
@@ -547,16 +547,16 @@ impl<'a> Index<'a> {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// let mut movie_index = client.get_or_create("movies").await.unwrap();
     ///
-    /// let progress = movie_index.set_displayed_attributes(&["title", "description", "release_date", "rank", "poster"]).await.unwrap();
+    /// let progress = movie_index.set_displayed_attributes(&["title", "description", "release_date", "rank", "poster"][..]).await.unwrap();
     /// # std::thread::sleep(std::time::Duration::from_secs(2));
     /// # progress.get_status().await.unwrap();
     /// # });
     /// ```
-    pub async fn set_displayed_attributes(&'a self, displayed_attributes: &[&str]) -> Result<Progress<'a>, Error> {
-        Ok(request::<&[&str], ProgressJson>(
+    pub async fn set_displayed_attributes(&'a self, displayed_attributes: impl IntoVecString) -> Result<Progress<'a>, Error> {
+        Ok(request::<Vec<String>, ProgressJson>(
             &format!("{}/indexes/{}/settings/displayed-attributes", self.client.host, self.uid),
             self.client.apikey,
-            Method::Post(displayed_attributes),
+            Method::Post(displayed_attributes.convert()),
             202,
         ).await?
         .into_progress(self))


### PR DESCRIPTION
Allow users to use a variety of data types when constructing `Settings` with the builder syntax.
Fix #38.
