### PR TITLE
Add missing IndexUpdate task type

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -15,6 +15,7 @@ pub enum TaskType {
     DocumentPartial { details: Option<DocumentAddition> },
     DocumentDeletion { details: Option<DocumentDeletion> },
     IndexCreation { details: Option<IndexCreation> },
+    IndexUpdate { details: Option<IndexUpdate> },
     IndexDeletion { details: Option<IndexDeletion> },
     SettingsUpdate { details: Option<Settings> },
 }
@@ -35,6 +36,12 @@ pub struct DocumentDeletion {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexCreation {
+    pub primary_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexUpdate {
     pub primary_key: Option<String>,
 }
 


### PR DESCRIPTION
As per the [specifications](https://github.com/meilisearch/specifications/blob/aa2a262ce4116666b65bfa2479b76a05268fc635/text/0060-tasks-api.md#3-type-field-enum) `IndexUpdate` is a possible task type that was missing. 