### PR TITLE
Standardize health method 

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -203,6 +203,7 @@ impl<'a> Client<'a> {
     /// # futures::executor::block_on(async move {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// let health = client.is_healthy().await;
+    /// assert_eq!(health, true);
     /// # });
     /// ```
     pub async fn is_healthy(&self) -> bool {

--- a/src/client.rs
+++ b/src/client.rs
@@ -198,7 +198,7 @@ impl<'a> Client<'a> {
     /// # Example
     ///
     /// ```
-    /// # use meilisearch_sdk::{client::*};
+    /// # use meilisearch_sdk::client::*;
     /// #
     /// # futures::executor::block_on(async move {
     /// let client = Client::new("http://localhost:7700", "masterKey");

--- a/src/client.rs
+++ b/src/client.rs
@@ -207,7 +207,7 @@ impl<'a> Client<'a> {
     /// # });
     /// ```
     pub async fn is_healthy(&self) -> bool {
-        if let Some(health) = self.health().await {
+        if let Ok(health) = self.health().await {
             health.status.as_str() == "available"
         } else {
             false

--- a/src/client.rs
+++ b/src/client.rs
@@ -207,7 +207,11 @@ impl<'a> Client<'a> {
     /// # });
     /// ```
     pub async fn is_healthy(&self) -> bool {
-        self.health().await.is_ok()
+        if let Some(health) = self.health().await {
+            health.status.as_str() == "available"
+        } else {
+            false
+        }
     }
 
     /// Get the private and public key.

--- a/src/client.rs
+++ b/src/client.rs
@@ -176,7 +176,7 @@ impl<'a> Client<'a> {
     /// # Example
     ///
     /// ```
-    /// # use meilisearch_sdk::{client::*, indexes::*, errors::{Error, ErrorCode}};
+    /// # use meilisearch_sdk::{client::*, errors::{Error, ErrorCode}};
     /// #
     /// # futures::executor::block_on(async move {
     /// let client = Client::new("http://localhost:7700", "masterKey");
@@ -191,6 +191,22 @@ impl<'a> Client<'a> {
             200,
         )
         .await
+    }
+
+    /// Get health of MeiliSearch server, return true or false.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*};
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let health = client.is_healthy().await;
+    /// # });
+    /// ```
+    pub async fn is_healthy(&self) -> bool {
+        self.health().await.is_ok()
     }
 
     /// Get the private and public key.


### PR DESCRIPTION
**Description**
Checking that method `health()` return `{'status': 'available'}` and added `is_healthy()` method who return boolean value

**Issue related**
meilisearch/integration-guides#55

**Some points of concern**
- I let `Health` struct like it was:
```rust
#[derive(Deserialize)]
pub struct Health {
    pub status: String,
}
```
but I see we could write it this way too:
```rust
#[derive(Deserialize)]
#[serde(tag="status")]
pub enum Health {
    #[serde(rename="available")]
    Available
}
```
 That's means API should return `'available'` and this could lead to more maintenance but it seemed to be more accurate.