### PR TITLE
use an OffsetDateTime on the ClientStats

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use crate::{
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{collections::HashMap, time::Duration};
+use time::OffsetDateTime;
 
 /// The top-level struct of the SDK, representing a client containing [indexes](../indexes/struct.Index.html).
 #[derive(Debug, Clone)]
@@ -588,7 +589,8 @@ impl Client {
 #[serde(rename_all = "camelCase")]
 pub struct ClientStats {
     pub database_size: usize,
-    pub last_update: Option<String>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub last_update: Option<OffsetDateTime>,
     pub indexes: HashMap<String, IndexStats>,
 }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -329,7 +329,7 @@ impl Task {
     /// # futures::executor::block_on(async move {
     /// # let client = Client::new("http://localhost:7700", "masterKey");
     /// let task = client
-    ///   .create_index("is_success", None)
+    ///   .create_index("is_pending", None)
     ///   .await
     ///   .unwrap();
     ///


### PR DESCRIPTION
# Pull Request

## What does this PR do?
I noticed we were still deserializing the `last_update` in the `ClientStats` structure in an `Option<String>`.
I typed the `String` into an `OffsetDateTime`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

--------

I also found a "bug" in one of our doctest where we were creating an index with a bad name.