### PR TITLE
Create get_update fn to get one update status

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -59,16 +59,12 @@ search_1: |-
     .execute()
     .await
     .unwrap();
-get_update_md: |-
-  You can get the status of a `Progress` instance:
-  ```rust 
+get_update_1: |-
+  // You can get the status of a `Progress` object:
   let status: Status = progress.get_status().await.unwrap();
-  ```
 
-  Or you can use index to get an update status using its `update_id`:
-  ```rust
+  // Or you can use index to get an update status using its `update_id`:
   let status: Status = index.get_update(1).await.unwrap();
-  ```
 get_all_updates_1: |-
   let status: Vec<ProgressStatus> = index.get_all_updates().await.unwrap();
 get_keys_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -59,8 +59,16 @@ search_1: |-
     .execute()
     .await
     .unwrap();
-get_update_1: |-
-  let status: Status = index.get_status(1).await.unwrap();
+get_update_md: |-
+  You can get the status of a `Progress` instance:
+  ```rust 
+  let status: Status = progress.get_status().await.unwrap();
+  ```
+
+  Or you can use index to get an update status using its `update_id`:
+  ```rust
+  let status: Status = index.get_update(1).await.unwrap();
+  ```
 get_all_updates_1: |-
   let status: Vec<ProgressStatus> = index.get_all_updates().await.unwrap();
 get_keys_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -60,7 +60,7 @@ search_1: |-
     .await
     .unwrap();
 get_update_1: |-
-  let status: Status = progress.get_status().await.unwrap();
+  let status: Status = index.get_status(1).await.unwrap();
 get_all_updates_1: |-
   let status: Vec<ProgressStatus> = index.get_all_updates().await.unwrap();
 get_keys_1: |-

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -621,14 +621,14 @@ impl<'a> Index<'a> {
 
     /// Get the status of an update on the index.
     /// 
-    /// After executing an update, a `Progress` object is returned,
-    /// you can use this object to check on the status of the update.
+    /// After executing an update, a `Progress` struct is returned,
+    /// you can use this struct to check on the status of the update.
     /// 
     /// In some cases, you might not need the status of the update directly,
     /// or would rather not wait for it to resolve.
     /// 
     /// For these cases, you can get the `update_id` from the `Progress` 
-    /// object and use it to query the index later on.
+    /// struct and use it to query the index later on.
     /// 
     /// For example, if a clients updates an entry over an HTTP request,
     /// you can respond with the `update_id` and have the client check

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -28,7 +28,6 @@ pub struct Progress<'a> {
 
 impl<'a> Progress<'a> {
 
-    ///
     /// # Example
     ///
     /// ```

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -27,6 +27,24 @@ pub struct Progress<'a> {
 }
 
 impl<'a> Progress<'a> {
+
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, document::*};
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let mut movies_index = client.get_or_create("movies").await.unwrap();
+    /// let progress = movies_index.delete_all_documents().await.unwrap();
+    /// let update_id = progress.get_update_id();
+    /// # client.delete_index("movies").await.unwrap();
+    /// # });
+    /// ```
+    pub fn get_update_id(&self) -> u64 {
+        self.id as u64
+    }
+
     ///
     /// # Example
     ///


### PR DESCRIPTION
Hi,

Having fun using this SDK, but I reckon a function to get the status of one single update is missing.

When I read through https://docs.meilisearch.com/reference/api/updates.html#get-an-update-status, I see for example:

```javascript
 client.index('movies').getUpdateStatus(1)
```

Where the argument of `getUpdateStatus`, I guess, is the update id based on what the cURL version does:

```bash
curl \
  -X GET 'http://localhost:7700/indexes/movies/updates/1'
```

Which mirrors the MeiliSearch `/indexes/:index_uid/updates/:updateId` endpoint.

The rather unlucky thing is that to do the same with the Rust SDK it is not sufficient, not possible, to use the update id.

```rust
 let status: Status = progress.get_status().await.unwrap();
```

The above requires access to the `progress` instance, which is not possible in my case. Regardless of any specific use case, _**it is my opinion**_ that for completeness sake, the `get_update` function, defined in this PR, is needed to complete the SDK. Of course this can be challenged, or perhaps there's a reason to why such function does not exist.


Thanks for the SDK! Great Job!

