### PR TITLE
Make MatchRange fields public

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct MatchRange {
-    start: usize,
-    length: usize,
+    pub start: usize,
+    pub length: usize,
 }
 
 /// A single result.


### PR DESCRIPTION
[...] so that it's possible to interpret them beyond what highlighting the SDK
supports.

Hi 👋  I found this to be getting in the way of displaying search results other than the `<em>` highlighting that the SDK supports.