### PR TITLE
Client without api key240

### DIFF
--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -5,7 +5,8 @@ use meilisearch_sdk::settings::Settings;
 // we need an async runtime
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let client: Client = Client::new("http://localhost:7700", "masterKey");
+    let api_key = Option::Some(String::from("masterKey"));
+    let client: Client = Client::new("http://localhost:7700", api_key);
 
     // We try to create an index called `movies` with a primary_key of `movie_id`.
     let my_index: Index = client

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -17,7 +17,7 @@ use crate::document::{display, Crate};
 lazy_static! {
     static ref CLIENT: Client = Client::new(
         "https://finding-demos.meilisearch.com",
-        "2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3",
+        Option::Some(String::from("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3")),
     );
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ use time::OffsetDateTime;
 #[derive(Debug, Clone)]
 pub struct Client {
     pub(crate) host: Rc<String>,
-    pub(crate) api_key: Rc<String>,
+    pub(crate) api_key: Rc<Option<String>>,
 }
 
 impl Client {
@@ -30,7 +30,7 @@ impl Client {
     /// // create the client
     /// let client = Client::new("http://localhost:7700", "masterKey");
     /// ```
-    pub fn new(host: impl Into<String>, api_key: impl Into<String>) -> Client {
+    pub fn new(host: impl Into<String>, api_key: impl Into<Option<String>>) -> Client {
         Client {
             host: Rc::new(host.into()),
             api_key: Rc::new(api_key.into()),
@@ -589,7 +589,12 @@ impl Client {
     /// let client = client::Client::new("http://localhost:7700", token);
     /// # });
     /// ```
-    pub fn generate_tenant_token(&self, search_rules: serde_json::Value, api_key: Option<&str>, expires_at: Option<OffsetDateTime>) -> Result<String, Error> {
+    pub fn generate_tenant_token(
+        &self,
+        search_rules: serde_json::Value,
+        api_key: Option<&str>,
+        expires_at: Option<OffsetDateTime>,
+    ) -> Result<String, Error> {
         let api_key = api_key.unwrap_or(&self.api_key);
 
         crate::tenant_tokens::generate_tenant_token(search_rules, api_key, expires_at)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,7 +24,7 @@ pub enum Error {
     TenantTokensInvalidApiKey,
     /// It is not possible to generate an already expired tenant token.
     TenantTokensExpiredSignature,
-    
+
     /// When jsonwebtoken cannot generate the token successfully.
     InvalidTenantToken(jsonwebtoken::errors::Error),
 

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -33,7 +33,8 @@ impl JsonIndex {
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", "masterKey");
+/// let api_key = Option::Some(String::from("masterKey"));
+/// let client = Client::new("http://localhost:7700", api_key);
 ///
 /// // get the index called movies or create it if it does not exist
 /// let movies = client
@@ -96,7 +97,8 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// # let index = client.create_index("delete", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "movies" and delete it
@@ -131,7 +133,8 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movies = client.index("execute_query");
     ///
     /// // add some documents
@@ -172,7 +175,8 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let mut movies = client.index("search");
     ///
     /// // add some documents
@@ -212,7 +216,8 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movies = client.index("get_document");
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
@@ -262,7 +267,8 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movie_index = client.index("get_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -322,7 +328,8 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movie_index = client.index("add_or_replace");
     ///
     /// let task = movie_index.add_or_replace(&[
@@ -395,7 +402,8 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+     /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movie_index = client.index("add_or_update");
     ///
     /// let task = movie_index.add_or_update(&[
@@ -457,7 +465,8 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movie_index = client.index("delete_all_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -501,7 +510,8 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let mut movies = client.index("delete_document");
     ///
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -546,7 +556,8 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movies = client.index("delete_documents");
     ///
     /// // add some documents
@@ -592,7 +603,8 @@ impl Index {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// # let index = client.create_index("fetch_info", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the information of the index named "fetch_info"
@@ -620,7 +632,8 @@ impl Index {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// # let index = client.create_index("get_primary_key", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the primary key of the index named "movies"
@@ -651,7 +664,8 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movies = client.index("get_task");
     ///
     /// let task = movies.add_documents(&[
@@ -697,7 +711,8 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let status = index.get_tasks().await.unwrap();
@@ -734,7 +749,8 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// # let index = client.create_index("get_stats", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let stats = index.get_stats().await.unwrap();
@@ -818,7 +834,8 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movie_index = client.index("add_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[
@@ -879,7 +896,8 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let movie_index = client.index("update_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[

--- a/src/key.rs
+++ b/src/key.rs
@@ -44,7 +44,8 @@ impl AsRef<Key> for Key {
 /// ```
 /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", "masterKey");
+/// let api_key = Option::Some(String::from("masterKey"));
+/// let client = Client::new("http://localhost:7700", api_key);
 ///
 /// let key = KeyBuilder::new("My little lovely test key")
 ///   .with_action(Action::DocumentsAdd)
@@ -168,7 +169,8 @@ impl KeyBuilder {
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder, client::Client};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let key = KeyBuilder::new("My little lovely test key")
     ///   .create(&client).await.unwrap();
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,8 @@
 //!
 //! fn main() { block_on(async move {
 //!     // Create a client (without sending any request so that can't fail)
-//!     let client = Client::new("http://localhost:7700", "masterKey");
+//!     let api_key = Option::Some(String::from("masterKey"));
+//!     let client = Client::new("http://localhost:7700", api_key);
 //!
 //! #    let index = client.create_index("movies", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //!     // An index is where the documents are stored.
@@ -51,7 +52,8 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", "masterKey");
+//!      let api_key = Option::Some(String::from("masterKey"));
+//!      let client = Client::new("http://localhost:7700", api_key);
 //! #    let movies = client.create_index("movies_2", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! // Meilisearch is typo-tolerant:
 //! println!("{:?}", client.index("movies_2").search().with_query("caorl").execute::<Movie>().await.unwrap().hits);
@@ -92,7 +94,8 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", "masterKey");
+//!      let api_key = Option::Some(String::from("masterKey"));
+//!      let client = Client::new("http://localhost:7700", api_key);
 //! #    let movies = client.create_index("movies_3", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let search_result = client.index("movies_3")
 //!   .search()
@@ -137,7 +140,8 @@
 //! # use serde::{Serialize, Deserialize};
 //! # use futures::executor::block_on;
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", "masterKey");
+//!      let api_key = Option::Some(String::from("masterKey"));
+//!      let client = Client::new("http://localhost:7700", api_key);
 //! #    let movies = client.create_index("movies_4", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let filterable_attributes = [
 //!     "id",
@@ -165,7 +169,8 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! # let client = Client::new("http://localhost:7700", "masterKey");
+//! # let api_key = Option::Some(String::from("masterkey")); 
+//! # let client = Client::new("http://localhost:7700", api_key);
 //! # let movies = client.create_index("movies_5", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! # let filterable_attributes = [
 //! #     "id",

--- a/src/request.rs
+++ b/src/request.rs
@@ -132,7 +132,7 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
 #[cfg(target_arch = "wasm32")]
 pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static>(
     url: &str,
-    apikey: &str,
+    apikey: &Option<String>,
     method: Method<Input>,
     expected_status_code: u16,
 ) -> Result<Output, Error> {
@@ -146,7 +146,10 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
     // The 2 following unwraps should not be able to fail
 
     let headers = Headers::new().unwrap();
-    headers.append("Authorization: Bearer", apikey).unwrap();
+
+    if let Some(key) = apikey {
+        headers.append("Authorization: Bearer", key).unwrap();
+    }
 
     let mut request: RequestInit = RequestInit::new();
     request.headers(&headers);

--- a/src/request.rs
+++ b/src/request.rs
@@ -15,58 +15,105 @@ pub(crate) enum Method<T: Serialize> {
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static>(
     url: &str,
-    apikey: &str,
+    apikey: &Option<String>,
     method: Method<Input>,
     expected_status_code: u16,
 ) -> Result<Output, Error> {
     use isahc::http::header;
     use isahc::*;
 
-    let auth = format!("Bearer {}", apikey);
-
     let mut response = match &method {
         Method::Get => {
-            Request::get(url)
-                .header(header::AUTHORIZATION, auth)
-                .body(())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+            if let Some(key) = apikey {
+                let auth = format!("Bearer {}", key);
+                Request::get(url)
+                    .header(header::AUTHORIZATION, auth)
+                    .body(())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            } else {
+                Request::get(url)
+                    .body(())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            }
         }
+
         Method::Delete => {
-            Request::delete(url)
-                .header(header::AUTHORIZATION, auth)
-                .body(())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+            if let Some(key) = apikey {
+                let auth = format!("Bearer {}", key);
+                Request::delete(url)
+                    .header(header::AUTHORIZATION, auth)
+                    .body(())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            } else {
+                Request::delete(url)
+                    .body(())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            }
         }
         Method::Post(body) => {
-            Request::post(url)
-                .header(header::AUTHORIZATION, auth)
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(to_string(&body).unwrap())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+            if let Some(key) = apikey {
+                let auth = format!("Bearer {}", key);
+                Request::post(url)
+                    .header(header::AUTHORIZATION, auth)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            } else {
+                Request::post(url)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            }
         }
         Method::Patch(body) => {
-            Request::patch(url)
-                .header(header::AUTHORIZATION, auth)
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(to_string(&body).unwrap())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+            if let Some(key) = apikey {
+                let auth = format!("Bearer {}", key);
+                Request::patch(url)
+                    .header(header::AUTHORIZATION, auth)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            } else {
+                Request::patch(url)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            }
         }
         Method::Put(body) => {
-            Request::put(url)
-                .header(header::AUTHORIZATION, auth)
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(to_string(&body).unwrap())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+            if let Some(key) = apikey {
+                let auth = format!("Bearer {}", key);
+                Request::put(url)
+                    .header(header::AUTHORIZATION, auth)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            } else {
+                Request::put(url)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            }
         }
     };
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -283,7 +283,7 @@ mod tests {
     use crate::{client::*, search::*};
     use meilisearch_test_macro::meilisearch_test;
     use serde::{Deserialize, Serialize};
-    use serde_json::{Map, Value, json};
+    use serde_json::{json, Map, Value};
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Document {
@@ -573,15 +573,20 @@ mod tests {
     }
 
     #[meilisearch_test]
-    async fn test_generate_tenant_token_from_client(client: Client, index: Index) -> Result<(), Error> {
-        use crate::key::{KeyBuilder, Action};
+    async fn test_generate_tenant_token_from_client(
+        client: Client,
+        index: Index,
+    ) -> Result<(), Error> {
+        use crate::key::{Action, KeyBuilder};
 
         setup_test_index(&client, &index).await?;
 
         let key = KeyBuilder::new("key for generate_tenant_token test")
             .with_action(Action::All)
             .with_index("*")
-            .create(&client).await.unwrap();
+            .create(&client)
+            .await
+            .unwrap();
         let allowed_client = Client::new("http://localhost:7700", key.key);
 
         let search_rules = vec![
@@ -593,10 +598,13 @@ mod tests {
         ];
 
         for rules in search_rules {
-            let token = allowed_client.generate_tenant_token(rules, None, None).expect("Cannot generate tenant token.");
+            let token = allowed_client
+                .generate_tenant_token(rules, None, None)
+                .expect("Cannot generate tenant token.");
             let new_client = Client::new("http://localhost:7700", token);
 
-            let result: SearchResults<Document> = new_client.index(index.uid.to_string())
+            let result: SearchResults<Document> = new_client
+                .index(index.uid.to_string())
                 .search()
                 .execute()
                 .await?;

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -168,7 +168,8 @@ impl Task {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// # let api_key = Option::Some(String::from("masterKey"));
+    /// # let client = Client::new("http://localhost:7700", api_key);
     /// let movies = client.index("movies_wait_for_completion");
     ///
     /// let status = movies.add_documents(&[
@@ -205,7 +206,8 @@ impl Task {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// # let api_key = Option::Some(String::from("masterKey"));
+    /// # let client = Client::new("http://localhost:7700", api_key);
     ///
     /// let task = client.create_index("try_make_index", None).await.unwrap();
     /// let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
@@ -239,7 +241,8 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// # let api_key = Option::Some(String::from("masterKey"));
+    /// # let client = Client::new("http://localhost:7700", api_key);
     /// # let task = client.create_index("unwrap_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -276,7 +279,8 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// # let api_key = Option::Some(String::from("masterKey"));
+    /// # let client = Client::new("http://localhost:7700", api_key);   
     /// # let task = client.create_index("is_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -303,7 +307,8 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let api_key = Option::Some(String::from("masterKey"));
+    /// let client = Client::new("http://localhost:7700", api_key);
     /// let task = client
     ///   .create_index("is_success", None)
     ///   .await

--- a/src/tenant_tokens.rs
+++ b/src/tenant_tokens.rs
@@ -1,13 +1,11 @@
-use crate::{
-    errors::* 
-};
-use serde::{Serialize, Deserialize};
-use jsonwebtoken::{encode, Header, EncodingKey};
-use time::{OffsetDateTime};
+use crate::errors::*;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use time::OffsetDateTime;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")] 
+#[serde(rename_all = "camelCase")]
 struct TenantTokenClaim {
     api_key_prefix: String,
     search_rules: Value,
@@ -15,20 +13,24 @@ struct TenantTokenClaim {
     exp: Option<OffsetDateTime>,
 }
 
-pub fn generate_tenant_token(search_rules: Value, api_key: impl AsRef<str>, expires_at: Option<OffsetDateTime>) -> Result<String, Error> {
+pub fn generate_tenant_token(
+    search_rules: Value,
+    api_key: impl AsRef<str>,
+    expires_at: Option<OffsetDateTime>,
+) -> Result<String, Error> {
     if api_key.as_ref().chars().count() < 8 {
-        return Err(Error::TenantTokensInvalidApiKey)
+        return Err(Error::TenantTokensInvalidApiKey);
     }
 
     if expires_at.map_or(false, |expires_at| OffsetDateTime::now_utc() > expires_at) {
-        return Err(Error::TenantTokensExpiredSignature)
+        return Err(Error::TenantTokensExpiredSignature);
     }
 
     let key_prefix = api_key.as_ref().chars().take(8).collect();
     let claims = TenantTokenClaim {
         api_key_prefix: key_prefix,
         exp: expires_at,
-        search_rules
+        search_rules,
     };
 
     let token = encode(
@@ -42,9 +44,9 @@ pub fn generate_tenant_token(search_rules: Value, api_key: impl AsRef<str>, expi
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
     use crate::tenant_tokens::*;
-    use jsonwebtoken::{decode, DecodingKey, Validation, Algorithm};
+    use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+    use serde_json::json;
     use std::collections::HashSet;
 
     const SEARCH_RULES: [&str; 1] = ["*"];
@@ -63,10 +65,14 @@ mod tests {
         let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, None).unwrap();
 
         let valid_key = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(VALID_KEY.as_ref()), &build_validation()
+            &token,
+            &DecodingKey::from_secret(VALID_KEY.as_ref()),
+            &build_validation(),
         );
         let invalid_key = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret("not-the-same-key".as_ref()), &build_validation()
+            &token,
+            &DecodingKey::from_secret("not-the-same-key".as_ref()),
+            &build_validation(),
         );
 
         assert!(valid_key.is_ok());
@@ -87,7 +93,9 @@ mod tests {
         let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, Some(exp)).unwrap();
 
         let decoded = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(VALID_KEY.as_ref()), &Validation::new(Algorithm::HS256)
+            &token,
+            &DecodingKey::from_secret(VALID_KEY.as_ref()),
+            &Validation::new(Algorithm::HS256),
         );
 
         assert!(decoded.is_ok());
@@ -106,8 +114,11 @@ mod tests {
         let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, None).unwrap();
 
         let decoded = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(VALID_KEY.as_ref()), &build_validation()
-        ).expect("Cannot decode the token");
+            &token,
+            &DecodingKey::from_secret(VALID_KEY.as_ref()),
+            &build_validation(),
+        )
+        .expect("Cannot decode the token");
 
         assert_eq!(decoded.claims.api_key_prefix, &VALID_KEY[..8]);
         assert_eq!(decoded.claims.search_rules, json!(SEARCH_RULES));
@@ -119,8 +130,11 @@ mod tests {
         let token = generate_tenant_token(json!(SEARCH_RULES), key, None).unwrap();
 
         let decoded = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(key.as_ref()), &build_validation()
-        ).expect("Cannot decode the token");
+            &token,
+            &DecodingKey::from_secret(key.as_ref()),
+            &build_validation(),
+        )
+        .expect("Cannot decode the token");
 
         assert_eq!(decoded.claims.api_key_prefix, "Ëa1ทt9bV");
     }


### PR DESCRIPTION
# Pull Request
## What does this PR do?
This pull request changes the type of the ```api_key``` field in the ```Client``` struct to **take an** ```Option<String>``` **instead of** a ```String```.
Fixes #240
[Issue](https://github.com/meilisearch/meilisearch-rust/issues/240)

Current issues with the changes:
I am running into this bug. I'm not sure where to make the change or what change to make.

```
error[E0277]: the trait bound `std::option::Option<std::string::String>: From<&str>` is not satisfied
   --> src/search.rs:476:5
    |
476 |     #[meilisearch_test]
    |     ^^^^^^^^^^^^^^^^^^^ the trait `From<&str>` is not implemented for `std::option::Option<std::string::String>`
    |
    = help: the following implementations were found:
              <std::option::Option<&'a T> as From<&'a std::option::Option<T>>>
              <std::option::Option<&'a mut T> as From<&'a mut std::option::Option<T>>>
              <std::option::Option<&'a tracing_core::span::Id> as From<&'a tracing::span::EnteredSpan>>
              <std::option::Option<&'a tracing_core::span::Id> as From<&'a tracing::span::Span>>
            and 10 others
    = note: required because of the requirements on the impl of `Into<std::option::Option<std::string::String>>` for `&str`
note: required by a bound in `client::Client::new`
```
## Notes
- I used ```cargo fmt```, so some of the changes are just formatting. 
- A lot of changes are to the commented code examples
