### PR TITLE
Remove the wasm lib.rs from the manifest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,11 @@ jobs:
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
     # Will still run for each push to bump-meilisearch-v*
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    name: Cargo check
+    uses: actions-rs/cargo@v1
+    with:
+      command: check
+      args: --workspace --all-targets --all
     name: integration-tests
     runs-on: ubuntu-latest
     steps:
@@ -55,4 +60,4 @@ jobs:
     - name: Build
       run:  |
         rustup target add wasm32-unknown-unknown
-        cargo check --example web_app --target wasm32-unknown-unknown --features=sync
+        cargo check -p web_app --target wasm32-unknown-unknown --features=sync

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,13 +17,8 @@ jobs:
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
     # Will still run for each push to bump-meilisearch-v*
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
-    name: Cargo check
-    uses: actions-rs/cargo@v1
-    with:
-      command: check
-      args: --workspace --all-targets --all
-    name: integration-tests
     runs-on: ubuntu-latest
+    name: integration-tests
     steps:
     - uses: actions/checkout@v2
     - name: Build
@@ -32,6 +27,11 @@ jobs:
       run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics --master-key=masterKey
     - name: Run tests
       run: cargo test --verbose
+    - name: Cargo check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --workspace --all-targets --all
 
   linter:
     name: clippy-check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT"
 readme  = "README.md"
 repository = "https://github.com/meilisearch/meilisearch-sdk"
 
+[workspace]
+members = ["examples/*"]
+
 [dependencies]
 async-trait = "0.1.51"
 iso8601-duration = "0.1.0"
@@ -46,9 +49,3 @@ yew = "0.18"
 lazy_static = "1.4"
 web-sys = "0.3"
 console_error_panic_hook = "0.1"
-
-[[example]]
-name = "web_app"
-crate-type = ["cdylib", "rlib"]
-required-features = ["sync"]
-path = "examples/web_app/src/lib.rs"

--- a/examples/cli-app/src/main.rs
+++ b/examples/cli-app/src/main.rs
@@ -1,9 +1,9 @@
 use futures::executor::block_on;
 use lazy_static::lazy_static;
-use meilisearch_sdk::{client::*,settings::Settings};
+use meilisearch_sdk::{client::*, settings::Settings};
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::io::{stdin};
+use std::io::stdin;
 
 // instantiate the client. load it once
 lazy_static! {
@@ -63,7 +63,7 @@ async fn search(query: &str) {
 async fn build_index() {
     // reading and parsing the file
     let content = include_str!("../assets/clothes.json");
-    
+
     // serialize the string to clothes objects
     let clothes: Vec<Clothes> = serde_json::from_str(content).unwrap();
 
@@ -78,15 +78,9 @@ async fn build_index() {
 
     // create the synonyms hashmap
     let mut synonyms = std::collections::HashMap::new();
-    synonyms.insert(
-        "sweater",
-        vec!["cardigan", "long-sleeve"],
-    );
+    synonyms.insert("sweater", vec!["cardigan", "long-sleeve"]);
     synonyms.insert("sweat pants", vec!["joggers", "gym pants"]);
-    synonyms.insert(
-        "t-shirt",
-        vec!["tees", "tshirt"],
-    );
+    synonyms.insert("t-shirt", vec!["tees", "tshirt"]);
 
     //create the settings struct
     let settings = Settings::new()
@@ -121,7 +115,7 @@ async fn build_index() {
         .wait_for_completion(&CLIENT, None, None)
         .await
         .unwrap();
-    
+
     if result.is_failure() {
         panic!(
             "Encountered an error while sending the documents: {:?}",


### PR DESCRIPTION
Having a link to the web_app `lib.rs` in the examples was making
it try to compile as a dev dependencies which is a constraint we
don’t want.
I removed it and instead included ALL the examples in our workspace
which means we’re now using THEIR cargo.toml instead of ours and
meilisearch-rust is compiled as a normal dependency for these examples.
I also added a `cargo check` for all the examples / tests / code in the
repo. This should execute faster than the test and thus throw errors faster.

This should unlock #254
