### PR TITLE
Update docs according to v0.25.0

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -58,16 +58,14 @@ search_post_1: |-
     .execute()
     .await
     .unwrap();
-get_update_1: |-
-  // You can get the status of a `Progress` object:
-  let status: Status = progress.get_status().await.unwrap();
-
-  // Or you can use index to get an update status using its `update_id`:
-  let status: Status = client.index("movies").get_update(1).await.unwrap();
-get_all_updates_1: |-
-  let status: Vec<ProgressStatus> = client.index("movies").get_all_updates().await.unwrap();
-get_keys_1: |-
-  let keys: Keys = client.get_keys().await.unwrap();
+get_task_by_index_1: |-
+  let task: Task = client.index("movies").get_task(1).await.unwrap();
+get_all_tasks_by_index_1: |-
+  let tasks: Vec<Task> = client.index("movies").get_tasks().await.unwrap();
+get_all_tasks_1: |-
+  let tasks: Vec<Task> = client.get_tasks().await.unwrap();
+get_task_1: |-
+  let task: Task = client.get_task(1).await.unwrap();
 get_settings_1: |-
   let settings: Settings = client.index("movies").get_settings().await.unwrap();
 update_settings_1: |-
@@ -685,3 +683,48 @@ geosearch_guide_sort_usage_2: |-
     .execute()
     .await
     .unwrap();
+get_one_key_1: |-
+  let key = client.get_key("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4").await.unwrap();
+get_all_keys_1: |-
+  let keys = client.get_keys().await.unwrap();
+create_a_key_1: |-
+  let mut key_options = KeyBuilder::new("Add documents: Products API key");
+  key_options.with_action(Action::DocumentsAdd)
+      .with_expires_at("2042-04-02T00:42:42Z")
+      .with_index("products");
+  let new_key = client.create_key(key_options).await.unwrap();
+update_a_key_1: |-
+  let key = client.get_key("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4").await.unwrap();
+  key.description = "Manage documents: Products/Reviews API key".to_string();
+  key.actions = vec![Action::DocumentsAdd, Action::DocumentsDelete];
+  key.indexes = vec!["products".to_string(), "reviews".to_string()];
+  key.expires_at = Some("2042-04-02T00:42:42Z".to_string());
+  let updated_key = client.update_key(&key);
+delete_a_key_1: |-
+  let key = client.get_key("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4").await.unwrap();
+  client.delete_key(&key);
+authorization_header_1:
+  let client = Client::new("http://localhost:7700", "masterKey");
+  let keys = client.get_keys().await.unwrap();
+security_guide_search_key_1: |-
+  let client = Client::new("http://localhost:7700", "apiKey");
+  let result = client.index("patient_medical_records").search().execute().await.unwrap();
+security_guide_update_key_1: |-
+  let client = Client::new("http://localhost:7700", "masterKey");
+  let key = client.get_key("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4").await.unwrap();
+  key.indexes = vec!["doctors".to_string()];
+  let updated_key = client.update_key(&key);
+security_guide_create_key_1: |-
+  let client = Client::new("http://localhost:7700", "masterKey");
+  let mut key_options = KeyBuilder::new("Search patient records key");
+  key_options.with_action(Action::Search)
+      .with_expires_at("2023-01-01T00:00:00Z")
+      .with_index("patient_medical_records");
+  let new_key = client.create_key(key_options).await.unwrap();
+security_guide_list_keys_1: |-
+  let client = Client::new("http://localhost:7700", "masterKey");
+  let keys = client.get_keys().await.unwrap();
+security_guide_delete_key_1: |-
+  let client = Client::new("http://localhost:7700", "masterKey");
+  let key = client.get_key("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4").await.unwrap();
+  client.delete_key(&key);

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ fn main() { block_on(async move {
 })}
 ```
 
+With the `uid`, you can check the status (`enqueued`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://docs.meilisearch.com/reference/api/tasks.html#get-task).
+
 #### Basic Search <!-- omit in TOC -->
 
 ```rust
@@ -203,10 +205,7 @@ client.index("movies_4").set_filterable_attributes(&filterable_attributes).await
 
 You only need to perform this operation once.
 
-Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`.
-Depending on the size of your dataset, this might take time. You can track the whole process
-using the [update
-status](https://docs.meilisearch.com/reference/api/updates.html#get-an-update-status).
+Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [tasks](https://docs.meilisearch.com/reference/api/tasks.html#get-task)).
 
 Then, you can perform the search:
 

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -12,21 +12,21 @@ The macro aims to ease the writing of tests by:
 Before explaining its usage, we're going to see a simple test *before* this macro:
 ```rust
 #[async_test]
-async fn test_get_all_tasks() -> Result<(), Error> {
+async fn test_get_tasks() -> Result<(), Error> {
   let client = Client::new("http://localhost:7700", "masterKey");
 
   let index = client
-    .create_index("test_get_all_tasks", None)
+    .create_index("test_get_tasks", None)
     .await?
     .wait_for_completion(&client, None, None)
     .await?
     .try_make_index(&client)
     .unwrap();
 
-  let tasks = index.get_all_tasks().await?;
+  let tasks = index.get_tasks().await?;
   // The only task is the creation of the index
   assert_eq!(status.len(), 1);
-  
+
   index.delete()
     .await?
     .wait_for_completion(&client, None, None)
@@ -38,7 +38,7 @@ async fn test_get_all_tasks() -> Result<(), Error> {
 I have multiple problems with this test:
 - `let client = Client::new("http://localhost:7700", "masterKey");`: This line is always the same in every test.
   And if you make a typo on the http addr or the master key, you'll have an error.
-- `let index = client.create_index("test_get_all_tasks", None)...`: Each test needs to have an unique name.
+- `let index = client.create_index("test_get_tasks", None)...`: Each test needs to have an unique name.
   This means we currently need to write the name of the test everywhere; it's not practical.
 - There are 11 lines dedicated to the creation and deletion of the index; this is once again something that'll never change
   whatever the test is. But, if you ever forget to delete the index at the end, you'll get in some trouble to re-run
@@ -49,8 +49,8 @@ I have multiple problems with this test:
 With this macro, all these problems are solved. See a rewrite of this test:
 ```rust
 #[meilisearch_test]
-async fn test_get_all_tasks(index: Index, client: Client) -> Result<(), Error> {
-  let tasks = index.get_all_tasks().await?;
+async fn test_get_tasks(index: Index, client: Client) -> Result<(), Error> {
+  let tasks = index.get_tasks().await?;
   // The only task is the creation of the index
   assert_eq!(status.len(), 1);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@
 //! })}
 //! ```
 //!
+//! With the `uid`, you can check the status (`enqueued`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://docs.meilisearch.com/reference/api/tasks.html#get-task).
+//!
 //! ### Basic Search <!-- omit in TOC -->
 //!
 //! ```rust
@@ -168,10 +170,7 @@
 //!
 //! You only need to perform this operation once.
 //!
-//! Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`.
-//! Depending on the size of your dataset, this might take time. You can track the whole process
-//! using the [update
-//! status](https://docs.meilisearch.com/reference/api/updates.html#get-an-update-status).
+//! Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [tasks](https://docs.meilisearch.com/reference/api/tasks.html#get-task)).
 //!
 //! Then, you can perform the search:
 //!


### PR DESCRIPTION
- Remove `update` mention from the README
- rename `update_type` to `task_type`
- Add code samples for v0.25.0 according to https://github.com/meilisearch/documentation/pull/1288/files