### PR TITLE
Add methods to automatically add/update documents in batches

### DIFF
--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -809,20 +809,12 @@ impl Index {
     ///
     /// ```
     /// use serde::{Serialize, Deserialize};
-    /// use meilisearch_sdk::{client::*, document::*};
+    /// use meilisearch_sdk::client::*;
     ///
     /// #[derive(Serialize, Deserialize, Debug)]
     /// struct Movie {
     ///     name: String,
     ///     description: String,
-    /// }
-    ///
-    /// impl Document for Movie {
-    ///     type UIDType = String;
-    ///
-    ///     fn get_uid(&self) -> &Self::UIDType {
-    ///         &self.name
-    ///     }
     /// }
     ///
     /// # futures::executor::block_on(async move {
@@ -855,7 +847,7 @@ impl Index {
     /// None).await.unwrap();
     /// # });
     /// ```
-    pub async fn add_documents_in_batches<T: Document>(
+    pub async fn add_documents_in_batches<T: Serialize>(
         &self,
         documents: &[T],
         batch_size: Option<usize>,
@@ -878,20 +870,12 @@ impl Index {
     ///
     /// ```
     /// use serde::{Serialize, Deserialize};
-    /// use meilisearch_sdk::{client::*, document::*};
+    /// use meilisearch_sdk::client::*;
     ///
     /// #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
     /// struct Movie {
     ///     name: String,
     ///     description: String,
-    /// }
-    ///
-    /// impl Document for Movie {
-    ///     type UIDType = String;
-    ///
-    ///     fn get_uid(&self) -> &Self::UIDType {
-    ///         &self.name
-    ///     }
     /// }
     ///
     /// # futures::executor::block_on(async move {
@@ -949,7 +933,7 @@ impl Index {
     /// None).await.unwrap();
     /// # });
     /// ```
-    pub async fn update_documents_in_batches<T: Document>(
+    pub async fn update_documents_in_batches<T: Serialize>(
         &self,
         documents: &[T],
         batch_size: Option<usize>,

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1008,7 +1008,4 @@ mod tests {
         }
         Ok(())
     }
-
-    #[meilisearch_test]
-    async fn test_add_documents_in_batches() {}
 }


### PR DESCRIPTION
Fix to issue #183

# Pull Request

## What does this PR do?
Fixes #183 
https://github.com/meilisearch/meilisearch-rust/issues/183
It adds two methods, `Index::add_documents_in_batches` and `Index::update_documents_in_batches` 
Takes inspiration from the python version of the implementation. 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
