### PR TITLE
Refactorise the errors

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -663,11 +663,11 @@ mod tests {
         let error = client.delete_key("invalid_key").await.unwrap_err();
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::ApiKeyNotFound,
                 error_type: ErrorType::InvalidRequest,
                 ..
-            }
+            })
         ));
 
         // ==> executing the action without enough right
@@ -681,21 +681,21 @@ mod tests {
         let error = client.delete_key("invalid_key").await.unwrap_err();
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKey,
                 error_type: ErrorType::Auth,
                 ..
-            }
+            })
         ));
         // with a good key
         let error = client.delete_key(&key.key).await.unwrap_err();
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKey,
                 error_type: ErrorType::Auth,
                 ..
-            }
+            })
         ));
 
         // cleanup
@@ -741,7 +741,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::MeilisearchError {
                 error_code: ErrorCode::InvalidApiKeyIndexes,
                 error_type: ErrorType::InvalidRequest,
                 ..
@@ -756,11 +756,11 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKeyExpiresAt,
                 error_type: ErrorType::InvalidRequest,
                 ..
-            }
+            })
         ));
 
         // ==> executing the action without enough right
@@ -776,11 +776,11 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKey,
                 error_type: ErrorType::Auth,
                 ..
-            }
+            })
         ));
 
         // cleanup
@@ -830,7 +830,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::MeilisearchError {
                 error_code: ErrorCode::InvalidApiKeyIndexes,
                 error_type: ErrorType::InvalidRequest,
                 ..
@@ -844,11 +844,11 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKeyExpiresAt,
                 error_type: ErrorType::InvalidRequest,
                 ..
-            }
+            })
         ));
         key.expires_at = None;
 
@@ -864,11 +864,11 @@ mod tests {
 
         assert!(matches!(
             error,
-            Error::MeiliSearchError {
+            Error::Meilisearch(MeilisearchError {
                 error_code: ErrorCode::InvalidApiKey,
                 error_type: ErrorType::Auth,
                 ..
-            }
+            })
         ));
 
         // cleanup

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use crate::errors::Error;
+use crate::errors::{Error, MeilisearchError};
 use log::{error, trace, warn};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{from_str, to_string};
@@ -194,8 +194,8 @@ fn parse_response<Output: DeserializeOwned>(
         "Expected response code {}, got {}",
         expected_status_code, status_code
     );
-    match from_str(&body) {
-        Ok(e) => Err(Error::from(&e)),
+    match from_str::<MeilisearchError>(&body) {
+        Ok(e) => Err(Error::from(e)),
         Err(e) => Err(Error::ParseError(e)),
     }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,7 +1,9 @@
 use serde::Deserialize;
 use std::time::Duration;
 
-use crate::{client::Client, errors::Error, indexes::Index, settings::Settings};
+use crate::{
+    client::Client, errors::Error, errors::MeilisearchError, indexes::Index, settings::Settings,
+};
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
@@ -41,23 +43,10 @@ pub struct IndexDeletion {
     pub deleted_documents: Option<usize>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TaskError {
-    #[serde(rename = "message")]
-    pub error_message: String,
-    #[serde(rename = "code")]
-    pub error_code: String,
-    #[serde(rename = "type")]
-    pub error_type: String,
-    #[serde(rename = "link")]
-    pub error_link: String,
-}
-
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FailedTask {
-    pub error: TaskError,
+    pub error: MeilisearchError,
     #[serde(flatten)]
     pub task: ProcessedTask,
 }
@@ -203,7 +192,6 @@ impl Task {
     /// // create the client
     /// let client = Client::new("http://localhost:7700", "masterKey");
     ///
-    /// // create a new index called movies
     /// let task = client.create_index("try_make_index", None).await.unwrap();
     /// let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -224,6 +212,117 @@ impl Task {
             } => Ok(client.index(index_uid)),
             _ => Err(self),
         }
+    }
+
+    /// Unwrap the [MeilisearchError] from a [Self::Failed] [Task].
+    ///
+    /// Will panic if the task was not [Self::Failed].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// # let task = client.create_index("unwrap_failure", None).await.unwrap();
+    /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
+    ///
+    ///
+    /// let task = index.set_ranking_rules(["wrong_ranking_rule"])
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// assert!(task.is_failure());
+    ///
+    /// let failure = task.unwrap_failure();
+    ///
+    /// assert_eq!(failure.error_code, ErrorCode::InvalidRankingRule);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub fn unwrap_failure(self) -> MeilisearchError {
+        match self {
+            Self::Failed {
+                content: FailedTask { error, .. },
+            } => error,
+            _ => panic!("Called `unwrap_failure` on a non `Failed` task."),
+        }
+    }
+
+    /// Returns `true` if the [Task] is [Self::Failed].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// # let task = client.create_index("is_failure", None).await.unwrap();
+    /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
+    ///
+    ///
+    /// let task = index.set_ranking_rules(["wrong_ranking_rule"])
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// assert!(task.is_failure());
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    pub fn is_failure(&self) -> bool {
+        matches!(self, Self::Failed { .. })
+    }
+
+    /// Returns `true` if the [Task] is [Self::Succeeded].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let task = client
+    ///   .create_index("is_success", None)
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// assert!(task.is_success());
+    /// # task.try_make_index(&client).unwrap().delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    pub fn is_success(&self) -> bool {
+        matches!(self, Self::Succeeded { .. })
+    }
+
+    /// Returns `true` if the [Task] is pending ([Self::Enqueued] or [Self::Processing]).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let task = client
+    ///   .create_index("is_success", None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// assert!(task.is_pending());
+    /// # task.wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap().delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Enqueued { .. } | Self::Processing { .. })
     }
 }
 
@@ -268,7 +367,11 @@ pub(crate) async fn async_sleep(interval: Duration) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{client::*, document};
+    use crate::{
+        client::*,
+        document,
+        errors::{ErrorCode, ErrorType},
+    };
     use meilisearch_test_macro::meilisearch_test;
     use serde::{Deserialize, Serialize};
     use std::time::{self, Duration};
@@ -469,11 +572,9 @@ mod test {
         let task = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
         let status = client.wait_for_task(task, None, None).await?;
 
-        assert!(matches!(status, Task::Failed { .. }));
-        if let Task::Failed { content: status } = status {
-            assert_eq!(status.error.error_code, "invalid_ranking_rule");
-            assert_eq!(status.error.error_type, "invalid_request");
-        }
+        let error = status.unwrap_failure();
+        assert_eq!(error.error_code, ErrorCode::InvalidRankingRule);
+        assert_eq!(error.error_type, ErrorType::InvalidRequest);
         Ok(())
     }
 }


### PR DESCRIPTION
- Merge the two meilisearch error types
- Use Deserialize and Serialize to generate the string associated with every error instead of writing it by hand