### PR TITLE
Fix typo test_query_crop_length

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -512,7 +512,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_query_crop_lenght() {
+    async fn test_query_crop_length() {
         let client = Client::new("http://localhost:7700", "masterKey");
         let index = setup_test_index(&client, "test_query_crop_lenght").await;
 


### PR DESCRIPTION
Small nit fix, typo in name of test.

was test_query_crop_lenght