### PR TITLE
Adding logging code to test_wait_for_pending_updates_time_out test

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -71,12 +71,12 @@ impl<'a> Progress {
     }
 
     /// Wait until MeiliSearch processes an update, and get its status.
-    /// 
+    ///
     /// `interval` = The frequency at which the server should be polled. Default = 50ms
     /// `timeout` = The maximum time to wait for processing to complete. Default = 5000ms
-    /// 
+    ///
     /// If the waited time exceeds `timeout` then `None` will be returned.
-    /// 
+    ///
     /// # Example
     ///
     /// ```
@@ -89,7 +89,7 @@ impl<'a> Progress {
     /// #    value: String,
     /// #    kind: String,
     /// # }
-    /// # 
+    /// #
     /// # impl document::Document for Document {
     /// #    type UIDType = usize;
     /// #
@@ -101,14 +101,14 @@ impl<'a> Progress {
     /// # futures::executor::block_on(async move {
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// let movies = client.create_index("movies_wait_for_pending", None).await.unwrap();
-    /// 
+    ///
     /// let progress = movies.add_documents(&[
     ///     Document { id: 0, kind: "title".into(), value: "The Social Network".to_string() },
     ///     Document { id: 1, kind: "title".into(), value: "Harry Potter and the Sorcerer's Stone".to_string() },
     /// ], None).await.unwrap();
-    /// 
+    ///
     /// let status = progress.wait_for_pending_update(None, None).await.unwrap();
-    /// 
+    ///
     /// # client.delete_index("movies_wait_for_pending").await.unwrap();
     /// assert!(matches!(status.unwrap(), UpdateStatus::Processed { .. }));
     /// # });
@@ -268,10 +268,10 @@ mod test {
        value: String,
        kind: String,
     }
-    
+
     impl document::Document for Document {
        type UIDType = usize;
-    
+
        fn get_uid(&self) -> &Self::UIDType {
            &self.id
        }
@@ -296,7 +296,7 @@ mod test {
         let status = progress.wait_for_pending_update(
             Some(Duration::from_millis(1)), Some(Duration::from_millis(6000))
         ).await.unwrap();
-    
+
         client.delete_index("movies_wait_for_pending_args").await.unwrap();
         assert!(matches!(status.unwrap(), UpdateStatus::Processed { .. }));
     }
@@ -317,10 +317,20 @@ mod test {
                 value: "Harry Potter and the Sorcerer's Stone".to_string(),
             },
         ], None).await.unwrap();
-        let status = progress.wait_for_pending_update(
+
+        let status =  progress.wait_for_pending_update(
             Some(Duration::from_millis(1)), Some(Duration::from_nanos(1))
         ).await;
-    
+
+        /*
+         * TODO: This if let is here to try to log more information to resolve https://github.com/meilisearch/meilisearch-rust/issues/144.
+         * Once this issue is resolved this should be removed.
+         */
+        if let Some(Err(err)) = &status {
+            println!("{:?}", err);
+            client.delete_index("movies_wait_for_pending_timeout").await.unwrap();
+        };
+
         client.delete_index("movies_wait_for_pending_timeout").await.unwrap();
         assert_eq!(status.is_none(), true);
     }


### PR DESCRIPTION
Relates to #144

@curquiza and @Mubelotix I'm not sure if this will catch the information needed to solve the random failure issue or not but it's currently my best idea at something to try. If either of you have a different idea feel free to close this in favor of another option.