### PR TITLE
Making Sync Feature the Default Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 
 [features]
-default = ["isahc-static-curl"]
+default = ["isahc-static-curl", "sync"]
 isahc-static-curl = ["isahc/static-curl"]
 sync = []
 


### PR DESCRIPTION
Making sync feature the default feature even though it is less
performant to make the user experience simpler. See issue #176.
Setting default feature doc: https://doc.rust-lang.org/cargo/reference/features.html#the-features-section