### PR TITLE
Client Without Api Key issue

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -397,7 +397,7 @@ add_movies_json_1: |-
   use futures::executor::block_on;
 
   fn main() { block_on(async move {
-    let client = Client::new("http://localhost:7700", "masterKey");
+    let client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // reading and parsing the file
     let mut file = File::open("movies.json").unwrap();
@@ -496,7 +496,7 @@ getting_started_add_documents_md: |-
   use futures::executor::block_on;
 
   fn main() { block_on(async move {
-    let client = Client::new("http://localhost:7700", "masterKey");
+    let client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // reading and parsing the file
     let mut file = File::open("movies.json").unwrap();
@@ -578,7 +578,7 @@ getting_started_update_displayedAttributes: |-
 
   client.index("movies").set_displayed_attributes(&displayed_attributes).await.unwrap();
 getting_started_communicating_with_a_protected_instance: |-
-  let client = Client::new("http://localhost:7700", "apiKey");
+  let client = Client::new("http://localhost:7700", Some("apiKey"));
   client.index("movies").search()
 getting_started_add_meteorites: |-
   use serde::{Serialize, Deserialize};
@@ -774,32 +774,32 @@ delete_a_key_1: |-
   let key = client.get_key("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4").await.unwrap();
   client.delete_key(&key);
 authorization_header_1:
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let keys = client.get_keys().await.unwrap();
 security_guide_search_key_1: |-
-  let client = Client::new("http://localhost:7700", "apiKey");
+  let client = Client::new("http://localhost:7700", Some("apiKey"));
   let result = client.index("patient_medical_records").search().execute().await.unwrap();
 security_guide_update_key_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let key = client.get_key("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4").await.unwrap();
   key.indexes = vec!["doctors".to_string()];
   let updated_key = client.update_key(&key);
 security_guide_create_key_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let mut key_options = KeyBuilder::new("Search patient records key");
   key_options.with_action(Action::Search)
       .with_expires_at(time::macros::datetime!(2023 - 01 - 01 00:00:00 UTC))
       .with_index("patient_medical_records");
   let new_key = client.create_key(key_options).await.unwrap();
 security_guide_list_keys_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let keys = client.get_keys().await.unwrap();
 security_guide_delete_key_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let key = client.get_key("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4").await.unwrap();
   client.delete_key(&key);
 landing_getting_started_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
 
   #[derive(Serialize, Deserialize)]
   struct Movie {
@@ -822,7 +822,7 @@ tenant_token_guide_generate_sdk_1: |-
 
   let token = client.generate_tenant_token(search_rules, api_key, expires_at).unwrap();
 tenant_token_guide_search_sdk_1: |-
-  let front_end_client = Client::new("http://127.0.0.1:7700", token);
+  let front_end_client = Client::new("http://127.0.0.1:7700", Some(token));
   let results: SearchResults<Patient> = front_end_client.index("patient_medical_records")
     .search()
     .with_query("blood test")

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ struct Movie {
 
 fn main() { block_on(async move {
     // Create a client (without sending any request so that can't fail)
-    let client = Client::new("http://localhost:7700", Some("masterKey"));
+    let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 
     // An index is where the documents are stored.
     let movies = client.index("movies");

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ struct Movie {
 
 fn main() { block_on(async move {
     // Create a client (without sending any request so that can't fail)
-    let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 
     // An index is where the documents are stored.
     let movies = client.index("movies");

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ struct Movie {
 
 fn main() { block_on(async move {
     // Create a client (without sending any request so that can't fail)
-    let client = Client::new("http://localhost:7700", some("masterKey"));
+    let client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // An index is where the documents are stored.
     let movies = client.index("movies");

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ struct Movie {
 
 fn main() { block_on(async move {
     // Create a client (without sending any request so that can't fail)
-    let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    let client = Client::new("http://localhost:7700", some("masterKey"));
 
     // An index is where the documents are stored.
     let movies = client.index("movies");

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ struct Movie {
 
 fn main() { block_on(async move {
     // Create a client (without sending any request so that can't fail)
-    let client = Client::new("http://localhost:7700", "masterKey");
+    let client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // An index is where the documents are stored.
     let movies = client.index("movies");

--- a/examples/cli-app/src/main.rs
+++ b/examples/cli-app/src/main.rs
@@ -7,7 +7,7 @@ use std::io::stdin;
 
 // instantiate the client. load it once
 lazy_static! {
-    static ref CLIENT: Client = Client::new("http://localhost:7700", Some("masterKey"));
+    static ref CLIENT: Client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 }
 
 fn main() {

--- a/examples/cli-app/src/main.rs
+++ b/examples/cli-app/src/main.rs
@@ -7,7 +7,7 @@ use std::io::stdin;
 
 // instantiate the client. load it once
 lazy_static! {
-    static ref CLIENT: Client = Client::new("http://localhost:7700", "masterKey");
+    static ref CLIENT: Client = Client::new("http://localhost:7700", Some("masterKey"));
 }
 
 fn main() {

--- a/examples/cli-app/src/main.rs
+++ b/examples/cli-app/src/main.rs
@@ -7,7 +7,7 @@ use std::io::stdin;
 
 // instantiate the client. load it once
 lazy_static! {
-    static ref CLIENT: Client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    static ref CLIENT: Client = Client::new("http://localhost:7700", Some("masterKey"));
 }
 
 fn main() {

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -5,7 +5,7 @@ use meilisearch_sdk::settings::Settings;
 // we need an async runtime
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let client: Client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    let client: Client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // We try to create an index called `movies` with a primary_key of `movie_id`.
     let my_index: Index = client

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -5,7 +5,7 @@ use meilisearch_sdk::settings::Settings;
 // we need an async runtime
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let client: Client = Client::new("http://localhost:7700", Some("masterKey"));
+    let client: Client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 
     // We try to create an index called `movies` with a primary_key of `movie_id`.
     let my_index: Index = client

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -5,7 +5,7 @@ use meilisearch_sdk::settings::Settings;
 // we need an async runtime
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let client: Client = Client::new("http://localhost:7700", "masterKey");
+    let client: Client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // We try to create an index called `movies` with a primary_key of `movie_id`.
     let my_index: Index = client

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -17,7 +17,7 @@ use crate::document::{display, Crate};
 lazy_static! {
     static ref CLIENT: Client = Client::new(
         "https://finding-demos.meilisearch.com",
-        Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3"),
+        Some(String::from("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3")),
     );
 }
 

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -18,7 +18,7 @@ lazy_static! {
     static ref CLIENT: Client = Client::new(
         "https://finding-demos.meilisearch.com",
         Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3")),
-    );
+    ;
 }
 
 struct Model {

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -17,8 +17,8 @@ use crate::document::{display, Crate};
 lazy_static! {
     static ref CLIENT: Client = Client::new(
         "https://finding-demos.meilisearch.com",
-        Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3"))
-    ;
+        Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3")
+    );
 }
 
 struct Model {

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -17,7 +17,7 @@ use crate::document::{display, Crate};
 lazy_static! {
     static ref CLIENT: Client = Client::new(
         "https://finding-demos.meilisearch.com",
-        "2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3",
+        Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3"),
     );
 }
 

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -17,7 +17,7 @@ use crate::document::{display, Crate};
 lazy_static! {
     static ref CLIENT: Client = Client::new(
         "https://finding-demos.meilisearch.com",
-        Some(String::from("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3")),
+        Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3".to_string()),
     );
 }
 

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -17,7 +17,7 @@ use crate::document::{display, Crate};
 lazy_static! {
     static ref CLIENT: Client = Client::new(
         "https://finding-demos.meilisearch.com",
-        Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3".to_string()),
+        Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3")),
     );
 }
 

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -17,7 +17,7 @@ use crate::document::{display, Crate};
 lazy_static! {
     static ref CLIENT: Client = Client::new(
         "https://finding-demos.meilisearch.com",
-        Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3")),
+        Some("2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3"))
     ;
 }
 

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -13,7 +13,7 @@ Before explaining its usage, we're going to see a simple test *before* this macr
 ```rust
 #[async_test]
 async fn test_get_tasks() -> Result<(), Error> {
-  let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+  let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 
   let index = client
     .create_index("test_get_tasks", None)
@@ -36,7 +36,7 @@ async fn test_get_tasks() -> Result<(), Error> {
 ```
 
 I have multiple problems with this test:
-- `let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));`: This line is always the same in every test.
+- `let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));`: This line is always the same in every test.
   And if you make a typo on the http addr or the master key, you'll have an error.
 - `let index = client.create_index("test_get_tasks", None)...`: Each test needs to have an unique name.
   This means we currently need to write the name of the test everywhere; it's not practical.
@@ -61,7 +61,7 @@ the test, the macro automatically did the same thing we've seen before.
 There are a few rules, though:
 1. The macro only handles three types of arguments:
   - `String`: It returns the name of the test.
-  - `Client`: It creates a client like that: `Client::new("http://localhost:7700", Some(String::from("masterKey")))`.
+  - `Client`: It creates a client like that: `Client::new("http://localhost:7700", Some("masterKey".to_string()))`.
   - `Index`: It creates and deletes an index, as we've seen before.
 2. You only get what you asked for. That means if you don't ask for an index, no index will be created in meilisearch.
   So, if you are testing the creation of indexes, you can ask for a `Client` and a `String` and then create it yourself.

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -36,7 +36,7 @@ async fn test_get_tasks() -> Result<(), Error> {
 ```
 
 I have multiple problems with this test:
-- `let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));`: This line is always the same in every test.
+- `let client = Client::new("http://localhost:7700", Some("masterKey"));`: This line is always the same in every test.
   And if you make a typo on the http addr or the master key, you'll have an error.
 - `let index = client.create_index("test_get_tasks", None)...`: Each test needs to have an unique name.
   This means we currently need to write the name of the test everywhere; it's not practical.

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -13,7 +13,7 @@ Before explaining its usage, we're going to see a simple test *before* this macr
 ```rust
 #[async_test]
 async fn test_get_tasks() -> Result<(), Error> {
-  let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
 
   let index = client
     .create_index("test_get_tasks", None)

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -61,7 +61,7 @@ the test, the macro automatically did the same thing we've seen before.
 There are a few rules, though:
 1. The macro only handles three types of arguments:
   - `String`: It returns the name of the test.
-  - `Client`: It creates a client like that: `Client::new("http://localhost:7700", Some("masterKey".to_string()))`.
+  - `Client`: It creates a client like that: `Client::new("http://localhost:7700", some("masterKey"))`.
   - `Index`: It creates and deletes an index, as we've seen before.
 2. You only get what you asked for. That means if you don't ask for an index, no index will be created in meilisearch.
   So, if you are testing the creation of indexes, you can ask for a `Client` and a `String` and then create it yourself.

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -13,7 +13,7 @@ Before explaining its usage, we're going to see a simple test *before* this macr
 ```rust
 #[async_test]
 async fn test_get_tasks() -> Result<(), Error> {
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 
   let index = client
     .create_index("test_get_tasks", None)
@@ -36,7 +36,7 @@ async fn test_get_tasks() -> Result<(), Error> {
 ```
 
 I have multiple problems with this test:
-- `let client = Client::new("http://localhost:7700", "masterKey");`: This line is always the same in every test.
+- `let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));`: This line is always the same in every test.
   And if you make a typo on the http addr or the master key, you'll have an error.
 - `let index = client.create_index("test_get_tasks", None)...`: Each test needs to have an unique name.
   This means we currently need to write the name of the test everywhere; it's not practical.
@@ -61,7 +61,7 @@ the test, the macro automatically did the same thing we've seen before.
 There are a few rules, though:
 1. The macro only handles three types of arguments:
   - `String`: It returns the name of the test.
-  - `Client`: It creates a client like that: `Client::new("http://localhost:7700", "masterKey")`.
+  - `Client`: It creates a client like that: `Client::new("http://localhost:7700", Some(String::from("masterKey")))`.
   - `Index`: It creates and deletes an index, as we've seen before.
 2. You only get what you asked for. That means if you don't ask for an index, no index will be created in meilisearch.
   So, if you are testing the creation of indexes, you can ask for a `Client` and a `String` and then create it yourself.

--- a/meilisearch-test-macro/src/lib.rs
+++ b/meilisearch-test-macro/src/lib.rs
@@ -83,7 +83,7 @@ pub fn meilisearch_test(params: TokenStream, input: TokenStream) -> TokenStream 
         // First we need to check if a client will be used and create it if it’s the case
         if use_client {
             outer_block.push(parse_quote!(
-                let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+                let client = Client::new("http://localhost:7700", some("masterKey"));
             ));
         }
 

--- a/meilisearch-test-macro/src/lib.rs
+++ b/meilisearch-test-macro/src/lib.rs
@@ -83,7 +83,7 @@ pub fn meilisearch_test(params: TokenStream, input: TokenStream) -> TokenStream 
         // First we need to check if a client will be used and create it if it’s the case
         if use_client {
             outer_block.push(parse_quote!(
-                let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+                let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
             ));
         }
 

--- a/meilisearch-test-macro/src/lib.rs
+++ b/meilisearch-test-macro/src/lib.rs
@@ -83,7 +83,7 @@ pub fn meilisearch_test(params: TokenStream, input: TokenStream) -> TokenStream 
         // First we need to check if a client will be used and create it if it’s the case
         if use_client {
             outer_block.push(parse_quote!(
-                let client = Client::new("http://localhost:7700", "masterKey");
+                let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
             ));
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -751,7 +751,7 @@ mod tests {
 
         let master_key = client.api_key.clone();
         // this key has no right
-        client.api_key = Arc::new(Option::from(key.key.clone()));
+        client.api_key = Arc::new(Some(key.key.clone()));
         // with a wrong key
         let error = client.delete_key("invalid_key").await.unwrap_err();
         assert!(matches!(
@@ -851,12 +851,9 @@ mod tests {
             })
         ));
 
-        let key = match client.api_key.as_ref() {
-            Some(key) => key,
-            None => panic!("test_error_create_key no key to delete"),
-        };
+        
         // cleanup
-        master_client.delete_key(key.unwrap()).await.unwrap();
+        master_client.delete_key(client.api_key.as_deref().unwrap()).await.unwrap();
     }
 
     #[meilisearch_test]
@@ -935,7 +932,7 @@ mod tests {
             })
         ));
 
-        master_client.delete_key(key.unwrap()).await.unwrap();
+        master_client.delete_key(client.api_key.as_deref().unwrap()).await.unwrap();
     }
 
     #[meilisearch_test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -681,7 +681,7 @@ mod tests {
             ),
             (
                 mock("DELETE", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, &None, Method::Delete, 200)
+                request::<String, ()>(address, None, Method::Delete, 200)
             ),
             (
                 mock("PUT", path).match_header("User-Agent", user_agent).create(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -851,9 +851,11 @@ mod tests {
             })
         ));
 
-        
         // cleanup
-        master_client.delete_key(client.api_key.as_deref().unwrap()).await.unwrap();
+        master_client
+            .delete_key(client.api_key.as_deref().unwrap())
+            .await
+            .unwrap();
     }
 
     #[meilisearch_test]
@@ -932,7 +934,10 @@ mod tests {
             })
         ));
 
-        master_client.delete_key(client.api_key.as_deref().unwrap()).await.unwrap();
+        master_client
+            .delete_key(client.api_key.as_deref().unwrap())
+            .await
+            .unwrap();
     }
 
     #[meilisearch_test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// ```
     pub fn new(host: impl Into<String>, api_key: Option<impl Into<String>>) -> Client {
         Client {
@@ -45,7 +45,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     ///
     /// let indexes: Vec<Index> = client.list_all_indexes().await.unwrap();
     /// println!("{:?}", indexes);
@@ -67,7 +67,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     ///
     /// let json_indexes = client.list_all_indexes_raw().await.unwrap();
     /// println!("{:?}", json_indexes);
@@ -94,7 +94,7 @@ impl Client {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let index = client.create_index("get_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_index"
@@ -118,7 +118,7 @@ impl Client {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let index = client.create_index("get_raw_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_raw_index"
@@ -159,7 +159,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // Create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     ///
     /// // Create a new index called movies and access it
     /// let task = client.create_index("create_index", None).await.unwrap();
@@ -221,7 +221,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let stats = client.get_stats().await.unwrap();
     /// # });
     /// ```
@@ -243,7 +243,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::{Error, ErrorCode}};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let health = client.health().await.unwrap();
     /// assert_eq!(health.status, "available");
     /// # });
@@ -266,7 +266,7 @@ impl Client {
     /// # use meilisearch_sdk::client::*;
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let health = client.is_healthy().await;
     /// assert_eq!(health, true);
     /// # });
@@ -290,7 +290,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let keys = client.get_keys().await.unwrap();
     /// assert!(keys.len() >= 2);
     /// # });
@@ -325,7 +325,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let key = client.get_keys().await.unwrap().into_iter().find(|k| k.description.starts_with("Default Search API Key")).unwrap();
     /// let key_id = // enter your API key here, for the example we'll say we entered our search API key.
     /// # key.key;
@@ -354,7 +354,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let key = KeyBuilder::new("delete_key");
     /// let key = client.create_key(key).await.unwrap();
     /// let inner_key = key.key.clone();
@@ -386,7 +386,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder, key::Action};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let mut key = KeyBuilder::new("create_key");
     /// key.with_index("*").with_action(Action::DocumentsAdd);
     /// let key = client.create_key(key).await.unwrap();
@@ -415,7 +415,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let key = KeyBuilder::new("update_key");
     /// let mut key = client.create_key(key).await.unwrap();
     /// assert!(key.indexes.is_empty());
@@ -444,7 +444,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let version = client.get_version().await.unwrap();
     /// # });
     /// ```
@@ -482,7 +482,7 @@ impl Client {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movies = client.index("movies_client_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -535,7 +535,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// # let client = client::Client::new("http://localhost:7700", some("masterKey"));
     /// # let index = client.create_index("movies_get_task", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     /// let task = index.delete_all_documents().await.unwrap();
     /// let task = client.get_task(task).await.unwrap();
@@ -559,7 +559,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// # let client = client::Client::new("http://localhost:7700", some("masterKey"));
     /// let tasks = client.get_tasks().await.unwrap();
     /// # });
     /// ```
@@ -587,7 +587,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// # let client = client::Client::new("http://localhost:7700", some("masterKey"));
     /// let token = client.generate_tenant_token(serde_json::json!(["*"]), None, None).unwrap();
     /// let client = client::Client::new("http://localhost:7700", Some(token));
     /// # });
@@ -598,9 +598,9 @@ impl Client {
         api_key: Option<String>,
         expires_at: Option<OffsetDateTime>,
     ) -> Result<String, Error> {
-        let self_key = match self.api_key.as_ref() {
-            Some(key) => key,
-            None => "",
+        let self_key = match self.api_key.as_ref(){
+            Some(key)=>key,
+            None=> ""
         };
         let api_key = api_key.unwrap_or_else(|| String::from(self_key));
 
@@ -659,9 +659,9 @@ mod tests {
         key::{Action, KeyBuilder},
     };
     use meilisearch_test_macro::meilisearch_test;
+    use time::OffsetDateTime;
     use mockito::mock;
     use std::mem;
-    use time::OffsetDateTime;
 
     #[meilisearch_test]
     async fn test_methods_has_qualified_version_as_header() {
@@ -672,35 +672,25 @@ mod tests {
 
         let assertions = vec![
             (
-                mock("GET", path)
-                    .match_header("User-Agent", user_agent)
-                    .create(),
-                request::<String, ()>(address, None, Method::Get, 200),
+                mock("GET", path).match_header("User-Agent", user_agent).create(),
+                request::<String, ()>(address, None, Method::Get, 200)
             ),
             (
-                mock("POST", path)
-                    .match_header("User-Agent", user_agent)
-                    .create(),
-                request::<String, ()>(address, None, Method::Post("".to_string()), 200),
+                mock("POST", path).match_header("User-Agent", user_agent).create(),
+                request::<String, ()>(address, None, Method::Post("".to_string()), 200)
             ),
             (
-                mock("DELETE", path)
-                    .match_header("User-Agent", user_agent)
-                    .create(),
-                request::<String, ()>(address, None, Method::Delete, 200),
+                mock("DELETE", path).match_header("User-Agent", user_agent).create(),
+                request::<String, ()>(address, None, Method::Delete, 200)
             ),
             (
-                mock("PUT", path)
-                    .match_header("User-Agent", user_agent)
-                    .create(),
-                request::<String, ()>(address, None, Method::Put("".to_string()), 200),
+                mock("PUT", path).match_header("User-Agent", user_agent).create(),
+                request::<String, ()>(address, None, Method::Put("".to_string()), 200)
             ),
             (
-                mock("PATCH", path)
-                    .match_header("User-Agent", user_agent)
-                    .create(),
-                request::<String, ()>(address, None, Method::Patch("".to_string()), 200),
-            ),
+                mock("PATCH", path).match_header("User-Agent", user_agent).create(),
+                request::<String, ()>(address, None, Method::Patch("".to_string()), 200)
+            )
         ];
 
         for (m, req) in assertions {
@@ -851,9 +841,9 @@ mod tests {
             })
         ));
 
-        let key = match client.api_key.as_ref() {
-            Some(key) => key,
-            None => panic!("test_error_create_key no key to delete"),
+        let key = match client.api_key.as_ref(){
+            Some(key)=>key,
+            None=> panic!("test_error_create_key no key to delete")
         };
         // cleanup
         master_client.delete_key(key).await.unwrap();
@@ -935,11 +925,13 @@ mod tests {
             })
         ));
 
+
         let key = match &*client.api_key {
-            Some(key) => key,
-            None => panic!("no key on test: test error update key"),
+            Some(key)=> key,
+            None => panic!("no key on test: test error update key")
         };
         master_client.delete_key(key).await.unwrap();
+
     }
 
     #[meilisearch_test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// ```
     pub fn new(host: impl Into<String>, api_key: Option<impl Into<String>>) -> Client {
         Client {
@@ -45,7 +45,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     ///
     /// let indexes: Vec<Index> = client.list_all_indexes().await.unwrap();
     /// println!("{:?}", indexes);
@@ -67,7 +67,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     ///
     /// let json_indexes = client.list_all_indexes_raw().await.unwrap();
     /// println!("{:?}", json_indexes);
@@ -94,7 +94,7 @@ impl Client {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let index = client.create_index("get_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_index"
@@ -118,7 +118,7 @@ impl Client {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let index = client.create_index("get_raw_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_raw_index"
@@ -159,7 +159,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // Create the client
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     ///
     /// // Create a new index called movies and access it
     /// let task = client.create_index("create_index", None).await.unwrap();
@@ -221,7 +221,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let stats = client.get_stats().await.unwrap();
     /// # });
     /// ```
@@ -243,7 +243,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::{Error, ErrorCode}};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let health = client.health().await.unwrap();
     /// assert_eq!(health.status, "available");
     /// # });
@@ -266,7 +266,7 @@ impl Client {
     /// # use meilisearch_sdk::client::*;
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let health = client.is_healthy().await;
     /// assert_eq!(health, true);
     /// # });
@@ -290,7 +290,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let keys = client.get_keys().await.unwrap();
     /// assert!(keys.len() >= 2);
     /// # });
@@ -325,7 +325,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let key = client.get_keys().await.unwrap().into_iter().find(|k| k.description.starts_with("Default Search API Key")).unwrap();
     /// let key_id = // enter your API key here, for the example we'll say we entered our search API key.
     /// # key.key;
@@ -354,7 +354,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let key = KeyBuilder::new("delete_key");
     /// let key = client.create_key(key).await.unwrap();
     /// let inner_key = key.key.clone();
@@ -386,7 +386,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder, key::Action};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let mut key = KeyBuilder::new("create_key");
     /// key.with_index("*").with_action(Action::DocumentsAdd);
     /// let key = client.create_key(key).await.unwrap();
@@ -415,7 +415,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let key = KeyBuilder::new("update_key");
     /// let mut key = client.create_key(key).await.unwrap();
     /// assert!(key.indexes.is_empty());
@@ -444,7 +444,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let version = client.get_version().await.unwrap();
     /// # });
     /// ```
@@ -482,7 +482,7 @@ impl Client {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movies = client.index("movies_client_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -535,7 +535,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// # let client = client::Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let index = client.create_index("movies_get_task", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     /// let task = index.delete_all_documents().await.unwrap();
     /// let task = client.get_task(task).await.unwrap();
@@ -559,7 +559,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// # let client = client::Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let tasks = client.get_tasks().await.unwrap();
     /// # });
     /// ```
@@ -587,7 +587,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// # let client = client::Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let token = client.generate_tenant_token(serde_json::json!(["*"]), None, None).unwrap();
     /// let client = client::Client::new("http://localhost:7700", Some(token));
     /// # });

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ use time::OffsetDateTime;
 #[derive(Debug, Clone)]
 pub struct Client {
     pub(crate) host: Rc<String>,
-    pub(crate) api_key: Rc<String>,
+    pub(crate) api_key: Rc<Option<String>>,
 }
 
 impl Client {
@@ -28,12 +28,12 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// ```
-    pub fn new(host: impl Into<String>, api_key: impl Into<String>) -> Client {
+    pub fn new(host: impl Into<String>, api_key: Option<impl Into<String>>) -> Client {
         Client {
             host: Rc::new(host.into()),
-            api_key: Rc::new(api_key.into()),
+            api_key: Rc::new(api_key.map(|key| key.into())),
         }
     }
 
@@ -67,7 +67,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     ///
     /// let json_indexes = client.list_all_indexes_raw().await.unwrap();
     /// println!("{:?}", json_indexes);
@@ -94,7 +94,7 @@ impl Client {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let index = client.create_index("get_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_index"
@@ -118,7 +118,7 @@ impl Client {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let index = client.create_index("get_raw_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_raw_index"
@@ -159,7 +159,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // Create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     ///
     /// // Create a new index called movies and access it
     /// let task = client.create_index("create_index", None).await.unwrap();
@@ -221,7 +221,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let stats = client.get_stats().await.unwrap();
     /// # });
     /// ```
@@ -243,7 +243,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::{Error, ErrorCode}};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let health = client.health().await.unwrap();
     /// assert_eq!(health.status, "available");
     /// # });
@@ -266,7 +266,7 @@ impl Client {
     /// # use meilisearch_sdk::client::*;
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let health = client.is_healthy().await;
     /// assert_eq!(health, true);
     /// # });
@@ -290,7 +290,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let keys = client.get_keys().await.unwrap();
     /// assert!(keys.len() >= 2);
     /// # });
@@ -325,7 +325,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let key = client.get_keys().await.unwrap().into_iter().find(|k| k.description.starts_with("Default Search API Key")).unwrap();
     /// let key_id = // enter your API key here, for the example we'll say we entered our search API key.
     /// # key.key;
@@ -354,7 +354,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let key = KeyBuilder::new("delete_key");
     /// let key = client.create_key(key).await.unwrap();
     /// let inner_key = key.key.clone();
@@ -386,7 +386,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder, key::Action};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let mut key = KeyBuilder::new("create_key");
     /// key.with_index("*").with_action(Action::DocumentsAdd);
     /// let key = client.create_key(key).await.unwrap();
@@ -415,7 +415,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let key = KeyBuilder::new("update_key");
     /// let mut key = client.create_key(key).await.unwrap();
     /// assert!(key.indexes.is_empty());
@@ -444,7 +444,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let version = client.get_version().await.unwrap();
     /// # });
     /// ```
@@ -482,7 +482,7 @@ impl Client {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = client::Client::new("http://localhost:7700", Some("masterKey"));
     /// let movies = client.index("movies_client_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -535,7 +535,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", "masterKey");
+    /// # let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let index = client.create_index("movies_get_task", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     /// let task = index.delete_all_documents().await.unwrap();
     /// let task = client.get_task(task).await.unwrap();
@@ -559,7 +559,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", "masterKey");
+    /// # let client = client::Client::new("http://localhost:7700", Some("masterKey"));
     /// let tasks = client.get_tasks().await.unwrap();
     /// # });
     /// ```
@@ -595,10 +595,14 @@ impl Client {
     pub fn generate_tenant_token(
         &self,
         search_rules: serde_json::Value,
-        api_key: Option<&str>,
+        api_key: Option<String>,
         expires_at: Option<OffsetDateTime>,
     ) -> Result<String, Error> {
-        let api_key = api_key.unwrap_or(&self.api_key);
+        let self_key = match self.api_key.as_ref(){
+            Some(key)=>key,
+            None=> ""
+        };
+        let api_key = api_key.unwrap_or(String::from(self_key));
 
         crate::tenant_tokens::generate_tenant_token(search_rules, api_key, expires_at)
     }
@@ -669,23 +673,23 @@ mod tests {
         let assertions = vec![
             (
                 mock("GET", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Get, 200)
+                request::<String, ()>(address, &None, Method::Get, 200)
             ),
             (
                 mock("POST", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Post("".to_string()), 200)
+                request::<String, ()>(address, &None, Method::Post("".to_string()), 200)
             ),
             (
                 mock("DELETE", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Delete, 200)
+                request::<String, ()>(address, &None, Method::Delete, 200)
             ),
             (
                 mock("PUT", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Put("".to_string()), 200)
+                request::<String, ()>(address, &None, Method::Put("".to_string()), 200)
             ),
             (
                 mock("PATCH", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Patch("".to_string()), 200)
+                request::<String, ()>(address, &None, Method::Patch("".to_string()), 200)
             )
         ];
 
@@ -738,7 +742,7 @@ mod tests {
 
         let master_key = client.api_key.clone();
         // this key has no right
-        client.api_key = Rc::new(key.key.clone());
+        client.api_key = Rc::new(Option::from(key.key.clone()));
         // with a wrong key
         let error = client.delete_key("invalid_key").await.unwrap_err();
         assert!(matches!(
@@ -823,7 +827,7 @@ mod tests {
 
         // backup the master key for cleanup at the end of the test
         let master_client = client.clone();
-        client.api_key = Rc::new(no_right_key.key.clone());
+        client.api_key = Rc::new(Some(no_right_key.key.clone()));
 
         let key = KeyBuilder::new(&description);
         let error = client.create_key(key).await.unwrap_err();
@@ -837,8 +841,12 @@ mod tests {
             })
         ));
 
+        let key = match client.api_key.as_ref(){
+            Some(key)=>key,
+            None=> panic!("test_error_create_key no key to delete")
+        };
         // cleanup
-        master_client.delete_key(&*client.api_key).await.unwrap();
+        master_client.delete_key(key).await.unwrap();
     }
 
     #[meilisearch_test]
@@ -904,7 +912,7 @@ mod tests {
 
         // backup the master key for cleanup at the end of the test
         let master_client = client.clone();
-        client.api_key = Rc::new(no_right_key.key.clone());
+        client.api_key = Rc::new(Option::from(no_right_key.key.clone()));
 
         let error = client.update_key(key).await.unwrap_err();
 
@@ -917,8 +925,13 @@ mod tests {
             })
         ));
 
-        // cleanup
-        master_client.delete_key(&*client.api_key).await.unwrap();
+
+        let key = match &*client.api_key {
+            Some(key)=> key,
+            None => panic!("no key on test: test error update key")
+        };
+        master_client.delete_key(key).await.unwrap();
+
     }
 
     #[meilisearch_test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -677,7 +677,7 @@ mod tests {
             ),
             (
                 mock("POST", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, &None, Method::Post("".to_string()), 200)
+                request::<String, ()>(address, None, Method::Post("".to_string()), 200)
             ),
             (
                 mock("DELETE", path).match_header("User-Agent", user_agent).create(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -602,7 +602,7 @@ impl Client {
             Some(key)=>key,
             None=> ""
         };
-        let api_key = api_key.unwrap_or(String::from(self_key));
+        let api_key = api_key.unwrap_or_else(|| String::from(self_key));
 
         crate::tenant_tokens::generate_tenant_token(search_rules, api_key, expires_at)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// ```
     pub fn new(host: impl Into<String>, api_key: Option<impl Into<String>>) -> Client {
         Client {
@@ -45,7 +45,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     ///
     /// let indexes: Vec<Index> = client.list_all_indexes().await.unwrap();
     /// println!("{:?}", indexes);
@@ -67,7 +67,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     ///
     /// let json_indexes = client.list_all_indexes_raw().await.unwrap();
     /// println!("{:?}", json_indexes);
@@ -94,7 +94,7 @@ impl Client {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let index = client.create_index("get_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_index"
@@ -118,7 +118,7 @@ impl Client {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let index = client.create_index("get_raw_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_raw_index"
@@ -159,7 +159,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // Create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     ///
     /// // Create a new index called movies and access it
     /// let task = client.create_index("create_index", None).await.unwrap();
@@ -221,7 +221,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let stats = client.get_stats().await.unwrap();
     /// # });
     /// ```
@@ -243,7 +243,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::{Error, ErrorCode}};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let health = client.health().await.unwrap();
     /// assert_eq!(health.status, "available");
     /// # });
@@ -266,7 +266,7 @@ impl Client {
     /// # use meilisearch_sdk::client::*;
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let health = client.is_healthy().await;
     /// assert_eq!(health, true);
     /// # });
@@ -290,7 +290,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let keys = client.get_keys().await.unwrap();
     /// assert!(keys.len() >= 2);
     /// # });
@@ -325,7 +325,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let key = client.get_keys().await.unwrap().into_iter().find(|k| k.description.starts_with("Default Search API Key")).unwrap();
     /// let key_id = // enter your API key here, for the example we'll say we entered our search API key.
     /// # key.key;
@@ -354,7 +354,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let key = KeyBuilder::new("delete_key");
     /// let key = client.create_key(key).await.unwrap();
     /// let inner_key = key.key.clone();
@@ -386,7 +386,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder, key::Action};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let mut key = KeyBuilder::new("create_key");
     /// key.with_index("*").with_action(Action::DocumentsAdd);
     /// let key = client.create_key(key).await.unwrap();
@@ -415,7 +415,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*, errors::Error, key::KeyBuilder};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let key = KeyBuilder::new("update_key");
     /// let mut key = client.create_key(key).await.unwrap();
     /// assert!(key.indexes.is_empty());
@@ -444,7 +444,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let version = client.get_version().await.unwrap();
     /// # });
     /// ```
@@ -482,7 +482,7 @@ impl Client {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = client::Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = client::Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movies = client.index("movies_client_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -535,7 +535,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let index = client.create_index("movies_get_task", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     /// let task = index.delete_all_documents().await.unwrap();
     /// let task = client.get_task(task).await.unwrap();
@@ -559,7 +559,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", Some("masterKey"));
+    /// # let client = client::Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let tasks = client.get_tasks().await.unwrap();
     /// # });
     /// ```
@@ -587,7 +587,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new("http://localhost:7700", "masterKey");
+    /// # let client = client::Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let token = client.generate_tenant_token(serde_json::json!(["*"]), None, None).unwrap();
     /// let client = client::Client::new("http://localhost:7700", token);
     /// # });

--- a/src/client.rs
+++ b/src/client.rs
@@ -689,7 +689,7 @@ mod tests {
             ),
             (
                 mock("PATCH", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, &None, Method::Patch("".to_string()), 200)
+                request::<String, ()>(address, None, Method::Patch("".to_string()), 200)
             )
         ];
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -856,7 +856,7 @@ mod tests {
             None => panic!("test_error_create_key no key to delete"),
         };
         // cleanup
-        master_client.delete_key(key).await.unwrap();
+        master_client.delete_key(key.unwrap()).await.unwrap();
     }
 
     #[meilisearch_test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -922,7 +922,7 @@ mod tests {
 
         // backup the master key for cleanup at the end of the test
         let master_client = client.clone();
-        client.api_key = Arc::new(Option::from(no_right_key.key.clone()));
+        client.api_key = Arc::new(Some(no_right_key.key.clone()));
 
         let error = client.update_key(key).await.unwrap_err();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -673,7 +673,7 @@ mod tests {
         let assertions = vec![
             (
                 mock("GET", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, &None, Method::Get, 200)
+                request::<String, ()>(address, None, Method::Get, 200)
             ),
             (
                 mock("POST", path).match_header("User-Agent", user_agent).create(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -685,7 +685,7 @@ mod tests {
             ),
             (
                 mock("PUT", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, &None, Method::Put("".to_string()), 200)
+                request::<String, ()>(address, None, Method::Put("".to_string()), 200)
             ),
             (
                 mock("PATCH", path).match_header("User-Agent", user_agent).create(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -482,7 +482,7 @@ impl Client {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = client::Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movies = client.index("movies_client_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -535,7 +535,7 @@ impl Client {
     /// ```
     /// # use meilisearch_sdk::*;
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// # let client = client::Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let index = client.create_index("movies_get_task", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     /// let task = index.delete_all_documents().await.unwrap();
     /// let task = client.get_task(task).await.unwrap();
@@ -589,7 +589,7 @@ impl Client {
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let token = client.generate_tenant_token(serde_json::json!(["*"]), None, None).unwrap();
-    /// let client = client::Client::new("http://localhost:7700", token);
+    /// let client = client::Client::new("http://localhost:7700", Some(token));
     /// # });
     /// ```
     pub fn generate_tenant_token(

--- a/src/client.rs
+++ b/src/client.rs
@@ -594,14 +594,10 @@ impl Client {
     pub fn generate_tenant_token(
         &self,
         search_rules: serde_json::Value,
-        api_key: Option<String>,
+        api_key: Option<&str>,
         expires_at: Option<OffsetDateTime>,
     ) -> Result<String, Error> {
-        let self_key = match self.api_key.as_ref() {
-            Some(key) => key,
-            None => "",
-        };
-        let api_key = api_key.unwrap_or_else(|| String::from(self_key));
+        let api_key = api_key.unwrap_or_default();
 
         crate::tenant_tokens::generate_tenant_token(search_rules, api_key, expires_at)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -935,11 +935,7 @@ mod tests {
             })
         ));
 
-        let key = match &*client.api_key {
-            Some(key) => key,
-            None => panic!("no key on test: test error update key"),
-        };
-        master_client.delete_key(key).await.unwrap();
+        master_client.delete_key(key.unwrap()).await.unwrap();
     }
 
     #[meilisearch_test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -76,7 +76,7 @@ impl Client {
     pub async fn list_all_indexes_raw(&self) -> Result<Vec<Value>, Error> {
         let json_indexes = request::<(), Vec<Value>>(
             &format!("{}/indexes", self.host),
-            &self.api_key,
+            self.api_key,
             Method::Get,
             200,
         )
@@ -131,7 +131,7 @@ impl Client {
     pub async fn get_raw_index(&self, uid: impl AsRef<str>) -> Result<Value, Error> {
         request::<(), Value>(
             &format!("{}/indexes/{}", self.host, uid.as_ref()),
-            &self.api_key,
+            self.api_key,
             Method::Get,
             200,
         )
@@ -181,7 +181,7 @@ impl Client {
     ) -> Result<Task, Error> {
         request::<Value, Task>(
             &format!("{}/indexes", self.host),
-            &self.api_key,
+            self.api_key,
             Method::Post(json!({
                 "uid": uid.as_ref(),
                 "primaryKey": primary_key,
@@ -196,7 +196,7 @@ impl Client {
     pub async fn delete_index(&self, uid: impl AsRef<str>) -> Result<Task, Error> {
         request::<(), Task>(
             &format!("{}/indexes/{}", self.host, uid.as_ref()),
-            &self.api_key,
+            self.api_key,
             Method::Delete,
             202,
         )
@@ -228,7 +228,7 @@ impl Client {
     pub async fn get_stats(&self) -> Result<ClientStats, Error> {
         request::<serde_json::Value, ClientStats>(
             &format!("{}/stats", self.host),
-            &self.api_key,
+            self.api_key,
             Method::Get,
             200,
         )
@@ -251,7 +251,7 @@ impl Client {
     pub async fn health(&self) -> Result<Health, Error> {
         request::<serde_json::Value, Health>(
             &format!("{}/health", self.host),
-            &self.api_key,
+            self.api_key,
             Method::Get,
             200,
         )
@@ -305,7 +305,7 @@ impl Client {
 
         let keys = request::<(), Keys>(
             &format!("{}/keys", self.host),
-            &self.api_key,
+            self.api_key,
             Method::Get,
             200,
         )
@@ -336,7 +336,7 @@ impl Client {
     pub async fn get_key(&self, key: impl AsRef<str>) -> Result<Key, Error> {
         request::<(), Key>(
             &format!("{}/keys/{}", self.host, key.as_ref()),
-            &self.api_key,
+            self.api_key,
             Method::Get,
             200,
         )
@@ -368,7 +368,7 @@ impl Client {
     pub async fn delete_key(&self, key: impl AsRef<str>) -> Result<(), Error> {
         request::<(), ()>(
             &format!("{}/keys/{}", self.host, key.as_ref()),
-            &self.api_key,
+            self.api_key,
             Method::Delete,
             204,
         )
@@ -397,7 +397,7 @@ impl Client {
     pub async fn create_key(&self, key: impl AsRef<KeyBuilder>) -> Result<Key, Error> {
         request::<&KeyBuilder, Key>(
             &format!("{}/keys", self.host),
-            &self.api_key,
+            self.api_key,
             Method::Post(key.as_ref()),
             201,
         )
@@ -429,7 +429,7 @@ impl Client {
     pub async fn update_key(&self, key: impl AsRef<Key>) -> Result<Key, Error> {
         request::<&Key, Key>(
             &format!("{}/keys/{}", self.host, key.as_ref().key),
-            &self.api_key,
+            self.api_key,
             Method::Patch(key.as_ref()),
             200,
         )
@@ -451,7 +451,7 @@ impl Client {
     pub async fn get_version(&self) -> Result<Version, Error> {
         request::<(), Version>(
             &format!("{}/version", self.host),
-            &self.api_key,
+            self.api_key,
             Method::Get,
             200,
         )
@@ -545,7 +545,7 @@ impl Client {
     pub async fn get_task(&self, task_id: impl AsRef<u64>) -> Result<Task, Error> {
         request::<(), Task>(
             &format!("{}/tasks/{}", self.host, task_id.as_ref()),
-            &self.api_key,
+            self.api_key,
             Method::Get,
             200,
         )
@@ -571,7 +571,7 @@ impl Client {
 
         let tasks = request::<(), Tasks>(
             &format!("{}/tasks", self.host),
-            &self.api_key,
+            self.api_key,
             Method::Get,
             200,
         )
@@ -598,9 +598,9 @@ impl Client {
         api_key: Option<String>,
         expires_at: Option<OffsetDateTime>,
     ) -> Result<String, Error> {
-        let self_key = match self.api_key.as_ref(){
-            Some(key)=>key,
-            None=> ""
+        let self_key = match self.api_key.as_ref() {
+            Some(key) => key,
+            None => "",
         };
         let api_key = api_key.unwrap_or_else(|| String::from(self_key));
 
@@ -659,9 +659,9 @@ mod tests {
         key::{Action, KeyBuilder},
     };
     use meilisearch_test_macro::meilisearch_test;
-    use time::OffsetDateTime;
     use mockito::mock;
     use std::mem;
+    use time::OffsetDateTime;
 
     #[meilisearch_test]
     async fn test_methods_has_qualified_version_as_header() {
@@ -672,25 +672,35 @@ mod tests {
 
         let assertions = vec![
             (
-                mock("GET", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, None, Method::Get, 200)
+                mock("GET", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, None, Method::Get, 200),
             ),
             (
-                mock("POST", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, None, Method::Post("".to_string()), 200)
+                mock("POST", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, None, Method::Post("".to_string()), 200),
             ),
             (
-                mock("DELETE", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, None, Method::Delete, 200)
+                mock("DELETE", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, None, Method::Delete, 200),
             ),
             (
-                mock("PUT", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, None, Method::Put("".to_string()), 200)
+                mock("PUT", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, None, Method::Put("".to_string()), 200),
             ),
             (
-                mock("PATCH", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, None, Method::Patch("".to_string()), 200)
-            )
+                mock("PATCH", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, None, Method::Patch("".to_string()), 200),
+            ),
         ];
 
         for (m, req) in assertions {
@@ -841,9 +851,9 @@ mod tests {
             })
         ));
 
-        let key = match client.api_key.as_ref(){
-            Some(key)=>key,
-            None=> panic!("test_error_create_key no key to delete")
+        let key = match client.api_key.as_ref() {
+            Some(key) => key,
+            None => panic!("test_error_create_key no key to delete"),
         };
         // cleanup
         master_client.delete_key(key).await.unwrap();
@@ -925,13 +935,11 @@ mod tests {
             })
         ));
 
-
         let key = match &*client.api_key {
-            Some(key)=> key,
-            None => panic!("no key on test: test error update key")
+            Some(key) => key,
+            None => panic!("no key on test: test error update key"),
         };
         master_client.delete_key(key).await.unwrap();
-
     }
 
     #[meilisearch_test]

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -20,7 +20,7 @@
 //! # use std::{thread::sleep, time::Duration};
 //! # futures::executor::block_on(async move {
 //! #
-//! let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+//! let client = Client::new("http://localhost:7700", some("masterKey"));
 //!
 //! // Create a dump
 //! let dump_info = client.create_dump().await.unwrap();
@@ -79,7 +79,7 @@ impl Client {
     /// # use std::{thread::sleep, time::Duration};
     /// # futures::executor::block_on(async move {
     /// #
-    /// # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// # let client = Client::new("http://localhost:7700", some("masterKey"));
     /// #
     /// let dump_info = client.create_dump().await.unwrap();
     /// assert!(matches!(dump_info.status, DumpStatus::InProgress));
@@ -88,7 +88,7 @@ impl Client {
     pub async fn create_dump(&self) -> Result<DumpInfo, Error> {
         request::<(), DumpInfo>(
             &format!("{}/dumps", self.host),
-            self.client.api_key,
+            &self.api_key,
             Method::Post(()),
             202,
         )
@@ -105,7 +105,7 @@ impl Client {
     /// # use std::{thread::sleep, time::Duration};
     /// # futures::executor::block_on(async move {
     /// #
-    /// # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// # let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let dump_info = client.create_dump().await.unwrap();
     /// # sleep(Duration::from_secs(5));
     /// #
@@ -115,7 +115,7 @@ impl Client {
     pub async fn get_dump_status(&self, dump_uid: impl AsRef<str>) -> Result<DumpInfo, Error> {
         request::<(), DumpInfo>(
             &format!("{}/dumps/{}/status", self.host, dump_uid.as_ref()),
-            self.client.api_key,
+            self.api_key,
             Method::Get,
             200,
         )

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -20,7 +20,7 @@
 //! # use std::{thread::sleep, time::Duration};
 //! # futures::executor::block_on(async move {
 //! #
-//! let client = Client::new("http://localhost:7700", Some("masterKey"));
+//! let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 //!
 //! // Create a dump
 //! let dump_info = client.create_dump().await.unwrap();
@@ -79,7 +79,7 @@ impl Client {
     /// # use std::{thread::sleep, time::Duration};
     /// # futures::executor::block_on(async move {
     /// #
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// #
     /// let dump_info = client.create_dump().await.unwrap();
     /// assert!(matches!(dump_info.status, DumpStatus::InProgress));
@@ -105,7 +105,7 @@ impl Client {
     /// # use std::{thread::sleep, time::Duration};
     /// # futures::executor::block_on(async move {
     /// #
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let dump_info = client.create_dump().await.unwrap();
     /// # sleep(Duration::from_secs(5));
     /// #

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -20,7 +20,7 @@
 //! # use std::{thread::sleep, time::Duration};
 //! # futures::executor::block_on(async move {
 //! #
-//! let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+//! let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 //!
 //! // Create a dump
 //! let dump_info = client.create_dump().await.unwrap();
@@ -79,7 +79,7 @@ impl Client {
     /// # use std::{thread::sleep, time::Duration};
     /// # futures::executor::block_on(async move {
     /// #
-    /// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// #
     /// let dump_info = client.create_dump().await.unwrap();
     /// assert!(matches!(dump_info.status, DumpStatus::InProgress));
@@ -105,7 +105,7 @@ impl Client {
     /// # use std::{thread::sleep, time::Duration};
     /// # futures::executor::block_on(async move {
     /// #
-    /// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let dump_info = client.create_dump().await.unwrap();
     /// # sleep(Duration::from_secs(5));
     /// #

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -20,7 +20,7 @@
 //! # use std::{thread::sleep, time::Duration};
 //! # futures::executor::block_on(async move {
 //! #
-//! let client = Client::new("http://localhost:7700", "masterKey");
+//! let client = Client::new("http://localhost:7700", Some("masterKey"));
 //!
 //! // Create a dump
 //! let dump_info = client.create_dump().await.unwrap();

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -88,7 +88,7 @@ impl Client {
     pub async fn create_dump(&self) -> Result<DumpInfo, Error> {
         request::<(), DumpInfo>(
             &format!("{}/dumps", self.host),
-            &self.api_key,
+            self.client.api_key,
             Method::Post(()),
             202,
         )
@@ -115,7 +115,7 @@ impl Client {
     pub async fn get_dump_status(&self, dump_uid: impl AsRef<str>) -> Result<DumpInfo, Error> {
         request::<(), DumpInfo>(
             &format!("{}/dumps/{}/status", self.host, dump_uid.as_ref()),
-            &self.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -88,7 +88,7 @@ impl Client {
     pub async fn create_dump(&self) -> Result<DumpInfo, Error> {
         request::<(), DumpInfo>(
             &format!("{}/dumps", self.host),
-            &self.api_key,
+            self.api_key,
             Method::Post(()),
             202,
         )

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,7 +24,7 @@ pub enum Error {
     TenantTokensInvalidApiKey,
     /// It is not possible to generate an already expired tenant token.
     TenantTokensExpiredSignature,
-    
+
     /// When jsonwebtoken cannot generate the token successfully.
     InvalidTenantToken(jsonwebtoken::errors::Error),
 

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -13,7 +13,7 @@ use time::OffsetDateTime;
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+/// let client = Client::new("http://localhost:7700", some("masterKey"));
 ///
 /// // get the index called movies or create it if it does not exist
 /// let movies = client
@@ -37,7 +37,7 @@ use time::OffsetDateTime;
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700",Some("masterKey".to_string()));
+/// let client = Client::new("http://localhost:7700",some("masterKey"));
 ///
 /// // use the implicit index creation if the index already exist or
 /// // Meilisearch would be able to create the index if it does not exist during:
@@ -103,7 +103,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let index = client.create_index("delete", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "movies" and delete it
@@ -138,7 +138,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movies = client.index("execute_query");
     ///
     /// // add some documents
@@ -219,7 +219,7 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movies = client.index("get_document");
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
@@ -269,7 +269,7 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movie_index = client.index("get_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -329,7 +329,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movie_index = client.index("add_or_replace");
     ///
     /// let task = movie_index.add_or_replace(&[
@@ -402,7 +402,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movie_index = client.index("add_or_update");
     ///
     /// let task = movie_index.add_or_update(&[
@@ -464,7 +464,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movie_index = client.index("delete_all_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -508,7 +508,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let mut movies = client.index("delete_document");
     ///
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -553,7 +553,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movies = client.index("delete_documents");
     ///
     /// // add some documents
@@ -599,7 +599,7 @@ impl Index {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let index = client.create_index("fetch_info", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the information of the index named "fetch_info"
@@ -657,7 +657,7 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movies = client.index("get_task");
     ///
     /// let task = movies.add_documents(&[
@@ -703,7 +703,7 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let status = index.get_tasks().await.unwrap();
@@ -740,7 +740,7 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let index = client.create_index("get_stats", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let stats = index.get_stats().await.unwrap();
@@ -782,7 +782,7 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movies = client.index("movies_index_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -824,7 +824,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movie_index = client.index("add_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[
@@ -885,7 +885,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movie_index = client.index("update_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -13,7 +13,7 @@ use time::OffsetDateTime;
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", "masterKey");
+/// let client = Client::new("http://localhost:7700", Some("masterKey"));
 ///
 /// // get the index called movies or create it if it does not exist
 /// let movies = client
@@ -37,7 +37,7 @@ use time::OffsetDateTime;
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", "masterKey");
+/// let client = Client::new("http://localhost:7700", Some("masterKey"));
 ///
 /// // use the implicit index creation if the index already exist or
 /// // Meilisearch would be able to create the index if it does not exist during:
@@ -103,7 +103,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let index = client.create_index("delete", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "movies" and delete it
@@ -138,7 +138,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movies = client.index("execute_query");
     ///
     /// // add some documents
@@ -179,7 +179,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let mut movies = client.index("search");
     ///
     /// // add some documents
@@ -219,7 +219,7 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movies = client.index("get_document");
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
@@ -269,7 +269,7 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movie_index = client.index("get_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -329,7 +329,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movie_index = client.index("add_or_replace");
     ///
     /// let task = movie_index.add_or_replace(&[
@@ -402,7 +402,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movie_index = client.index("add_or_update");
     ///
     /// let task = movie_index.add_or_update(&[
@@ -464,7 +464,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movie_index = client.index("delete_all_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -508,7 +508,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let mut movies = client.index("delete_document");
     ///
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -553,7 +553,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movies = client.index("delete_documents");
     ///
     /// // add some documents
@@ -599,7 +599,7 @@ impl Index {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let index = client.create_index("fetch_info", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the information of the index named "fetch_info"
@@ -657,7 +657,7 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movies = client.index("get_task");
     ///
     /// let task = movies.add_documents(&[
@@ -703,7 +703,7 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let status = index.get_tasks().await.unwrap();
@@ -740,7 +740,7 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let index = client.create_index("get_stats", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let stats = index.get_stats().await.unwrap();
@@ -824,7 +824,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movie_index = client.index("add_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -13,7 +13,7 @@ use time::OffsetDateTime;
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", Some("masterKey"));
+/// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 ///
 /// // get the index called movies or create it if it does not exist
 /// let movies = client
@@ -37,7 +37,7 @@ use time::OffsetDateTime;
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", Some("masterKey"));
+/// let client = Client::new("http://localhost:7700",Some(String::from("masterKey")));
 ///
 /// // use the implicit index creation if the index already exist or
 /// // Meilisearch would be able to create the index if it does not exist during:
@@ -103,7 +103,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let index = client.create_index("delete", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "movies" and delete it
@@ -138,7 +138,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = ("http://localhost:7700", Some(String::from("masterKey")));
     /// let movies = client.index("execute_query");
     ///
     /// // add some documents
@@ -219,7 +219,7 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movies = client.index("get_document");
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
@@ -269,7 +269,7 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movie_index = client.index("get_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -329,7 +329,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movie_index = client.index("add_or_replace");
     ///
     /// let task = movie_index.add_or_replace(&[
@@ -402,7 +402,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movie_index = client.index("add_or_update");
     ///
     /// let task = movie_index.add_or_update(&[
@@ -464,7 +464,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movie_index = client.index("delete_all_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -508,7 +508,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let mut movies = client.index("delete_document");
     ///
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -553,7 +553,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movies = client.index("delete_documents");
     ///
     /// // add some documents
@@ -599,7 +599,7 @@ impl Index {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let index = client.create_index("fetch_info", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the information of the index named "fetch_info"
@@ -625,7 +625,7 @@ impl Index {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let index = client.create_index("get_primary_key", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the primary key of the index named "movies"
@@ -657,7 +657,7 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movies = client.index("get_task");
     ///
     /// let task = movies.add_documents(&[
@@ -703,7 +703,7 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let status = index.get_tasks().await.unwrap();
@@ -740,7 +740,7 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let index = client.create_index("get_stats", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let stats = index.get_stats().await.unwrap();
@@ -782,7 +782,7 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movies = client.index("movies_index_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -824,7 +824,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movie_index = client.index("add_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[
@@ -885,7 +885,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movie_index = client.index("update_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[
@@ -926,7 +926,7 @@ impl Index {
     ///         description: String::from("Updated!")
     /// }];
     ///
-    /// let tasks = movie_index.update_documents_in_batches(&updated_movies, Some(1), None).await.unwrap();
+    /// let tasks = movie_index.(&updated_movies, Some(1), None).await.unwrap();
     ///
     /// client.wait_for_task(tasks.last().unwrap(), None, None).await.unwrap();
     ///

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -13,7 +13,7 @@ use time::OffsetDateTime;
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+/// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 ///
 /// // get the index called movies or create it if it does not exist
 /// let movies = client
@@ -37,7 +37,7 @@ use time::OffsetDateTime;
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700",Some(String::from("masterKey")));
+/// let client = Client::new("http://localhost:7700",Some("masterKey".to_string()));
 ///
 /// // use the implicit index creation if the index already exist or
 /// // Meilisearch would be able to create the index if it does not exist during:
@@ -103,7 +103,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let index = client.create_index("delete", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "movies" and delete it
@@ -138,7 +138,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movies = client.index("execute_query");
     ///
     /// // add some documents
@@ -219,7 +219,7 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movies = client.index("get_document");
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
@@ -269,7 +269,7 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movie_index = client.index("get_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -329,7 +329,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movie_index = client.index("add_or_replace");
     ///
     /// let task = movie_index.add_or_replace(&[
@@ -402,7 +402,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movie_index = client.index("add_or_update");
     ///
     /// let task = movie_index.add_or_update(&[
@@ -464,7 +464,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movie_index = client.index("delete_all_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -508,7 +508,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let mut movies = client.index("delete_document");
     ///
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -553,7 +553,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movies = client.index("delete_documents");
     ///
     /// // add some documents
@@ -599,7 +599,7 @@ impl Index {
     ///
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let index = client.create_index("fetch_info", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the information of the index named "fetch_info"
@@ -657,7 +657,7 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movies = client.index("get_task");
     ///
     /// let task = movies.add_documents(&[
@@ -703,7 +703,7 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let status = index.get_tasks().await.unwrap();
@@ -740,7 +740,7 @@ impl Index {
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let index = client.create_index("get_stats", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let stats = index.get_stats().await.unwrap();
@@ -782,7 +782,7 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movies = client.index("movies_index_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -824,7 +824,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movie_index = client.index("add_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[
@@ -885,7 +885,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movie_index = client.index("update_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -88,7 +88,7 @@ impl Index {
     pub async fn update(&self, primary_key: impl AsRef<str>) -> Result<(), Error> {
         request::<serde_json::Value, serde_json::Value>(
             &format!("{}/indexes/{}", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Put(json!({ "primaryKey": primary_key.as_ref() })),
             200,
         )
@@ -115,7 +115,7 @@ impl Index {
     pub async fn delete(self) -> Result<Task, Error> {
         request::<(), Task>(
             &format!("{}/indexes/{}", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -156,7 +156,7 @@ impl Index {
     ) -> Result<SearchResults<T>, Error> {
         request::<&Query, SearchResults<T>>(
             &format!("{}/indexes/{}/search", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(query),
             200,
         )
@@ -239,7 +239,7 @@ impl Index {
                 "{}/indexes/{}/documents/{}",
                 self.client.host, self.uid, uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -302,7 +302,7 @@ impl Index {
             url.push_str("attributesToRetrieve=");
             url.push_str(attributes_to_retrieve);
         }
-        request::<(), Vec<T>>(&url, &self.client.api_key, Method::Get, 200).await
+        request::<(), Vec<T>>(&url, self.client.api_key, Method::Get, 200).await
     }
 
     /// Add a list of [Document]s or replace them if they already exist.
@@ -368,7 +368,7 @@ impl Index {
         } else {
             format!("{}/indexes/{}/documents", self.client.host, self.uid)
         };
-        request::<&[T], Task>(&url, &self.client.api_key, Method::Post(documents), 202).await
+        request::<&[T], Task>(&url, self.client.api_key, Method::Post(documents), 202).await
     }
 
     /// Alias for [Index::add_or_replace].
@@ -444,7 +444,7 @@ impl Index {
         } else {
             format!("{}/indexes/{}/documents", self.client.host, self.uid)
         };
-        request::<&[T], Task>(&url, &self.client.api_key, Method::Put(documents), 202).await
+        request::<&[T], Task>(&url, self.client.api_key, Method::Put(documents), 202).await
     }
 
     /// Delete all documents in the index.
@@ -484,7 +484,7 @@ impl Index {
     pub async fn delete_all_documents(&self) -> Result<Task, Error> {
         request::<(), Task>(
             &format!("{}/indexes/{}/documents", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -529,7 +529,7 @@ impl Index {
                 "{}/indexes/{}/documents/{}",
                 self.client.host, self.uid, uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -578,7 +578,7 @@ impl Index {
                 "{}/indexes/{}/documents/delete-batch",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(uids),
             202,
         )
@@ -687,7 +687,7 @@ impl Index {
                 self.uid,
                 uid.as_ref()
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -724,7 +724,7 @@ impl Index {
 
         Ok(request::<(), AllTasks>(
             &format!("{}/indexes/{}/tasks", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -751,7 +751,7 @@ impl Index {
     pub async fn get_stats(&self) -> Result<IndexStats, Error> {
         request::<serde_json::Value, IndexStats>(
             &format!("{}/indexes/{}/stats", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -138,7 +138,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = ("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let movies = client.index("execute_query");
     ///
     /// // add some documents
@@ -926,7 +926,7 @@ impl Index {
     ///         description: String::from("Updated!")
     /// }];
     ///
-    /// let tasks = movie_index.(&updated_movies, Some(1), None).await.unwrap();
+    /// let tasks = movie_index.update_documents_in_batches(&updated_movies, Some(1), None).await.unwrap();
     ///
     /// client.wait_for_task(tasks.last().unwrap(), None, None).await.unwrap();
     ///

--- a/src/key.rs
+++ b/src/key.rs
@@ -44,7 +44,7 @@ impl AsRef<Key> for Key {
 /// ```
 /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+/// let client = Client::new("http://localhost:7700", some("masterKey"));
 ///
 /// let key = KeyBuilder::new("My little lovely test key")
 ///   .with_action(Action::DocumentsAdd)
@@ -168,7 +168,7 @@ impl KeyBuilder {
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder, client::Client};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let key = KeyBuilder::new("My little lovely test key")
     ///   .create(&client).await.unwrap();
     ///

--- a/src/key.rs
+++ b/src/key.rs
@@ -44,7 +44,7 @@ impl AsRef<Key> for Key {
 /// ```
 /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", "masterKey");
+/// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 ///
 /// let key = KeyBuilder::new("My little lovely test key")
 ///   .with_action(Action::DocumentsAdd)
@@ -168,7 +168,7 @@ impl KeyBuilder {
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder, client::Client};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let key = KeyBuilder::new("My little lovely test key")
     ///   .create(&client).await.unwrap();
     ///

--- a/src/key.rs
+++ b/src/key.rs
@@ -44,7 +44,7 @@ impl AsRef<Key> for Key {
 /// ```
 /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
 /// # futures::executor::block_on(async move {
-/// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+/// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 ///
 /// let key = KeyBuilder::new("My little lovely test key")
 ///   .with_action(Action::DocumentsAdd)
@@ -168,7 +168,7 @@ impl KeyBuilder {
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder, client::Client};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let key = KeyBuilder::new("My little lovely test key")
     ///   .create(&client).await.unwrap();
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! fn main() { block_on(async move {
 //!     // Create a client (without sending any request so that can't fail)
-//!     let client = Client::new("http://localhost:7700", Some("masterKey"));
+//!     let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 //!
 //! #    let index = client.create_index("movies", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //!     // An index is where the documents are stored.
@@ -51,7 +51,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", Some("masterKey"));
+//! #    let client = ("http://localhost:7700", Some("masterKey"));
 //! #    let movies = client.create_index("movies_2", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! // Meilisearch is typo-tolerant:
 //! println!("{:?}", client.index("movies_2").search().with_query("caorl").execute::<Movie>().await.unwrap().hits);
@@ -92,7 +92,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", Some("masterKey"));
+//! #    let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 //! #    let movies = client.create_index("movies_3", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let search_result = client.index("movies_3")
 //!   .search()
@@ -137,7 +137,7 @@
 //! # use serde::{Serialize, Deserialize};
 //! # use futures::executor::block_on;
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", Some("masterKey"));
+//! #    let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 //! #    let movies = client.create_index("movies_4", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let filterable_attributes = [
 //!     "id",
@@ -165,7 +165,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! # let client = Client::new("http://localhost:7700", Some("masterKey"));
+//! # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 //! # let movies = client.create_index("movies_5", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! # let filterable_attributes = [
 //! #     "id",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! fn main() { block_on(async move {
 //!     // Create a client (without sending any request so that can't fail)
-//!     let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+//!     let client = Client::new("http://localhost:7700", some("masterKey"));
 //!
 //! #    let index = client.create_index("movies", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //!     // An index is where the documents are stored.
@@ -51,7 +51,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+//! #    let client = Client::new("http://localhost:7700", some("masterKey"));
 //! #    let movies = client.create_index("movies_2", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! // Meilisearch is typo-tolerant:
 //! println!("{:?}", client.index("movies_2").search().with_query("caorl").execute::<Movie>().await.unwrap().hits);
@@ -92,7 +92,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+//! #    let client = Client::new("http://localhost:7700", some("masterKey"));
 //! #    let movies = client.create_index("movies_3", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let search_result = client.index("movies_3")
 //!   .search()
@@ -137,7 +137,7 @@
 //! # use serde::{Serialize, Deserialize};
 //! # use futures::executor::block_on;
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+//! #    let client = Client::new("http://localhost:7700", some("masterKey"));
 //! #    let movies = client.create_index("movies_4", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let filterable_attributes = [
 //!     "id",
@@ -165,7 +165,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+//! # let client = Client::new("http://localhost:7700", some("masterKey"));
 //! # let movies = client.create_index("movies_5", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! # let filterable_attributes = [
 //! #     "id",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! fn main() { block_on(async move {
 //!     // Create a client (without sending any request so that can't fail)
-//!     let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+//!     let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 //!
 //! #    let index = client.create_index("movies", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //!     // An index is where the documents are stored.
@@ -51,7 +51,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+//! #    let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 //! #    let movies = client.create_index("movies_2", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! // Meilisearch is typo-tolerant:
 //! println!("{:?}", client.index("movies_2").search().with_query("caorl").execute::<Movie>().await.unwrap().hits);
@@ -92,7 +92,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+//! #    let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 //! #    let movies = client.create_index("movies_3", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let search_result = client.index("movies_3")
 //!   .search()
@@ -137,7 +137,7 @@
 //! # use serde::{Serialize, Deserialize};
 //! # use futures::executor::block_on;
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+//! #    let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 //! #    let movies = client.create_index("movies_4", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let filterable_attributes = [
 //!     "id",
@@ -165,7 +165,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+//! # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 //! # let movies = client.create_index("movies_5", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! # let filterable_attributes = [
 //! #     "id",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = ("http://localhost:7700", Some("masterKey"));
+//! #    let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 //! #    let movies = client.create_index("movies_2", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! // Meilisearch is typo-tolerant:
 //! println!("{:?}", client.index("movies_2").search().with_query("caorl").execute::<Movie>().await.unwrap().hits);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! fn main() { block_on(async move {
 //!     // Create a client (without sending any request so that can't fail)
-//!     let client = Client::new("http://localhost:7700", "masterKey");
+//!     let client = Client::new("http://localhost:7700", Some("masterKey"));
 //!
 //! #    let index = client.create_index("movies", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //!     // An index is where the documents are stored.
@@ -51,7 +51,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", "masterKey");
+//! #    let client = Client::new("http://localhost:7700", Some("masterKey"));
 //! #    let movies = client.create_index("movies_2", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! // Meilisearch is typo-tolerant:
 //! println!("{:?}", client.index("movies_2").search().with_query("caorl").execute::<Movie>().await.unwrap().hits);
@@ -92,7 +92,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", "masterKey");
+//! #    let client = Client::new("http://localhost:7700", Some("masterKey"));
 //! #    let movies = client.create_index("movies_3", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let search_result = client.index("movies_3")
 //!   .search()
@@ -137,7 +137,7 @@
 //! # use serde::{Serialize, Deserialize};
 //! # use futures::executor::block_on;
 //! # fn main() { block_on(async move {
-//! #    let client = Client::new("http://localhost:7700", "masterKey");
+//! #    let client = Client::new("http://localhost:7700", Some("masterKey"));
 //! #    let movies = client.create_index("movies_4", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let filterable_attributes = [
 //!     "id",
@@ -165,7 +165,7 @@
 //! #    genres: Vec<String>,
 //! # }
 //! # fn main() { block_on(async move {
-//! # let client = Client::new("http://localhost:7700", "masterKey");
+//! # let client = Client::new("http://localhost:7700", Some("masterKey"));
 //! # let movies = client.create_index("movies_5", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! # let filterable_attributes = [
 //! #     "id",

--- a/src/request.rs
+++ b/src/request.rs
@@ -15,7 +15,7 @@ pub(crate) enum Method<T: Serialize> {
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static>(
     url: &str,
-    apikey: &Option<String>,
+    apikey: Option<String>,
     method: Method<Input>,
     expected_status_code: u16,
 ) -> Result<Output, Error> {
@@ -26,45 +26,45 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
 
     let mut response = match &method {
         Method::Get => {
-            if let Some(key) = apikey{
+            if let Some(key) = apikey {
                 let auth = format!("Bearer {}", key);
                 Request::get(url)
-                .header(header::AUTHORIZATION, auth)
-                .header(header::USER_AGENT, user_agent)
-                .body(())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
-            }else{
+                    .header(header::AUTHORIZATION, auth)
+                    .header(header::USER_AGENT, user_agent)
+                    .body(())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            } else {
                 Request::get(url)
-                .header(header::USER_AGENT, user_agent)
-                .body(())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+                    .header(header::USER_AGENT, user_agent)
+                    .body(())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
             }
         }
         Method::Delete => {
-            if let Some(key) = apikey{
+            if let Some(key) = apikey {
                 let auth = format!("Bearer {}", key);
                 Request::delete(url)
-                .header(header::AUTHORIZATION, auth)
-                .header(header::USER_AGENT, user_agent)
-                .body(())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
-            }else{
+                    .header(header::AUTHORIZATION, auth)
+                    .header(header::USER_AGENT, user_agent)
+                    .body(())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            } else {
                 Request::delete(url)
-                .header(header::USER_AGENT, user_agent)
-                .body(())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+                    .header(header::USER_AGENT, user_agent)
+                    .body(())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
             }
         }
         Method::Post(body) => {
-            if let Some(key) = apikey{
+            if let Some(key) = apikey {
                 let auth = format!("Bearer {}", key);
                 Request::post(url)
                     .header(header::AUTHORIZATION, auth)
@@ -74,56 +74,56 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
                     .map_err(|_| crate::errors::Error::InvalidRequest)?
                     .send_async()
                     .await?
-            }else{
+            } else {
                 Request::post(url)
-                .header(header::CONTENT_TYPE, "application/json")
-                .header(header::USER_AGENT, user_agent)
-                .body(to_string(&body).unwrap())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::USER_AGENT, user_agent)
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
             }
         }
         Method::Patch(body) => {
-            if let Some(key) = apikey{
+            if let Some(key) = apikey {
                 let auth = format!("Bearer {}", key);
-            Request::patch(url)
-                .header(header::AUTHORIZATION, auth)
-                .header(header::CONTENT_TYPE, "application/json")
-                .header(header::USER_AGENT, user_agent)
-                .body(to_string(&body).unwrap())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
-            }else{
                 Request::patch(url)
-                .header(header::CONTENT_TYPE, "application/json")
-                .header(header::USER_AGENT, user_agent)
-                .body(to_string(&body).unwrap())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+                    .header(header::AUTHORIZATION, auth)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::USER_AGENT, user_agent)
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            } else {
+                Request::patch(url)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::USER_AGENT, user_agent)
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
             }
         }
         Method::Put(body) => {
-            if let Some(key) = apikey{
+            if let Some(key) = apikey {
                 let auth = format!("Bearer {}", key);
-            Request::put(url)
-                .header(header::AUTHORIZATION, auth)
-                .header(header::CONTENT_TYPE, "application/json")
-                .header(header::USER_AGENT, user_agent)
-                .body(to_string(&body).unwrap())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
-            }else{
                 Request::put(url)
-                .header(header::CONTENT_TYPE, "application/json")
-                .header(header::USER_AGENT, user_agent)
-                .body(to_string(&body).unwrap())
-                .map_err(|_| crate::errors::Error::InvalidRequest)?
-                .send_async()
-                .await?
+                    .header(header::AUTHORIZATION, auth)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::USER_AGENT, user_agent)
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            } else {
+                Request::put(url)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::USER_AGENT, user_agent)
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
             }
         }
     };
@@ -159,7 +159,7 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
 
     let headers = Headers::new().unwrap();
 
-    if let Some(key) = apikey{
+    if let Some(key) = apikey {
         headers.append("Authorization: Bearer", key).unwrap();
     }
     headers.append("User-Agent", &user_agent).unwrap();

--- a/src/request.rs
+++ b/src/request.rs
@@ -143,7 +143,7 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
 #[cfg(target_arch = "wasm32")]
 pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static>(
     url: &str,
-    apikey: Option<String>,
+    apikey: &Option<String>,
     method: Method<Input>,
     expected_status_code: u16,
 ) -> Result<Output, Error> {

--- a/src/request.rs
+++ b/src/request.rs
@@ -39,67 +39,50 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
                     .send_async()
                     .await?
             }
-        }
         Method::Delete => {
+
+            let mut request = Request::delete(url)
+              .header(header::USER_AGENT, user_agent);
+            
             if let Some(key) = apikey {
                 let auth = format!("Bearer {}", key);
-                Request::delete(url)
-                    .header(header::AUTHORIZATION, auth)
-                    .header(header::USER_AGENT, user_agent)
-                    .body(())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
-            } else {
-                Request::delete(url)
-                    .header(header::USER_AGENT, user_agent)
-                    .body(())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
+                request = request.header(header::AUTHORIZATION, auth);
             }
+            request
+                    .body(())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
         }
         Method::Post(body) => {
-            if let Some(key) = apikey {
-                let auth = format!("Bearer {}", key);
-                Request::post(url)
-                    .header(header::AUTHORIZATION, auth)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .header(header::USER_AGENT, user_agent)
-                    .body(to_string(&body).unwrap())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
-            } else {
-                Request::post(url)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .header(header::USER_AGENT, user_agent)
-                    .body(to_string(&body).unwrap())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
-            }
+            
+            let mut request = Request::post(url)
+            .header(header::USER_AGENT, user_agent);
+          
+          if let Some(key) = apikey {
+              let auth = format!("Bearer {}", key);
+              request = request.header(header::AUTHORIZATION, auth);
+          }
+          request
+                  .body(to_string(&body).unwrap())
+                  .map_err(|_| crate::errors::Error::InvalidRequest)?
+                  .send_async()
+                  .await?
+
         }
         Method::Patch(body) => {
-            if let Some(key) = apikey {
-                let auth = format!("Bearer {}", key);
-                Request::patch(url)
-                    .header(header::AUTHORIZATION, auth)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .header(header::USER_AGENT, user_agent)
-                    .body(to_string(&body).unwrap())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
-            } else {
-                Request::patch(url)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .header(header::USER_AGENT, user_agent)
-                    .body(to_string(&body).unwrap())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
-            }
+            let mut request = Request::patch(url)
+            .header(header::USER_AGENT, user_agent);
+          
+          if let Some(key) = apikey {
+              let auth = format!("Bearer {}", key);
+              request = request.header(header::AUTHORIZATION, auth);
+          }
+          request
+                  .body(to_string(&body).unwrap())
+                  .map_err(|_| crate::errors::Error::InvalidRequest)?
+                  .send_async()
+                  .await?
         }
         Method::Put(body) => {
             if let Some(key) = apikey {

--- a/src/request.rs
+++ b/src/request.rs
@@ -15,46 +15,78 @@ pub(crate) enum Method<T: Serialize> {
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static>(
     url: &str,
-    apikey: &str,
+    apikey: &Option<String>,
     method: Method<Input>,
     expected_status_code: u16,
 ) -> Result<Output, Error> {
     use isahc::http::header;
     use isahc::*;
 
-    let auth = format!("Bearer {}", apikey);
     let user_agent = qualified_version();
 
     let mut response = match &method {
         Method::Get => {
-            Request::get(url)
+            if let Some(key) = apikey{
+                let auth = format!("Bearer {}", key);
+                Request::get(url)
                 .header(header::AUTHORIZATION, auth)
                 .header(header::USER_AGENT, user_agent)
                 .body(())
                 .map_err(|_| crate::errors::Error::InvalidRequest)?
                 .send_async()
                 .await?
+            }else{
+                Request::get(url)
+                .header(header::USER_AGENT, user_agent)
+                .body(())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+            }
         }
         Method::Delete => {
-            Request::delete(url)
+            if let Some(key) = apikey{
+                let auth = format!("Bearer {}", key);
+                Request::delete(url)
                 .header(header::AUTHORIZATION, auth)
                 .header(header::USER_AGENT, user_agent)
                 .body(())
                 .map_err(|_| crate::errors::Error::InvalidRequest)?
                 .send_async()
                 .await?
+            }else{
+                Request::delete(url)
+                .header(header::USER_AGENT, user_agent)
+                .body(())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+            }
         }
         Method::Post(body) => {
-            Request::post(url)
-                .header(header::AUTHORIZATION, auth)
+            if let Some(key) = apikey{
+                let auth = format!("Bearer {}", key);
+                Request::post(url)
+                    .header(header::AUTHORIZATION, auth)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::USER_AGENT, user_agent)
+                    .body(to_string(&body).unwrap())
+                    .map_err(|_| crate::errors::Error::InvalidRequest)?
+                    .send_async()
+                    .await?
+            }else{
+                Request::post(url)
                 .header(header::CONTENT_TYPE, "application/json")
                 .header(header::USER_AGENT, user_agent)
                 .body(to_string(&body).unwrap())
                 .map_err(|_| crate::errors::Error::InvalidRequest)?
                 .send_async()
                 .await?
+            }
         }
         Method::Patch(body) => {
+            if let Some(key) = apikey{
+                let auth = format!("Bearer {}", key);
             Request::patch(url)
                 .header(header::AUTHORIZATION, auth)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -63,8 +95,19 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
                 .map_err(|_| crate::errors::Error::InvalidRequest)?
                 .send_async()
                 .await?
+            }else{
+                Request::patch(url)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::USER_AGENT, user_agent)
+                .body(to_string(&body).unwrap())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+            }
         }
         Method::Put(body) => {
+            if let Some(key) = apikey{
+                let auth = format!("Bearer {}", key);
             Request::put(url)
                 .header(header::AUTHORIZATION, auth)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -73,6 +116,15 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
                 .map_err(|_| crate::errors::Error::InvalidRequest)?
                 .send_async()
                 .await?
+            }else{
+                Request::put(url)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::USER_AGENT, user_agent)
+                .body(to_string(&body).unwrap())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+            }
         }
     };
 
@@ -91,7 +143,7 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
 #[cfg(target_arch = "wasm32")]
 pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static>(
     url: &str,
-    apikey: &str,
+    apikey: Option<String>,
     method: Method<Input>,
     expected_status_code: u16,
 ) -> Result<Output, Error> {
@@ -106,7 +158,10 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
     // The 2 following unwraps should not be able to fail
 
     let headers = Headers::new().unwrap();
-    headers.append("Authorization: Bearer", apikey).unwrap();
+
+    if let Some(key) = apikey{
+        headers.append("Authorization: Bearer", apikey).unwrap();
+    }
     headers.append("User-Agent", &user_agent).unwrap();
 
     let mut request: RequestInit = RequestInit::new();

--- a/src/request.rs
+++ b/src/request.rs
@@ -26,80 +26,75 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
 
     let mut response = match &method {
         Method::Get => {
-            let mut request = Request::get(url)
-              .header(header::USER_AGENT, user_agent);
-            
-            if let Some(key) = apikey {
-                let auth = format!("Bearer {}", key);
-                request = request.header(header::AUTHORIZATION, auth);
-            }
-            request
-                    .body(())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
-            }
-        Method::Delete => {
+            let mut request = Request::get(url).header(header::USER_AGENT, user_agent);
 
-            let mut request = Request::delete(url)
-              .header(header::USER_AGENT, user_agent);
-            
             if let Some(key) = apikey {
                 let auth = format!("Bearer {}", key);
                 request = request.header(header::AUTHORIZATION, auth);
             }
             request
-                    .body(())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
+                .body(())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+        }
+        Method::Delete => {
+            let mut request = Request::delete(url).header(header::USER_AGENT, user_agent);
+
+            if let Some(key) = apikey {
+                let auth = format!("Bearer {}", key);
+                request = request.header(header::AUTHORIZATION, auth);
+            }
+            request
+                .body(())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
         }
         Method::Post(body) => {
-            
             let mut request = Request::post(url)
-            .header(header::USER_AGENT, user_agent)
-            .header(header::CONTENT_TYPE, "application/json");
-          
-          if let Some(key) = apikey {
-              let auth = format!("Bearer {}", key);
-              request = request.header(header::AUTHORIZATION, auth);
-          }
-          request
-                  .body(to_string(&body).unwrap())
-                  .map_err(|_| crate::errors::Error::InvalidRequest)?
-                  .send_async()
-                  .await?
+                .header(header::USER_AGENT, user_agent)
+                .header(header::CONTENT_TYPE, "application/json");
 
+            if let Some(key) = apikey {
+                let auth = format!("Bearer {}", key);
+                request = request.header(header::AUTHORIZATION, auth);
+            }
+            request
+                .body(to_string(&body).unwrap())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
         }
         Method::Patch(body) => {
             let mut request = Request::patch(url)
-            .header(header::USER_AGENT, user_agent)
-            .header(header::CONTENT_TYPE, "application/json");
-          
-          if let Some(key) = apikey {
-              let auth = format!("Bearer {}", key);
-              request = request.header(header::AUTHORIZATION, auth);
-          }
-          request
-                  .body(to_string(&body).unwrap())
-                  .map_err(|_| crate::errors::Error::InvalidRequest)?
-                  .send_async()
-                  .await?
+                .header(header::USER_AGENT, user_agent)
+                .header(header::CONTENT_TYPE, "application/json");
+
+            if let Some(key) = apikey {
+                let auth = format!("Bearer {}", key);
+                request = request.header(header::AUTHORIZATION, auth);
+            }
+            request
+                .body(to_string(&body).unwrap())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
         }
         Method::Put(body) => {
             let mut request = Request::put(url)
-            .header(header::USER_AGENT, user_agent)
-            .header(header::CONTENT_TYPE, "application/json");
-          
-          if let Some(key) = apikey {
-              let auth = format!("Bearer {}", key);
-              request = request.header(header::AUTHORIZATION, auth);
-          }
-          request
-                  .body(to_string(&body).unwrap())
-                  .map_err(|_| crate::errors::Error::InvalidRequest)?
-                  .send_async()
-                  .await?
+                .header(header::USER_AGENT, user_agent)
+                .header(header::CONTENT_TYPE, "application/json");
+
+            if let Some(key) = apikey {
+                let auth = format!("Bearer {}", key);
+                request = request.header(header::AUTHORIZATION, auth);
+            }
+            request
+                .body(to_string(&body).unwrap())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
         }
     };
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -57,7 +57,8 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
         Method::Post(body) => {
             
             let mut request = Request::post(url)
-            .header(header::USER_AGENT, user_agent);
+            .header(header::USER_AGENT, user_agent)
+            .header(header::CONTENT_TYPE, "application/json");
           
           if let Some(key) = apikey {
               let auth = format!("Bearer {}", key);
@@ -72,7 +73,8 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
         }
         Method::Patch(body) => {
             let mut request = Request::patch(url)
-            .header(header::USER_AGENT, user_agent);
+            .header(header::USER_AGENT, user_agent)
+            .header(header::CONTENT_TYPE, "application/json");
           
           if let Some(key) = apikey {
               let auth = format!("Bearer {}", key);
@@ -85,25 +87,19 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
                   .await?
         }
         Method::Put(body) => {
-            if let Some(key) = apikey {
-                let auth = format!("Bearer {}", key);
-                Request::put(url)
-                    .header(header::AUTHORIZATION, auth)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .header(header::USER_AGENT, user_agent)
-                    .body(to_string(&body).unwrap())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
-            } else {
-                Request::put(url)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .header(header::USER_AGENT, user_agent)
-                    .body(to_string(&body).unwrap())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
-            }
+            let mut request = Request::put(url)
+            .header(header::USER_AGENT, user_agent)
+            .header(header::CONTENT_TYPE, "application/json");
+          
+          if let Some(key) = apikey {
+              let auth = format!("Bearer {}", key);
+              request = request.header(header::AUTHORIZATION, auth);
+          }
+          request
+                  .body(to_string(&body).unwrap())
+                  .map_err(|_| crate::errors::Error::InvalidRequest)?
+                  .send_async()
+                  .await?
         }
     };
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -143,7 +143,7 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
 #[cfg(target_arch = "wasm32")]
 pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static>(
     url: &str,
-    apikey: &Option<String>,
+    apikey: Option<&str>,
     method: Method<Input>,
     expected_status_code: u16,
 ) -> Result<Output, Error> {

--- a/src/request.rs
+++ b/src/request.rs
@@ -26,18 +26,14 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
 
     let mut response = match &method {
         Method::Get => {
+            let mut request = Request::get(url)
+              .header(header::USER_AGENT, user_agent);
+            
             if let Some(key) = apikey {
                 let auth = format!("Bearer {}", key);
-                Request::get(url)
-                    .header(header::AUTHORIZATION, auth)
-                    .header(header::USER_AGENT, user_agent)
-                    .body(())
-                    .map_err(|_| crate::errors::Error::InvalidRequest)?
-                    .send_async()
-                    .await?
-            } else {
-                Request::get(url)
-                    .header(header::USER_AGENT, user_agent)
+                request = request.header(header::AUTHORIZATION, auth);
+            }
+            request
                     .body(())
                     .map_err(|_| crate::errors::Error::InvalidRequest)?
                     .send_async()

--- a/src/request.rs
+++ b/src/request.rs
@@ -160,7 +160,7 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
     let headers = Headers::new().unwrap();
 
     if let Some(key) = apikey{
-        headers.append("Authorization: Bearer", apikey).unwrap();
+        headers.append("Authorization: Bearer", key).unwrap();
     }
     headers.append("User-Agent", &user_agent).unwrap();
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -102,7 +102,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///
 /// ```
 /// # use meilisearch_sdk::{client::Client, search::Query, indexes::Index};
-/// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+/// # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 /// # let index = client.index("does not matter");
 /// let query = Query::new(&index)
 ///     .with_query("space")
@@ -113,7 +113,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///
 /// ```
 /// # use meilisearch_sdk::{client::Client, search::Query, indexes::Index};
-/// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+/// # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
 /// # let index = client.index("does not matter");
 /// let query = index.search()
 ///     .with_query("space")

--- a/src/search.rs
+++ b/src/search.rs
@@ -102,7 +102,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///
 /// ```
 /// # use meilisearch_sdk::{client::Client, search::Query, indexes::Index};
-/// # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+/// # let client = Client::new("http://localhost:7700", some("masterKey"));
 /// # let index = client.index("does not matter");
 /// let query = Query::new(&index)
 ///     .with_query("space")
@@ -113,7 +113,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///
 /// ```
 /// # use meilisearch_sdk::{client::Client, search::Query, indexes::Index};
-/// # let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+/// # let client = Client::new("http://localhost:7700", some("masterKey"));
 /// # let index = client.index("does not matter");
 /// let query = index.search()
 ///     .with_query("space")

--- a/src/search.rs
+++ b/src/search.rs
@@ -730,7 +730,7 @@ mod tests {
             .create(&client)
             .await
             .unwrap();
-        let allowed_client = Client::new("http://localhost:7700", key.key);
+        let allowed_client = Client::new("http://localhost:7700", Option::from(key.key));
 
         let search_rules = vec![
             json!({ "*": {}}),
@@ -744,7 +744,7 @@ mod tests {
             let token = allowed_client
                 .generate_tenant_token(rules, None, None)
                 .expect("Cannot generate tenant token.");
-            let new_client = Client::new("http://localhost:7700", token);
+            let new_client = Client::new("http://localhost:7700", Option::from(token));
 
             let result: SearchResults<Document> = new_client
                 .index(index.uid.to_string())

--- a/src/search.rs
+++ b/src/search.rs
@@ -102,7 +102,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///
 /// ```
 /// # use meilisearch_sdk::{client::Client, search::Query, indexes::Index};
-/// # let client = Client::new("http://localhost:7700", "masterKey");
+/// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 /// # let index = client.index("does not matter");
 /// let query = Query::new(&index)
 ///     .with_query("space")
@@ -113,7 +113,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///
 /// ```
 /// # use meilisearch_sdk::{client::Client, search::Query, indexes::Index};
-/// # let client = Client::new("http://localhost:7700", "masterKey");
+/// # let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
 /// # let index = client.index("does not matter");
 /// let query = index.search()
 ///     .with_query("space")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -201,7 +201,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_settings");
     /// let settings = index.get_settings().await.unwrap();
@@ -223,7 +223,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", SSome(String::from("masterKey")));
     /// # client.create_index("get_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_synonyms");
     /// let synonyms = index.get_synonyms().await.unwrap();
@@ -248,7 +248,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_stop_words");
     /// let stop_words = index.get_stop_words().await.unwrap();
@@ -273,7 +273,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_ranking_rules");
     /// let ranking_rules = index.get_ranking_rules().await.unwrap();
@@ -298,7 +298,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = ("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_filterable_attributes");
     /// let filterable_attributes = index.get_filterable_attributes().await.unwrap();
@@ -348,7 +348,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_distinct_attribute");
     /// let distinct_attribute = index.get_distinct_attribute().await.unwrap();
@@ -373,7 +373,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_searchable_attributes");
     /// let searchable_attributes = index.get_searchable_attributes().await.unwrap();
@@ -398,7 +398,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = ("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_displayed_attributes");
     /// let displayed_attributes = index.get_displayed_attributes().await.unwrap();
@@ -455,7 +455,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("set_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_synonyms");
     ///
@@ -491,7 +491,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("set_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_stop_words");
     ///
@@ -528,7 +528,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("set_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_ranking_rules");
     ///
@@ -574,7 +574,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("set_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_filterable_attributes");
     ///
@@ -611,7 +611,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("set_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_sortable_attributes");
     ///
@@ -648,7 +648,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("set_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_distinct_attribute");
     ///
@@ -679,7 +679,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("set_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_searchable_attributes");
     ///
@@ -715,7 +715,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("set_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_displayed_attributes");
     ///
@@ -752,7 +752,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("reset_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_settings");
     ///
@@ -777,7 +777,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("reset_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_synonyms");
     ///
@@ -805,7 +805,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("reset_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_stop_words");
     ///
@@ -834,7 +834,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", SSome(String::from("masterKey")));
     /// # client.create_index("reset_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_ranking_rules");
     ///
@@ -862,7 +862,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("reset_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_filterable_attributes");
     ///
@@ -890,7 +890,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-   /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+   /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("reset_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_sortable_attributes");
     ///
@@ -918,7 +918,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("reset_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_distinct_attribute");
     ///
@@ -946,7 +946,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("reset_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_searchable_attributes");
     ///
@@ -974,7 +974,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("reset_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_displayed_attributes");
     ///

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -201,7 +201,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("get_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_settings");
     /// let settings = index.get_settings().await.unwrap();
@@ -223,7 +223,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("get_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_synonyms");
     /// let synonyms = index.get_synonyms().await.unwrap();
@@ -248,7 +248,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("get_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_stop_words");
     /// let stop_words = index.get_stop_words().await.unwrap();
@@ -273,7 +273,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("get_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_ranking_rules");
     /// let ranking_rules = index.get_ranking_rules().await.unwrap();
@@ -298,7 +298,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("get_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_filterable_attributes");
     /// let filterable_attributes = index.get_filterable_attributes().await.unwrap();
@@ -348,7 +348,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("get_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_distinct_attribute");
     /// let distinct_attribute = index.get_distinct_attribute().await.unwrap();
@@ -373,7 +373,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("get_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_searchable_attributes");
     /// let searchable_attributes = index.get_searchable_attributes().await.unwrap();
@@ -398,7 +398,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("get_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_displayed_attributes");
     /// let displayed_attributes = index.get_displayed_attributes().await.unwrap();
@@ -455,7 +455,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("set_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_synonyms");
     ///
@@ -491,7 +491,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("set_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_stop_words");
     ///
@@ -528,7 +528,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("set_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_ranking_rules");
     ///
@@ -574,7 +574,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("set_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_filterable_attributes");
     ///
@@ -611,7 +611,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("set_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_sortable_attributes");
     ///
@@ -648,7 +648,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("set_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_distinct_attribute");
     ///
@@ -679,7 +679,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("set_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_searchable_attributes");
     ///
@@ -715,7 +715,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("set_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_displayed_attributes");
     ///
@@ -752,7 +752,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("reset_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_settings");
     ///
@@ -777,7 +777,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("reset_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_synonyms");
     ///
@@ -805,7 +805,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("reset_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_stop_words");
     ///
@@ -834,7 +834,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("reset_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_ranking_rules");
     ///
@@ -862,7 +862,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("reset_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_filterable_attributes");
     ///
@@ -890,7 +890,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("reset_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_sortable_attributes");
     ///
@@ -918,7 +918,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("reset_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_distinct_attribute");
     ///
@@ -946,7 +946,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("reset_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_searchable_attributes");
     ///
@@ -974,7 +974,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # client.create_index("reset_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_displayed_attributes");
     ///

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -223,7 +223,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("get_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_synonyms");
     /// let synonyms = index.get_synonyms().await.unwrap();
@@ -248,7 +248,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("get_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_stop_words");
     /// let stop_words = index.get_stop_words().await.unwrap();
@@ -273,7 +273,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("get_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_ranking_rules");
     /// let ranking_rules = index.get_ranking_rules().await.unwrap();
@@ -298,7 +298,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("get_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_filterable_attributes");
     /// let filterable_attributes = index.get_filterable_attributes().await.unwrap();
@@ -323,7 +323,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("get_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_sortable_attributes");
     /// let sortable_attributes = index.get_sortable_attributes().await.unwrap();
@@ -348,7 +348,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("get_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_distinct_attribute");
     /// let distinct_attribute = index.get_distinct_attribute().await.unwrap();
@@ -373,7 +373,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("get_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_searchable_attributes");
     /// let searchable_attributes = index.get_searchable_attributes().await.unwrap();
@@ -398,7 +398,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("get_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_displayed_attributes");
     /// let displayed_attributes = index.get_displayed_attributes().await.unwrap();
@@ -426,7 +426,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("set_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_settings");
     ///
@@ -455,7 +455,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("set_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_synonyms");
     ///
@@ -491,7 +491,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("set_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_stop_words");
     ///
@@ -528,7 +528,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("set_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_ranking_rules");
     ///
@@ -574,7 +574,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("set_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_filterable_attributes");
     ///
@@ -611,7 +611,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("set_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_sortable_attributes");
     ///
@@ -648,7 +648,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("set_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_distinct_attribute");
     ///
@@ -679,7 +679,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("set_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_searchable_attributes");
     ///
@@ -715,7 +715,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("set_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_displayed_attributes");
     ///
@@ -752,7 +752,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("reset_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_settings");
     ///
@@ -777,7 +777,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("reset_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_synonyms");
     ///
@@ -805,7 +805,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("reset_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_stop_words");
     ///
@@ -834,7 +834,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("reset_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_ranking_rules");
     ///
@@ -862,7 +862,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("reset_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_filterable_attributes");
     ///
@@ -890,7 +890,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+   /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("reset_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_sortable_attributes");
     ///
@@ -918,7 +918,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("reset_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_distinct_attribute");
     ///
@@ -946,7 +946,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("reset_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_searchable_attributes");
     ///
@@ -974,7 +974,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # client.create_index("reset_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_displayed_attributes");
     ///

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -223,7 +223,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", SSome(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_synonyms");
     /// let synonyms = index.get_synonyms().await.unwrap();
@@ -298,7 +298,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = ("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_filterable_attributes");
     /// let filterable_attributes = index.get_filterable_attributes().await.unwrap();
@@ -398,7 +398,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = ("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("get_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_displayed_attributes");
     /// let displayed_attributes = index.get_displayed_attributes().await.unwrap();
@@ -834,7 +834,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", SSome(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # client.create_index("reset_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_ranking_rules");
     ///

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -211,7 +211,7 @@ impl Index {
     pub async fn get_settings(&self) -> Result<Settings, Error> {
         request::<(), Settings>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -236,7 +236,7 @@ impl Index {
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -261,7 +261,7 @@ impl Index {
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -286,7 +286,7 @@ impl Index {
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -311,7 +311,7 @@ impl Index {
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -336,7 +336,7 @@ impl Index {
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -361,7 +361,7 @@ impl Index {
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -386,7 +386,7 @@ impl Index {
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -411,7 +411,7 @@ impl Index {
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Get,
             200,
         )
@@ -441,7 +441,7 @@ impl Index {
     pub async fn set_settings(&self, settings: &Settings) -> Result<Task, Error> {
         request::<&Settings, Task>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(settings),
             202,
         )
@@ -477,7 +477,7 @@ impl Index {
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(synonyms),
             202,
         )
@@ -509,7 +509,7 @@ impl Index {
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(
                 stop_words
                     .into_iter()
@@ -555,7 +555,7 @@ impl Index {
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(
                 ranking_rules
                     .into_iter()
@@ -592,7 +592,7 @@ impl Index {
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(
                 filterable_attributes
                     .into_iter()
@@ -629,7 +629,7 @@ impl Index {
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(
                 sortable_attributes
                     .into_iter()
@@ -665,7 +665,7 @@ impl Index {
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(distinct_attribute.as_ref().to_string()),
             202,
         )
@@ -696,7 +696,7 @@ impl Index {
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(
                 searchable_attributes
                     .into_iter()
@@ -732,7 +732,7 @@ impl Index {
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Post(
                 displayed_attributes
                     .into_iter()
@@ -763,7 +763,7 @@ impl Index {
     pub async fn reset_settings(&self) -> Result<Task, Error> {
         request::<(), Task>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -791,7 +791,7 @@ impl Index {
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -819,7 +819,7 @@ impl Index {
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -848,7 +848,7 @@ impl Index {
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -876,7 +876,7 @@ impl Index {
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -890,7 +890,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-   /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_sortable_attributes");
     ///
@@ -904,7 +904,7 @@ impl Index {
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -932,7 +932,7 @@ impl Index {
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -960,7 +960,7 @@ impl Index {
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )
@@ -988,7 +988,7 @@ impl Index {
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.api_key,
             Method::Delete,
             202,
         )

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -201,7 +201,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("get_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_settings");
     /// let settings = index.get_settings().await.unwrap();
@@ -223,7 +223,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("get_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_synonyms");
     /// let synonyms = index.get_synonyms().await.unwrap();
@@ -248,7 +248,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("get_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_stop_words");
     /// let stop_words = index.get_stop_words().await.unwrap();
@@ -273,7 +273,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("get_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_ranking_rules");
     /// let ranking_rules = index.get_ranking_rules().await.unwrap();
@@ -298,7 +298,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("get_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_filterable_attributes");
     /// let filterable_attributes = index.get_filterable_attributes().await.unwrap();
@@ -348,7 +348,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("get_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_distinct_attribute");
     /// let distinct_attribute = index.get_distinct_attribute().await.unwrap();
@@ -373,7 +373,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("get_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_searchable_attributes");
     /// let searchable_attributes = index.get_searchable_attributes().await.unwrap();
@@ -398,7 +398,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("get_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_displayed_attributes");
     /// let displayed_attributes = index.get_displayed_attributes().await.unwrap();
@@ -455,7 +455,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("set_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_synonyms");
     ///
@@ -491,7 +491,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("set_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_stop_words");
     ///
@@ -528,7 +528,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("set_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_ranking_rules");
     ///
@@ -574,7 +574,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("set_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_filterable_attributes");
     ///
@@ -611,7 +611,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("set_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_sortable_attributes");
     ///
@@ -648,7 +648,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("set_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_distinct_attribute");
     ///
@@ -679,7 +679,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("set_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_searchable_attributes");
     ///
@@ -715,7 +715,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("set_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_displayed_attributes");
     ///
@@ -752,7 +752,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_settings");
     ///
@@ -777,7 +777,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_synonyms");
     ///
@@ -805,7 +805,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_stop_words");
     ///
@@ -834,7 +834,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_ranking_rules");
     ///
@@ -862,7 +862,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_filterable_attributes");
     ///
@@ -890,7 +890,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-   /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+   /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_sortable_attributes");
     ///
@@ -918,7 +918,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_distinct_attribute");
     ///
@@ -946,7 +946,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_searchable_attributes");
     ///
@@ -974,7 +974,7 @@ impl Index {
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # client.create_index("reset_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_displayed_attributes");
     ///

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -168,7 +168,7 @@ impl Task {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey")); 
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey"))); 
     /// let movies = client.index("movies_wait_for_completion");
     ///
     /// let status = movies.add_documents(&[
@@ -205,7 +205,7 @@ impl Task {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     ///
     /// let task = client.create_index("try_make_index", None).await.unwrap();
     /// let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
@@ -239,7 +239,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let task = client.create_index("unwrap_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -276,7 +276,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// # let task = client.create_index("is_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -303,7 +303,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let task = client
     ///   .create_index("is_success", None)
     ///   .await
@@ -327,7 +327,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
     /// let task = client
     ///   .create_index("is_pending", None)
     ///   .await

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -168,7 +168,7 @@ impl Task {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string())); 
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let movies = client.index("movies_wait_for_completion");
     ///
     /// let status = movies.add_documents(&[

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -168,7 +168,7 @@ impl Task {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let movies = client.index("movies_wait_for_completion");
     ///
     /// let status = movies.add_documents(&[
@@ -205,7 +205,7 @@ impl Task {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     ///
     /// let task = client.create_index("try_make_index", None).await.unwrap();
     /// let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
@@ -239,7 +239,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let task = client.create_index("unwrap_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -276,7 +276,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// # let task = client.create_index("is_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -303,7 +303,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let task = client
     ///   .create_index("is_success", None)
     ///   .await
@@ -327,7 +327,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
+    /// let client = Client::new("http://localhost:7700", some("masterKey"));
     /// let task = client
     ///   .create_index("is_pending", None)
     ///   .await

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -168,7 +168,7 @@ impl Task {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey"))); 
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string())); 
     /// let movies = client.index("movies_wait_for_completion");
     ///
     /// let status = movies.add_documents(&[
@@ -205,7 +205,7 @@ impl Task {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     ///
     /// let task = client.create_index("try_make_index", None).await.unwrap();
     /// let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
@@ -239,7 +239,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let task = client.create_index("unwrap_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -276,7 +276,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// # let task = client.create_index("is_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -303,7 +303,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let task = client
     ///   .create_index("is_success", None)
     ///   .await
@@ -327,7 +327,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", Some(String::from("masterKey")));
+    /// let client = Client::new("http://localhost:7700", Some("masterKey".to_string()));
     /// let task = client
     ///   .create_index("is_pending", None)
     ///   .await

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -168,7 +168,7 @@ impl Task {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey")); 
     /// let movies = client.index("movies_wait_for_completion");
     ///
     /// let status = movies.add_documents(&[
@@ -205,7 +205,7 @@ impl Task {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     ///
     /// let task = client.create_index("try_make_index", None).await.unwrap();
     /// let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
@@ -239,7 +239,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let task = client.create_index("unwrap_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -276,7 +276,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// # let task = client.create_index("is_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
@@ -303,7 +303,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let task = client
     ///   .create_index("is_success", None)
     ///   .await
@@ -327,7 +327,7 @@ impl Task {
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let task = client
     ///   .create_index("is_pending", None)
     ///   .await

--- a/src/tenant_tokens.rs
+++ b/src/tenant_tokens.rs
@@ -16,6 +16,7 @@ struct TenantTokenClaim {
 }
 
 pub fn generate_tenant_token(search_rules: Value, api_key: impl AsRef<str>, expires_at: Option<OffsetDateTime>) -> Result<String, Error> {
+    
     if api_key.as_ref().chars().count() < 8 {
         return Err(Error::TenantTokensInvalidApiKey)
     }


### PR DESCRIPTION
# Pull Request

This is a redo of a previous pull request draft. I have failing tests, I can't tell if its me or the branch, as the **tests fail even after a clean fork of the main branch**

## What does this PR do?
This PR takes care of issue #240, creating a client without an api key. In this PR, the ```api_key``` field is changed from a ```String``` to an ```Option<String>```.

Fixes #240
[issue](https://github.com/meilisearch/meilisearch-rust/issues/240)

## Note
- I believe my implementation of the ```generate_tenant_token``` function in the ```client.rs``` file to be wrong in this implementation.

- Current error in vs code now has an issue with  the test attribute macro ```#[meilisearch_test]```. The error reads :
                            ```
                            expected Option<{unknown}>, found &str
                            ```
        I'm unsure why this would be.

I'm opening this up for review, the code is done. I don't know what to do about the tests as clean forks of the code still have the failing tests. At least for me