### PR TITLE
Check code samples automatically

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -21,11 +21,12 @@ get_documents_1: |-
 add_or_replace_documents_1: |-
   let progress: Progress = movies.add_or_replace(&[
     Movie {
-      id: 287947,
+      id: "287947".to_string(),
       title: "Shazam".to_string(),
       poster: "https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg".to_string(),
       overview: "A boy is given the ability to become an adult superhero in times of need with a single magic word.".to_string(),
-      release_date: "2019-03-23".to_string(),
+      release_date: 1553323329, // 2019-03-23
+      genres: vec![],
     }
   ], None).await.unwrap();
 add_or_update_documents_1: |-
@@ -60,9 +61,9 @@ search_1: |-
     .await
     .unwrap();
 get_update_1: |-
-  let status: Status = progress.get_status().await.unwrap();
+  let status: UpdateStatus = progress.get_status().await.unwrap();
 get_all_updates_1: |-
-  let status: Vec<ProgressStatus> = index.get_all_updates().await.unwrap();
+  let status: Vec<UpdateStatus> = movies.get_all_updates().await.unwrap();
 get_keys_1: |-
   let keys: Keys = client.get_keys().await.unwrap();
 get_settings_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -26,7 +26,7 @@ add_or_replace_documents_1: |-
       poster: "https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg".to_string(),
       overview: "A boy is given the ability to become an adult superhero in times of need with a single magic word.".to_string(),
       release_date: 1553323329, // 2019-03-23
-      genres: vec![],
+      .. Default::default()
     }
   ], None).await.unwrap();
 add_or_update_documents_1: |-

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 examples/web_app/target/*
 .vscode
+tests/generated_from_code_samples.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Rust wrapper for the MeiliSearch API. MeiliSearch is a powerful, 
 license = "MIT"
 readme  = "README.md"
 repository = "https://github.com/meilisearch/meilisearch-sdk"
+build = "scripts/generate_tests.rs"
 
 [dependencies]
 serde_json = "1.0"
@@ -38,6 +39,9 @@ wasm-bindgen-futures = "0.4"
 yew = "0.17"
 web-sys = "0.3"
 console_error_panic_hook = "0.1"
+
+[build-dependencies]
+yaml-rust = "0.4.5"
 
 [[example]]
 name = "web_app"

--- a/scripts/generate_tests.rs
+++ b/scripts/generate_tests.rs
@@ -5,6 +5,7 @@ const PRELUDE: &str = r#"
 //! This file was generated automatically from the code samples (path: `.code-samples.meilisearch.yaml`).
 //! It is not possible to edit this file directly.
 //! Some parts of this file are also contained in `scripts/generate_tests.rs`.
+//! Run `cargo test code_sample -- --test-threads=1` to run all code sample tests.
 #![allow(unused_variables)]
 
 use futures_await_test::async_test;
@@ -53,7 +54,7 @@ impl Document for Movie {
 
 const TEST: &str = r#"
 #[async_test]
-async fn [NAME]() {
+async fn code_sample_[NAME]() {
     let client = Client::new("http://localhost:7700", "masterKey");
     let movies = setup_test_index(&client, "[NAME]").await;
     [ADDITIONAL_CONFIG]

--- a/scripts/generate_tests.rs
+++ b/scripts/generate_tests.rs
@@ -1,0 +1,116 @@
+use yaml_rust::YamlLoader;
+use std::{fs::File, io::Write};
+
+const PRELUDE: &str = r#"
+//! This file was generated automatically from the code samples (path: `.code-samples.meilisearch.yaml`).
+//! It is not possible to edit this file directly.
+//! Some parts of this file are also contained in `scripts/generate_tests.rs`.
+#![allow(unused_variables)]
+
+use futures_await_test::async_test;
+use meilisearch_sdk::{indexes::*, client::*, progress::*, document::*, search::*, settings::*};
+use serde::{Serialize, Deserialize};
+use std::collections::HashMap;
+
+#[allow(unused_must_use)]
+async fn setup_test_index<'a>(client: &'a Client<'a>, name: &'a str) -> Index<'a> {
+    // try to delete
+    client.delete_index(name).await;
+
+    let index = client.create_index(name, None).await.unwrap();
+
+    // We could add data if we wanted to
+    /*index.add_documents(&[
+        Movie {
+            id: "".to_string(),
+            title: "".to_string(),
+            poster: "".to_string(),
+            overview: "".to_string(),
+            release_date: 0,
+            genres: vec![],
+        }
+    ], None).await.unwrap();*/
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    index
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Movie {
+    id: String,
+    title: String,
+    poster: String,
+    overview: String,
+    release_date: i64,
+    genres: Vec<String>
+}
+impl Document for Movie {
+    type UIDType = String;
+    fn get_uid(&self) -> &Self::UIDType { &self.id }
+}
+
+"#;
+
+const TEST: &str = r#"
+#[async_test]
+async fn [NAME]() {
+    let client = Client::new("http://localhost:7700", "masterKey");
+    let movies = setup_test_index(&client, "[NAME]").await;
+    [ADDITIONAL_CONFIG]
+
+    [CODE]
+}
+"#;
+
+fn main() {
+    println!("cargo:rerun-if-changed=.code-samples.meilisearch.yaml");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Read the code samples
+    let raw_code_samples = std::fs::read_to_string(".code-samples.meilisearch.yaml").expect("Failed to load code samples");
+    let code_samples = YamlLoader::load_from_str(&raw_code_samples).expect("Invalid code samples");
+    let code_samples = &code_samples[0].as_hash().expect("Code samples must be a Hash");
+
+    // Initialize the code
+    let mut generated_file_content = String::new();
+    generated_file_content.push_str(PRELUDE);
+
+    // Append each code sample as a test function
+    for (name, code) in code_samples.into_iter() {
+        let name = name.as_str().expect("The key of a code sample must be a String");
+        let code = code.as_str().expect("The content of a code sample must be a String");
+
+        // Formatting
+        let code = code.replace("\n", "\n  ");
+        let code = code.replace("  ", "    ");
+
+        // Test generation
+        let mut generated_test = TEST.to_string();
+        generated_test = generated_test.replace("[NAME]", name);
+        generated_test = generated_test.replace("[CODE]", &code);
+
+        // Add custom test workarrounds
+        let additionnal_config = match name {
+            "get_update_1" => "    let progress = movies.delete_all_documents().await.unwrap();\n",
+            _ => "",
+        };
+        if !additionnal_config.is_empty() {
+            let additionnal_config = "\n    // THE FOLLOWING LINES ARE SPECIFIC TO THIS TEST AND CAN ONLY BE EDITED IN `scripts/generate_tests.rs`\n".to_string() + additionnal_config;
+            let additionnal_config = additionnal_config + "    // END";
+            generated_test = generated_test.replace("[ADDITIONAL_CONFIG]", &additionnal_config);
+        } else {
+            generated_test = generated_test.replace("[ADDITIONAL_CONFIG]\n", "");
+        }
+
+        // Append test to file content
+        if !name.ends_with("_md") {
+            generated_file_content.push_str(&generated_test)
+        }
+    }
+
+    // Create or update the generated test file
+    let mut output_file = File::create("tests/generated_from_code_samples.rs").expect("Failed to open output file");
+    output_file.write_all(generated_file_content.as_bytes()).expect("Failed to write to output file");
+}
+
+

--- a/scripts/generate_tests.rs
+++ b/scripts/generate_tests.rs
@@ -162,6 +162,11 @@ fn main() {
     }
 
     // Create or update the generated test file
+    match std::fs::create_dir("tests") {
+        Ok(()) => (),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => (),
+        Err(e) => panic!("Failed to create `tests` directory: {}", e),
+    }
     let mut output_file = File::create("tests/generated_from_code_samples.rs").expect("Failed to open output file");
     output_file.write_all(generated_file_content.as_bytes()).expect("Failed to write to output file");
 }


### PR DESCRIPTION
I added a small build script that will generate a test file from code samples.
The file will be located in `tests/generated_from_code_samples.rs` and contains 78 additional tests.
This is a great way to track breaking changes in the code samples.
I also made a few fixes to code samples as there was breaking changes in the past that were not updated.

<details><summary>Generated test preview</summary>
<p>

```rust

#[async_test]
async fn code_sample_delete_one_document_1() {
    // Setup
    let client = Client::new("http://localhost:7700", "masterKey");
    let _ = client.delete_index("delete_one_document_1").await;
    let movies = setup_test_index(&client, "delete_one_document_1").await;
    
    // Code sample
    let progress: Progress = movies.delete_document(25684).await.unwrap();

    // Cleanup
    let _ = client.delete_index("delete_one_document_1").await;
}

#[async_test]
async fn code_sample_delete_documents_1() {
    // Setup
    let client = Client::new("http://localhost:7700", "masterKey");
    let _ = client.delete_index("delete_documents_1").await;
    let movies = setup_test_index(&client, "delete_documents_1").await;
    
    // Code sample
    let progress: Progress = movies.delete_documents(&[23488, 153738, 437035, 363869]).await.unwrap();

    // Cleanup
    let _ = client.delete_index("delete_documents_1").await;
}

// and 76 other tests like these 2
```

</p>
</details>