### PR TITLE
Added support for array filters

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 
 /// The top-level struct of the SDK, representing a client containing [indexes](../indexes/struct.Index.html).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Client {
     pub(crate) host: Rc<String>,
     pub(crate) api_key: Rc<String>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,7 +29,7 @@ impl Client {
         }
     }
 
-    /// List all [indexes] and returns values as instances of Index(../indexes/struct.Index.html).
+    /// List all indexes and return values as instances of [Index](crate::indexes::Index).
     ///
     /// # Example
     ///
@@ -56,7 +56,7 @@ impl Client {
         }
     }
 
-    /// List all [indexes] and returns as Json (../indexes/struct.Index.html).
+    /// List all [indexes](crate::indexes::Index) and return as [Json](crate::indexes::JsonIndex).
     ///
     /// # Example
     ///

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -272,7 +272,7 @@ impl From<&serde_json::Value> for Error {
         let error_type = json
             .get("type")
             .and_then(|v| v.as_str())
-            .and_then(|s| ErrorType::parse(s))
+            .and_then(ErrorType::parse)
             .unwrap_or(ErrorType::Internal);
 
         // If the response doesn't contain a type field, the error type
@@ -281,7 +281,7 @@ impl From<&serde_json::Value> for Error {
         let error_code = json
             .get("code")
             .and_then(|v| v.as_str())
-            .map(|s| ErrorCode::parse(s))
+            .map(ErrorCode::parse)
             .unwrap_or_else(|| {
                 ErrorCode::Unknown(UnknownErrorCode(String::from("missing error code")))
             });

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,13 +3,13 @@
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
-    /// The exhaustive list of MeiliSearch errors: https://github.com/meilisearch/specifications/blob/main/text/0061-error-format-and-definitions.md
-    /// Also check out: https://github.com/meilisearch/MeiliSearch/blob/main/meilisearch-error/src/lib.rs
+    /// The exhaustive list of MeiliSearch errors is available in the
+    /// [specification](https://github.com/meilisearch/specifications/blob/main/text/0061-error-format-and-definitions.md).
+    /// You can also check out the [source code](https://github.com/meilisearch/MeiliSearch/blob/main/meilisearch-error/src/lib.rs).
     MeiliSearchError {
         /// The human readable error message
         error_message: String,
-        /// The error code of the error.  Officially documented at
-        /// https://docs.meilisearch.com/errors.
+        /// The error code of the error. Officially documented [here](https://docs.meilisearch.com/errors).
         error_code: ErrorCode,
         /// The type of error (invalid request, internal error, or authentication
         /// error)
@@ -18,8 +18,7 @@ pub enum Error {
         error_link: String,
     },
 
-    /// There is no MeiliSearch server listening on the [specified host]
-    /// (../client/struct.Client.html#method.new).
+    /// There is no MeiliSearch server listening on the [specified host](crate::client::Client::new).
     UnreachableServer,
     /// The MeiliSearch server returned an invalid JSON for a request.
     ParseError(serde_json::Error),
@@ -49,7 +48,7 @@ pub enum ErrorType {
 
 /// The error code.
 ///
-/// Officially documented at https://docs.meilisearch.com/errors.
+/// Officially documented [here](https://docs.meilisearch.com/errors).
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum ErrorCode {

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -7,12 +7,12 @@ use serde_json::json;
 use std::{collections::HashMap, fmt::Display};
 
 #[derive(Deserialize, Debug)]
-#[allow(non_snake_case)]
+#[serde(rename_all = "camelCase")]
 pub struct JsonIndex {
     uid: String,
-    primaryKey: Option<String>,
-    createdAt: String,
-    updatedAt: String,
+    primary_key: Option<String>,
+    created_at: String,
+    updated_at: String,
 }
 
 impl JsonIndex {
@@ -694,7 +694,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_primary_key(&self) -> Result<Option<String>, Error> {
-        Ok(self.fetch_info().await?.primaryKey)
+        Ok(self.fetch_info().await?.primary_key)
     }
 
     /// Get the status of an update on the index.

--- a/src/search.rs
+++ b/src/search.rs
@@ -322,22 +322,27 @@ impl<'a> Query<'a> {
             matches: None,
         }
     }
+
     pub fn with_query<'b>(&'b mut self, query: &'a str) -> &'b mut Query<'a> {
         self.query = Some(query);
         self
     }
+
     pub fn with_offset<'b>(&'b mut self, offset: usize) -> &'b mut Query<'a> {
         self.offset = Some(offset);
         self
     }
+
     pub fn with_limit<'b>(&'b mut self, limit: usize) -> &'b mut Query<'a> {
         self.limit = Some(limit);
         self
     }
+
     pub fn with_filter<'b>(&'b mut self, filter: impl Into<Filter<'a>>) -> &'b mut Query<'a> {
         self.filter = Some(filter.into());
         self
     }
+
     pub fn with_facets_distribution<'b>(
         &'b mut self,
         facets_distribution: Selectors<&'a [&'a str]>,
@@ -345,10 +350,12 @@ impl<'a> Query<'a> {
         self.facets_distribution = Some(facets_distribution);
         self
     }
+
     pub fn with_sort<'b>(&'b mut self, sort: &'a [&'a str]) -> &'b mut Query<'a> {
         self.sort = Some(sort);
         self
     }
+
     pub fn with_attributes_to_retrieve<'b>(
         &'b mut self,
         attributes_to_retrieve: Selectors<&'a [&'a str]>,
@@ -356,6 +363,7 @@ impl<'a> Query<'a> {
         self.attributes_to_retrieve = Some(attributes_to_retrieve);
         self
     }
+
     pub fn with_attributes_to_crop<'b>(
         &'b mut self,
         attributes_to_crop: Selectors<&'a [(&'a str, Option<usize>)]>,
@@ -363,6 +371,7 @@ impl<'a> Query<'a> {
         self.attributes_to_crop = Some(attributes_to_crop);
         self
     }
+
     pub fn with_attributes_to_highlight<'b>(
         &'b mut self,
         attributes_to_highlight: Selectors<&'a [&'a str]>,
@@ -370,14 +379,17 @@ impl<'a> Query<'a> {
         self.attributes_to_highlight = Some(attributes_to_highlight);
         self
     }
+
     pub fn with_crop_length<'b>(&'b mut self, crop_length: usize) -> &'b mut Query<'a> {
         self.crop_length = Some(crop_length);
         self
     }
+
     pub fn with_matches<'b>(&'b mut self, matches: bool) -> &'b mut Query<'a> {
         self.matches = Some(matches);
         self
     }
+
     pub fn build(&mut self) -> Query<'a> {
         self.clone()
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -831,7 +831,7 @@ impl Index {
         .into_progress(self))
     }
 
-    /// Reset [filterable attributes]https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html) of the index.
+    /// Reset [filterable attributes](https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html) of the index.
     ///
     /// # Example
     ///
@@ -860,7 +860,7 @@ impl Index {
         .into_progress(self))
     }
 
-    /// Reset [sortable attributes]https://docs.meilisearch.com/reference/features/sorting.html) of the index.
+    /// Reset [sortable attributes](https://docs.meilisearch.com/reference/features/sorting.html) of the index.
     ///
     /// # Example
     ///


### PR DESCRIPTION
**Changes:**
- Added support for array filters.
- Derive `Clone` for `Client`

**Notes:**
I changed the `with_filter` method to require an `impl Into<Filter<'a>>`. This should both allow writing custom filter types for building more complex queries and, for some of the simpler cases, to simply pass in a few `Vec`s to get it to "just work". Another notable change, is that the string part of the filter now uses Cow, as I quickly run into issues in my project with ownership when building more complex queries.

Fixes #217
Fixes #163