### PR TITLE
refactorise the errors

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -663,11 +663,11 @@ mod tests {
         let error = client.delete_key("invalid_key").await.unwrap_err();
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::ApiKeyNotFound,
                 error_type: ErrorType::InvalidRequest,
                 ..
-            }
+            })
         ));
 
         // ==> executing the action without enough right
@@ -681,21 +681,21 @@ mod tests {
         let error = client.delete_key("invalid_key").await.unwrap_err();
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKey,
                 error_type: ErrorType::Auth,
                 ..
-            }
+            })
         ));
         // with a good key
         let error = client.delete_key(&key.key).await.unwrap_err();
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKey,
                 error_type: ErrorType::Auth,
                 ..
-            }
+            })
         ));
 
         // cleanup
@@ -741,7 +741,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::MeilisearchError {
                 error_code: ErrorCode::InvalidApiKeyIndexes,
                 error_type: ErrorType::InvalidRequest,
                 ..
@@ -756,11 +756,11 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKeyExpiresAt,
                 error_type: ErrorType::InvalidRequest,
                 ..
-            }
+            })
         ));
 
         // ==> executing the action without enough right
@@ -776,11 +776,11 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKey,
                 error_type: ErrorType::Auth,
                 ..
-            }
+            })
         ));
 
         // cleanup
@@ -830,7 +830,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::MeilisearchError {
                 error_code: ErrorCode::InvalidApiKeyIndexes,
                 error_type: ErrorType::InvalidRequest,
                 ..
@@ -844,11 +844,11 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKeyExpiresAt,
                 error_type: ErrorType::InvalidRequest,
                 ..
-            }
+            })
         ));
         key.expires_at = None;
 
@@ -864,11 +864,11 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKey,
                 error_type: ErrorType::Auth,
                 ..
-            }
+            })
         ));
 
         // cleanup

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use crate::errors::Error;
+use crate::errors::{Error, MeilisearchError};
 use log::{error, trace, warn};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{from_str, to_string};
@@ -194,8 +194,8 @@ fn parse_response<Output: DeserializeOwned>(
         "Expected response code {}, got {}",
         expected_status_code, status_code
     );
-    match from_str(&body) {
-        Ok(e) => Err(Error::from(&e)),
+    match from_str::<MeilisearchError>(&body) {
+        Ok(e) => Err(Error::from(e)),
         Err(e) => Err(Error::ParseError(e)),
     }
 }


### PR DESCRIPTION
- Merge the two meilisearch error types
- Use Deserialize and Serialize to generate the string associated with every error instead of writing it by hand