### PR TITLE
Update version for the next release (v0.15.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -449,7 +449,7 @@ search_guide_2: |-
 getting_started_add_documents_md: |-
   ```toml
     [dependencies]
-    meilisearch-sdk = "0.14"
+    meilisearch-sdk = "0.15"
     # futures: because we want to block on futures
     futures = "0.3"
     # serde: required if you are going to use documents

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-sdk"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Mubelotix <mubelotix@gmail.com>"]
 edition = "2018"
 description = "Rust wrapper for the Meilisearch API. Meilisearch is a powerful, fast, open-source, easy to use and deploy search engine."

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.14.0"
+meilisearch-sdk = "0.15.0"
 ```
 
 The following optional dependencies may also be useful:

--- a/README.tpl
+++ b/README.tpl
@@ -50,7 +50,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.14.0"
+meilisearch-sdk = "0.15.0"
 ```
 
 The following optional dependencies may also be useful:


### PR DESCRIPTION
## ⚠️ Breaking changes

* Refactorise the errors, now `error_code` and `error_type` has types instead of `string` (#234) @irevoire
* Put type on timestamp and duration (#237) @irevoire
  * The `time` crate will be needed if you need to manipulate API keys (check for more info https://github.com/meilisearch/meilisearch-rust/issues/226, https://github.com/meilisearch/meilisearch-rust/pull/237#discussion_r806222451, and https://github.com/meilisearch/integration-guides/issues/121#issuecomment-944379531).

## 🚀 Enhancements

* Refactorise the settings (#235) @irevoire

Thanks again to @irevoire! 🎉
