### PR TITLE
Improve the test-macro

### DIFF
--- a/meilisearch-test-macro/src/lib.rs
+++ b/meilisearch-test-macro/src/lib.rs
@@ -89,9 +89,12 @@ pub fn meilisearch_test(params: TokenStream, input: TokenStream) -> TokenStream 
 
         // Now we do the same for the index name
         if use_name {
-            let name = &outer_fn.sig.ident;
+            let fn_name = &outer_fn.sig.ident;
+            // the name we're going to return is the complete path to the function ie something like that;
+            // `indexes::tests::test_fetch_info` but since the `::` are not allowed by meilisearch as an index
+            // name we're going to rename that to `indexes-tests-test_fetch_info`.
             outer_block.push(parse_quote!(
-                let name = stringify!(#name).to_string();
+                let name = format!("{}::{}", std::module_path!(), stringify!(#fn_name)).replace("::", "-");
             ));
         }
 


### PR DESCRIPTION
Before this PR, the test macro was using the name of the function as the name of the index.
That caused a bug in our test suite because, at some point, we had two tests with the same name;
```
test indexes::tests::test_fetch_info ... ok
test client::tests::test_fetch_info ... ok
```
Now, this PR uses the whole path of the test instead of only the name of the function, but since
meilisearch doesn't allow `:` in the index name, it then proceeds to replace all the `::` with one
`-`. Thus for the previous examples the generated index name would be
```
indexes-tests-test_fetch_info
client-tests-test_fetch_info
```
That seems like a good solution since rust forbids having two functions with the same name in the
same module, and it's still easily readable in case we need to debug something in meilisearch from
the index name.
