### PR TITLE
Fix wasm example compilation

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -27,7 +27,6 @@ pub struct Progress<'a> {
 }
 
 impl<'a> Progress<'a> {
-    ///
     /// # Example
     ///
     /// ```
@@ -143,6 +142,7 @@ pub(crate) async fn async_sleep(interval: Duration) {
 #[cfg(target_arch = "wasm32")]
 pub(crate) async fn async_sleep(interval: Duration) {
     use wasm_bindgen_futures::JsFuture;
+    use std::convert::TryInto;
 
     JsFuture::from(js_sys::Promise::new(&mut |yes, _| {
         web_sys::window()


### PR DESCRIPTION
The bug was here for a long time but we don't run CI with the Wasm target and we did not try to compile the webapp since the merge of the bug.