### PR TITLE
Adding the new flag required for the wasm build check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Also, the WASM example compilation should be checked:
 
 ```bash
 rustup target add wasm32-unknown-unknown
-cargo check --example web_app --target wasm32-unknown-unknown
+cargo check --example web_app --target wasm32-unknown-unknown --features=sync
 ```
 
 Each PR should pass the tests to be accepted.


### PR DESCRIPTION
The wasm build now requires the `--features=sync` flag as mentioned here https://github.com/meilisearch/meilisearch-rust/pull/132#issuecomment-860783197. Without this flag the build fails so I added it to the instructions in the `CONTRIBUTING.md`.