### PR TITLE
Fix get document doc tests using the wrong index name

### DIFF
--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -213,7 +213,7 @@ impl Index {
     ///
     /// # futures::executor::block_on(async move {
     /// let client = Client::new("http://localhost:7700", "masterKey");
-    /// let movies = client.index("get_documents");
+    /// let movies = client.index("get_document");
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
     /// // retrieve a document (you have to put the document in the index before)


### PR DESCRIPTION
Because `get_documents` and `get_document` used the same `index_name` in their example, I stumbled into a concurrency issue where one deleted the index before the assertions of the second. 

To avoid that every doc-tests uses its own index name. Which was the problem here.

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Meilisearch(MeilisearchError { error_message: "Index `get_documents` not found.", error_code: IndexNotFound, error_type: InvalidRequest, error_link: "https://docs.meilisearch.com/errors#index_not_found" })', src/indexes.rs:23:73
```