### PR TITLE
Update task api for v0.28.0

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -55,13 +55,13 @@ search_post_1: |-
     .await
     .unwrap();
 get_task_by_index_1: |-
-  let task: TaskInfo = client.index("movies").get_task(1).await.unwrap();
+  let task: Task = client.index("movies").get_task(1).await.unwrap();
 get_all_tasks_by_index_1: |-
   let tasks: TasksResults = client.index("movies").get_tasks().await.unwrap();
 get_all_tasks_1: |-
   let tasks: TasksResults = client.get_tasks().await.unwrap();
 get_task_1: |-
-  let task: TaskInfo = client.get_task(1).await.unwrap();
+  let task: Task = client.get_task(1).await.unwrap();
 get_settings_1: |-
   let settings: Settings = client.index("movies").get_settings().await.unwrap();
 update_settings_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -330,7 +330,7 @@ settings_guide_stop_words_1: |-
       "an"
     ]);
 
-  let task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_filterable_attributes_1: |-
   let settings = Settings::new()
     .with_filterable_attributes([
@@ -352,7 +352,7 @@ settings_guide_ranking_rules_1: |-
       "rank:desc",
     ]);
 
-  let task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_distinct_1: |-
   let settings = Settings::new()
     .with_distinct_attribute("product_id");

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -18,7 +18,7 @@ get_one_document_1: |-
 get_documents_1: |-
   let documents: Vec<Movie> = client.index("movies").get_documents(None, Some(2), None).await.unwrap();
 add_or_replace_documents_1: |-
-  let task: Task = client.index("movies").add_or_replace(&[
+  let task: TaskInfo = client.index("movies").add_or_replace(&[
     Movie {
       id: 287947,
       title: "Shazam".to_string(),
@@ -35,18 +35,18 @@ add_or_update_documents_1: |-
     title: String
   }
 
-  let task: Task = client.index("movies").add_or_update(&[
+  let task: TaskInfo = client.index("movies").add_or_update(&[
     IncompleteMovie {
       id: 287947,
       title: "Shazam ⚡️".to_string()
     }
   ], None).await.unwrap();
 delete_all_documents_1: |-
-  let task: Task = client.index("movies").delete_all_documents().await.unwrap();
+  let task: TaskInfo = client.index("movies").delete_all_documents().await.unwrap();
 delete_one_document_1: |-
-  let task: Task = client.index("movies").delete_document(25684).await.unwrap();
+  let task: TaskInfo = client.index("movies").delete_document(25684).await.unwrap();
 delete_documents_1: |-
-  let task: Task = client.index("movies").delete_documents(&[23488, 153738, 437035, 363869]).await.unwrap();
+  let task: TaskInfo = client.index("movies").delete_documents(&[23488, 153738, 437035, 363869]).await.unwrap();
 search_post_1: |-
   let results: SearchResults<Movie> = client.index("movies")
     .search()
@@ -55,13 +55,13 @@ search_post_1: |-
     .await
     .unwrap();
 get_task_by_index_1: |-
-  let task: Task = client.index("movies").get_task(1).await.unwrap();
+  let task: TaskInfo = client.index("movies").get_task(1).await.unwrap();
 get_all_tasks_by_index_1: |-
-  let tasks: Vec<Task> = client.index("movies").get_tasks().await.unwrap();
+  let tasks: TasksResults = client.index("movies").get_tasks().await.unwrap();
 get_all_tasks_1: |-
-  let tasks: Vec<Task> = client.get_tasks().await.unwrap();
+  let tasks: TasksResults = client.get_tasks().await.unwrap();
 get_task_1: |-
-  let task: Task = client.get_task(1).await.unwrap();
+  let task: TaskInfo = client.get_task(1).await.unwrap();
 get_settings_1: |-
   let settings: Settings = client.index("movies").get_settings().await.unwrap();
 update_settings_1: |-
@@ -103,9 +103,9 @@ update_settings_1: |-
     ])
     .with_synonyms(synonyms);
 
-  let task: Task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 reset_settings_1: |-
-  let task: Task = client.index("movies").reset_settings().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_settings().await.unwrap();
 get_synonyms_1: |-
   let synonyms: HashMap<String, Vec<String>> = client.index("movies").get_synonyms().await.unwrap();
 update_synonyms_1: |-
@@ -114,16 +114,16 @@ update_synonyms_1: |-
   synonyms.insert(String::from("logan"), vec![String::from("xmen"), String::from("wolverine")]);
   synonyms.insert(String::from("wow"), vec![String::from("world of warcraft")]);
 
-  let task: Task = client.index("movies").set_synonyms(&synonyms).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_synonyms(&synonyms).await.unwrap();
 reset_synonyms_1: |-
-  let task: Task = client.index("movies").reset_synonyms().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_synonyms().await.unwrap();
 get_stop_words_1: |-
   let stop_words: Vec<String> = client.index("movies").get_stop_words().await.unwrap();
 update_stop_words_1: |-
   let stop_words = ["of", "the", "to"];
-  let task: Task = client.index("movies").set_stop_words(&stop_words).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_stop_words(&stop_words).await.unwrap();
 reset_stop_words_1: |-
-  let task: Task = client.index("movies").reset_stop_words().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_stop_words().await.unwrap();
 get_ranking_rules_1: |-
   let ranking_rules: Vec<String> = client.index("movies").get_ranking_rules().await.unwrap();
 update_ranking_rules_1: |-
@@ -138,15 +138,15 @@ update_ranking_rules_1: |-
     "rank:desc",
   ];
 
-  let task: Task = client.index("movies").set_ranking_rules(&ranking_rules).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_ranking_rules(&ranking_rules).await.unwrap();
 reset_ranking_rules_1: |-
-  let task: Task = client.index("movies").reset_ranking_rules().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_ranking_rules().await.unwrap();
 get_distinct_attribute_1: |-
   let distinct_attribute: Option<String> = client.index("shoes").get_distinct_attribute().await.unwrap();
 update_distinct_attribute_1: |-
-  let task: Task = client.index("shoes").set_distinct_attribute("skuid").await.unwrap();
+  let task: TaskInfo = client.index("shoes").set_distinct_attribute("skuid").await.unwrap();
 reset_distinct_attribute_1: |-
-  let task: Task = client.index("shoes").reset_distinct_attribute().await.unwrap();
+  let task: TaskInfo = client.index("shoes").reset_distinct_attribute().await.unwrap();
 get_searchable_attributes_1: |-
   let searchable_attributes: Vec<String> = client.index("movies").get_searchable_attributes().await.unwrap();
 update_searchable_attributes_1: |-
@@ -156,9 +156,9 @@ update_searchable_attributes_1: |-
     "genres"
   ];
 
-  let task: Task = client.index("movies").set_searchable_attributes(&searchable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_searchable_attributes(&searchable_attributes).await.unwrap();
 reset_searchable_attributes_1: |-
-  let task: Task = client.index("movies").reset_searchable_attributes().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_searchable_attributes().await.unwrap();
 get_filterable_attributes_1: |-
   let filterable_attributes: Vec<String> = client.index("movies").get_filterable_attributes().await.unwrap();
 update_filterable_attributes_1: |-
@@ -167,9 +167,9 @@ update_filterable_attributes_1: |-
     "director"
   ];
 
-  let task: Task = client.index("movies").set_filterable_attributes(&filterable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_filterable_attributes(&filterable_attributes).await.unwrap();
 reset_filterable_attributes_1: |-
-  let task: Task = client.index("movies").reset_filterable_attributes().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_filterable_attributes().await.unwrap();
 get_displayed_attributes_1: |-
   let displayed_attributes: Vec<String> = client.index("movies").get_displayed_attributes().await.unwrap();
 update_displayed_attributes_1: |-
@@ -180,9 +180,9 @@ update_displayed_attributes_1: |-
     "release_date"
   ];
 
-  let task: Task = client.index("movies").set_displayed_attributes(&displayed_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_displayed_attributes(&displayed_attributes).await.unwrap();
 reset_displayed_attributes_1: |-
-  let task: Task = client.index("movies").reset_displayed_attributes().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_displayed_attributes().await.unwrap();
 get_index_stats_1: |-
   let stats: IndexStats = client.index("movies").get_stats().await.unwrap();
 get_indexes_stats_1: |-
@@ -193,7 +193,7 @@ get_health_1: |-
 get_version_1: |-
   let version: Version = client.get_version().await.unwrap();
 distinct_attribute_guide_1: |-
-  let task: Task = client.index("jackets").set_distinct_attribute("product_id").await.unwrap();
+  let task: TaskInfo = client.index("jackets").set_distinct_attribute("product_id").await.unwrap();
 field_properties_guide_searchable_1: |-
   let searchable_attributes = [
     "title",
@@ -201,7 +201,7 @@ field_properties_guide_searchable_1: |-
     "genres"
   ];
 
-  let task: Task = client.index("movies").set_searchable_attributes(&searchable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_searchable_attributes(&searchable_attributes).await.unwrap();
 field_properties_guide_displayed_1: |-
   let displayed_attributes = [
     "title",
@@ -210,7 +210,7 @@ field_properties_guide_displayed_1: |-
     "release_date"
   ];
 
-  let task: Task = client.index("movies").set_displayed_attributes(&displayed_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_displayed_attributes(&displayed_attributes).await.unwrap();
 filtering_guide_1: |-
   let results: SearchResults<Movie> = client.index("movies").search()
     .with_query("Avengers")
@@ -338,7 +338,7 @@ settings_guide_filterable_attributes_1: |-
       "genres"
     ]);
 
-  let task: Task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_ranking_rules_1: |-
   let settings = Settings::new()
     .with_ranking_rules([
@@ -357,7 +357,7 @@ settings_guide_distinct_1: |-
   let settings = Settings::new()
     .with_distinct_attribute("product_id");
 
-  let task: Task = client.index("jackets").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("jackets").set_settings(&settings).await.unwrap();
 settings_guide_searchable_1: |-
   let settings = Settings::new()
     .with_searchable_attributes([
@@ -366,7 +366,7 @@ settings_guide_searchable_1: |-
       "genres"
     ]);
 
-  let task: Task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_displayed_1: |-
   let settings = Settings::new()
     .with_displayed_attributes([
@@ -376,7 +376,7 @@ settings_guide_displayed_1: |-
       "release_date"
     ]);
 
-  let task: Task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_sortable_1: |-
   let settings = Settings::new()
     .with_sortable_attributes([
@@ -384,7 +384,7 @@ settings_guide_sortable_1: |-
       "price"
     ]);
 
-  let task: Task = client.index("books").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("books").set_settings(&settings).await.unwrap();
 add_movies_json_1: |-
   use meilisearch_sdk::{
     indexes::*,
@@ -417,7 +417,7 @@ documents_guide_add_movie_1: |-
   }
 
   // Add a document to our index
-  let task: Task = client.index("movies").add_documents(&[
+  let task: TaskInfo = client.index("movies").add_documents(&[
     IncompleteMovie {
       id: "123sq178".to_string(),
       title: "Amélie Poulain".to_string(),
@@ -437,7 +437,7 @@ primary_field_guide_add_document_primary_key: |-
     price: f64
   }
 
-  let task: Task = client.index("books").add_documents(&[
+  let task: TaskInfo = client.index("books").add_documents(&[
     Book {
       reference_number: "287947".to_string(),
       title: "Diary of a Wimpy Kid".to_string(),
@@ -616,7 +616,7 @@ getting_started_configure_settings: |-
       "mass",
       "_geo"
     ])
-  let task: Task = client.index("meteorites").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("meteorites").set_settings(&settings).await.unwrap();
 getting_started_geo_radius: |-
   let results: SearchResults<Meteorite> = client.index("meteorites").search()
     .with_filter("_geoRadius(46.9480, 7.4474, 210000)")
@@ -643,7 +643,7 @@ getting_started_filtering: |-
     .await
     .unwrap();
 faceted_search_update_settings_1: |-
-  let task: Task = client.index("movies").set_filterable_attributes(["director", "genres"]).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_filterable_attributes(["director", "genres"]).await.unwrap();
 faceted_search_filter_1: |-
   let results: SearchResults<Movie> = client.index("movies").search()
     .with_query("thriller")
@@ -683,7 +683,7 @@ sorting_guide_update_sortable_attributes_1: |-
     "price"
   ];
 
-  let task: Task = client.index("books").set_sortable_attributes(&sortable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("books").set_sortable_attributes(&sortable_attributes).await.unwrap();
 sorting_guide_update_ranking_rules_1: |-
   let ranking_rules = [
     "words",
@@ -694,7 +694,7 @@ sorting_guide_update_ranking_rules_1: |-
     "exactness"
   ];
 
-  let task: Task = client.index("books").set_ranking_rules(&ranking_rules).await.unwrap();
+  let task: TaskInfo = client.index("books").set_ranking_rules(&ranking_rules).await.unwrap();
 sorting_guide_sort_parameter_1: |-
   let results: SearchResults<Books> = client.index("books").search()
     .with_query("science fiction")
@@ -717,9 +717,9 @@ update_sortable_attributes_1: |-
     "author"
   ];
 
-  let task: Task = client.index("books").set_sortable_attributes(&sortable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("books").set_sortable_attributes(&sortable_attributes).await.unwrap();
 reset_sortable_attributes_1: |-
-  let task: Task = client.index("books").reset_sortable_attributes().await.unwrap();
+  let task: TaskInfo = client.index("books").reset_sortable_attributes().await.unwrap();
 search_parameter_guide_sort_1: |-
   let results: SearchResults<Books> = client.index("books").search()
     .with_query("science fiction")
@@ -728,7 +728,7 @@ search_parameter_guide_sort_1: |-
     .await
     .unwrap();
 geosearch_guide_filter_settings_1: |-
-  let task: Task = client.index("restaurants").set_filterable_attributes(&["_geo"]).await.unwrap();
+  let task: TaskInfo = client.index("restaurants").set_filterable_attributes(&["_geo"]).await.unwrap();
 geosearch_guide_filter_usage_1: |-
   let results: SearchResults<Restaurant> = client.index("restaurants").search()
     .with_filter("_geoRadius(45.472735, 9.184019, 2000)")
@@ -742,7 +742,7 @@ geosearch_guide_filter_usage_2: |-
     .await
     .unwrap();
 geosearch_guide_sort_settings_1: |-
-  let task: Task = client.index("restaurants").set_sortable_attributes(&["_geo"]).await.unwrap();
+  let task: TaskInfo = client.index("restaurants").set_sortable_attributes(&["_geo"]).await.unwrap();
 geosearch_guide_sort_usage_1: |-
   let results: SearchResults<Restaurant> = client.index("restaurants").search()
     .with_sort(&["_geoPoint(48.8561446, 2.2978204):asc"])

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -25,7 +25,7 @@ async fn test_get_tasks() -> Result<(), Error> {
 
   let tasks = index.get_tasks().await?;
   // The only task is the creation of the index
-  assert_eq!(status.len(), 1);
+  assert_eq!(status.results.len(), 1);
 
   index.delete()
     .await?
@@ -52,7 +52,7 @@ With this macro, all these problems are solved. See a rewrite of this test:
 async fn test_get_tasks(index: Index, client: Client) -> Result<(), Error> {
   let tasks = index.get_tasks().await?;
   // The only task is the creation of the index
-  assert_eq!(status.len(), 1);
+  assert_eq!(status.results.len(), 1);
 }
 ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -608,7 +608,7 @@ impl Client {
         .await
     }
 
-    /// Get all tasks from the server.
+    /// Get all tasks with query parameters from the server.
     ///
     /// # Example
     ///
@@ -622,18 +622,52 @@ impl Client {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     ///
     /// let mut query = tasks::TasksQuery::new(&client);
-    /// query.with_index_uid(["get_tasks"]);
-    /// let tasks = client.get_tasks(&query).await.unwrap();
+    /// query.with_index_uid(["get_tasks_with"]);
+    /// let tasks = client.get_tasks_with(&query).await.unwrap();
+    ///
+    /// assert!(tasks.results.len() > 0);
+    /// # client.index("get_tasks_with").delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn get_tasks_with(
+        &self,
+        tasks_query: &TasksQuery<'_>,
+    ) -> Result<TasksResults, Error> {
+        let tasks = request::<&TasksQuery, TasksResults>(
+            &format!("{}/tasks", self.host),
+            &self.api_key,
+            Method::Get(tasks_query),
+            200,
+        )
+        .await?;
+
+        Ok(tasks)
+    }
+
+    /// Get all tasks from the server.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::*;
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///
+    /// let tasks = client.get_tasks().await.unwrap();
     ///
     /// assert!(tasks.results.len() > 0);
     /// # client.index("get_tasks").delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn get_tasks(&self, tasks_query: &TasksQuery<'_>) -> Result<TasksResults, Error> {
-        let tasks = request::<&TasksQuery, TasksResults>(
+    pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
+        let tasks = request::<(), TasksResults>(
             &format!("{}/tasks", self.host),
             &self.api_key,
-            Method::Get(tasks_query),
+            Method::Get(()),
             200,
         )
         .await?;
@@ -774,8 +808,14 @@ mod tests {
 
     #[meilisearch_test]
     async fn test_get_tasks(client: Client) {
+        let tasks = client.get_tasks().await.unwrap();
+        assert!(tasks.results.len() >= 2);
+    }
+
+    #[meilisearch_test]
+    async fn test_get_tasks_with_params(client: Client) {
         let query = TasksQuery::new(&client);
-        let tasks = client.get_tasks(&query).await.unwrap();
+        let tasks = client.get_tasks_with(&query).await.unwrap();
         assert!(tasks.results.len() >= 2);
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use crate::{
     key::{Key, KeyBuilder},
     request::*,
     task_info::TaskInfo,
-    tasks::*,
+    tasks::{Task, TasksQuery, TasksResults},
     utils::async_sleep,
 };
 use serde::Deserialize;
@@ -621,13 +621,12 @@ impl Client {
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     ///
-    /// let query = TasksQuery::new();
-    /// query.with_index_uid(["get_tasks"])
+    /// let mut query = tasks::TasksQuery::new(&client);
+    /// query.with_index_uid(["get_tasks"]);
     /// let tasks = client.get_tasks(&query).await.unwrap();
     ///
     /// assert!(tasks.results.len() > 0);
-    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
-    /// # });
+    /// # client.index("get_tasks").delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
     pub async fn get_tasks(&self, tasks_query: &TasksQuery<'_>) -> Result<TasksResults, Error> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -621,21 +621,16 @@ impl Client {
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     ///
-    /// let tasks = client.get_tasks().with_index_uid(["get_tasks"]).execute().await.unwrap();
+    /// let query = TasksQuery::new();
+    /// query.with_index_uid(["get_tasks"])
+    /// let tasks = client.get_tasks(&query).await.unwrap();
     ///
     /// assert!(tasks.results.len() > 0);
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// # });
     /// ```
-    pub fn get_tasks(&self) -> TasksQuery {
-        TasksQuery::new(self)
-    }
-
-    pub(crate) async fn execute_get_tasks(
-        &self,
-        tasks_query: &TasksQuery<'_>,
-    ) -> Result<TasksResults, Error> {
+    pub async fn get_tasks(&self, tasks_query: &TasksQuery<'_>) -> Result<TasksResults, Error> {
         let tasks = request::<&TasksQuery, TasksResults>(
             &format!("{}/tasks", self.host),
             &self.api_key,
@@ -780,7 +775,8 @@ mod tests {
 
     #[meilisearch_test]
     async fn test_get_tasks(client: Client) {
-        let tasks = client.get_tasks().execute().await.unwrap();
+        let query = TasksQuery::new(&client);
+        let tasks = client.get_tasks(&query).await.unwrap();
         assert!(tasks.results.len() >= 2);
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -428,10 +428,23 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
+    ///
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// let mut key = KeyBuilder::new("create_key");
     /// key.with_index("*").with_action(Action::DocumentsAdd);
     /// let key = client.create_key(key).await.unwrap();
+    /// # // Method 2
+    /// let key = client.create_key("create_key")
+    ///     .with_index("*")
+    ///     .with_action(Action::DocumentsAdd)
+    ///     .execute()
+    ///     .await.unwrap();
+    /// # // Method 3
+    /// let key = KeyBuilder::new("My little lovely test key")
+    ///   .create(&client).await.unwrap();
+    ///
+    ///
+    ///
     /// assert_eq!(key.description, "create_key");
     /// # client.delete_key(key).await.unwrap();
     /// # });
@@ -619,11 +632,21 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    /// let tasks = client.get_tasks().await.unwrap();
+    ///
+    /// let tasks = TasksQueryBuilder::new().with_index_uid(["movies"]).execute(&client).execute();
+    ///
+    /// let tasks = client
+    ///     .get_tasks()
+    ///     .with_index_uid(["movies"])
+    ///     .execute()
+    ///     .await.unwrap();
+    ///
+    ///
+    /// let tasks = client.get_task().await.unwrap();
     /// dbg!(&tasks);
     /// # });
     /// ```
-    pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
+    pub async fn get_tasks(&self, tasks_query: TasksQuery) -> Result<TasksResults, Error> {
         let tasks = request::<(), TasksResults>(
             &format!("{}/tasks", self.host),
             &self.api_key,

--- a/src/client.rs
+++ b/src/client.rs
@@ -428,11 +428,11 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    ///
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// let mut key = KeyBuilder::new("create_key");
     /// key.with_index("*").with_action(Action::DocumentsAdd);
     /// let key = client.create_key(key).await.unwrap();
+    ///
     /// assert_eq!(key.description, "create_key");
     /// # client.delete_key(key).await.unwrap();
     /// # });
@@ -620,12 +620,11 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
     /// let mut query = tasks::TasksQuery::new(&client);
     /// query.with_index_uid(["get_tasks_with"]);
     /// let tasks = client.get_tasks_with(&query).await.unwrap();
     ///
-    /// assert!(tasks.results.len() > 0);
+    /// # assert!(tasks.results.len() > 0);
     /// # client.index("get_tasks_with").delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
@@ -656,10 +655,9 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
     /// let tasks = client.get_tasks().await.unwrap();
     ///
-    /// assert!(tasks.results.len() > 0);
+    /// # assert!(tasks.results.len() > 0);
     /// # client.index("get_tasks").delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -621,10 +621,11 @@ impl Client {
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     ///
+    /// let tasks = client.get_tasks().with_index_uid(["get_tasks"]).execute().await.unwrap();
     ///
-    ///
-    ///
-    /// let tasks = client.get_tasks().with_index_uid(&["get_tasks"]).execute().await.unwrap();
+    /// assert!(tasks.results.len() > 0);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
     /// # });
     /// ```
     pub fn get_tasks(&self) -> TasksQuery {

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,9 @@ use crate::{
     indexes::*,
     key::{Key, KeyBuilder},
     request::*,
-    tasks::{async_sleep, Task},
+    task_info::TaskInfo,
+    tasks::*,
+    utils::async_sleep,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -197,8 +199,8 @@ impl Client {
         &self,
         uid: impl AsRef<str>,
         primary_key: Option<&str>,
-    ) -> Result<Task, Error> {
-        request::<Value, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Value, TaskInfo>(
             &format!("{}/indexes", self.host),
             &self.api_key,
             Method::Post(json!({
@@ -212,8 +214,8 @@ impl Client {
 
     /// Delete an index from its UID.
     /// To delete an [Index], use the [Index::delete] method.
-    pub async fn delete_index(&self, uid: impl AsRef<str>) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn delete_index(&self, uid: impl AsRef<str>) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!("{}/indexes/{}", self.host, uid.as_ref()),
             &self.api_key,
             Method::Delete,
@@ -511,7 +513,7 @@ impl Client {
     ///
     /// If the waited time exceeds `timeout` then an [Error::Timeout] will be returned.
     ///
-    /// See also [Index::wait_for_task, Task::wait_for_completion].
+    /// See also [Index::wait_for_task, Task::wait_for_completion, TaskInfo::wait_for_completion].
     ///
     /// # Example
     ///
@@ -548,7 +550,7 @@ impl Client {
     /// ```
     pub async fn wait_for_task(
         &self,
-        task_id: impl AsRef<u64>,
+        task_id: impl AsRef<u32>,
         interval: Option<Duration>,
         timeout: Option<Duration>,
     ) -> Result<Task, Error> {
@@ -560,7 +562,6 @@ impl Client {
 
         while timeout > elapsed_time {
             task_result = self.get_task(&task_id).await;
-
             match task_result {
                 Ok(status) => match status {
                     Task::Failed { .. } | Task::Succeeded { .. } => {
@@ -596,7 +597,7 @@ impl Client {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn get_task(&self, task_id: impl AsRef<u64>) -> Result<Task, Error> {
+    pub async fn get_task(&self, task_id: impl AsRef<u32>) -> Result<Task, Error> {
         request::<(), Task>(
             &format!("{}/tasks/{}", self.host, task_id.as_ref()),
             &self.api_key,
@@ -619,15 +620,11 @@ impl Client {
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// let tasks = client.get_tasks().await.unwrap();
+    /// dbg!(&tasks);
     /// # });
     /// ```
-    pub async fn get_tasks(&self) -> Result<Vec<Task>, Error> {
-        #[derive(Deserialize)]
-        struct Tasks {
-            pub results: Vec<Task>,
-        }
-
-        let tasks = request::<(), Tasks>(
+    pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
+        let tasks = request::<(), TasksResults>(
             &format!("{}/tasks", self.host),
             &self.api_key,
             Method::Get,
@@ -635,7 +632,9 @@ impl Client {
         )
         .await?;
 
-        Ok(tasks.results)
+        dbg!(&tasks);
+
+        Ok(tasks)
     }
 
     /// Generates a new tenant token.
@@ -767,6 +766,12 @@ mod tests {
             m.assert();
             mem::drop(m);
         }
+    }
+
+    #[meilisearch_test]
+    async fn test_get_tasks(client: Client) {
+        let tasks = client.get_tasks().await.unwrap();
+        assert!(tasks.results.len() >= 2);
     }
 
     #[meilisearch_test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -433,18 +433,6 @@ impl Client {
     /// let mut key = KeyBuilder::new("create_key");
     /// key.with_index("*").with_action(Action::DocumentsAdd);
     /// let key = client.create_key(key).await.unwrap();
-    /// # // Method 2
-    /// let key = client.create_key("create_key")
-    ///     .with_index("*")
-    ///     .with_action(Action::DocumentsAdd)
-    ///     .execute()
-    ///     .await.unwrap();
-    /// # // Method 3
-    /// let key = KeyBuilder::new("My little lovely test key")
-    ///   .create(&client).await.unwrap();
-    ///
-    ///
-    ///
     /// assert_eq!(key.description, "create_key");
     /// # client.delete_key(key).await.unwrap();
     /// # });

--- a/src/client.rs
+++ b/src/client.rs
@@ -624,7 +624,7 @@ impl Client {
     ///
     ///
     ///
-    /// let tasks = client.get_tasks(&["get_tasks"]).with_index_uid().await.unwrap();
+    /// let tasks = client.get_tasks().with_index_uid(&["get_tasks"]).execute().await.unwrap();
     /// # });
     /// ```
     pub fn get_tasks(&self) -> TasksQuery {

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -735,12 +735,7 @@ impl Index {
     /// ```
     pub async fn get_task(&self, uid: impl AsRef<u32>) -> Result<Task, Error> {
         request::<(), Task>(
-            &format!(
-                "{}/indexes/{}/tasks/{}",
-                self.client.host,
-                self.uid,
-                uid.as_ref()
-            ),
+            &format!("{}/tasks/{}", self.client.host, uid.as_ref()),
             &self.client.api_key,
             Method::Get,
             200,
@@ -1088,7 +1083,6 @@ mod tests {
     // }
 
     #[meilisearch_test]
-    // TODO: failing because on document deletion the task type changed from clearAll -> documentDeletion
     async fn test_get_one_task(client: Client, index: Index) -> Result<(), Error> {
         let task = index
             .delete_all_documents()

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -729,7 +729,7 @@ impl Index {
     ///    Task::Succeeded { content } => content.uid,
     /// };
     ///
-    /// assert_eq!(task.get_uid(), from_index);
+    /// assert_eq!(task.get_task_uid(), from_index);
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
@@ -758,13 +758,9 @@ impl Index {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
-    /// let status = index.get_tasks().await.unwrap();
-    /// assert!(status.results.len() == 1); // the index was created
+    /// let tasks = index.get_tasks().await.unwrap();
     ///
-    /// index.set_ranking_rules(["wrong_ranking_rule"]).await.unwrap();
-    ///
-    /// let status = index.get_tasks().await.unwrap();
-    /// assert!(status.results.len() == 2);
+    /// assert!(tasks.results.len() > 0);
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1080,6 +1080,7 @@ mod tests {
     }
 
     // #[meilisearch_test]
+    // TODO: when implementing the filters in get_tasks
     // async fn test_get_tasks_no_docs(index: Index) {
     //     // The at this point the only task that is supposed to exist is the creation of the index
     //     let status = index.get_tasks().await.unwrap();
@@ -1087,6 +1088,7 @@ mod tests {
     // }
 
     #[meilisearch_test]
+    // TODO: failing because on document deletion the task type changed from clearAll -> documentDeletion
     async fn test_get_one_task(client: Client, index: Index) -> Result<(), Error> {
         let task = index
             .delete_all_documents()

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -764,12 +764,22 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub fn get_tasks(&self) -> TasksQuery {
-        let mut task = self.client.get_tasks();
+    /// TODO: how to pass a tasks_query?
+    pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
+        let mut query = TasksQuery::new(&self.client);
 
-        task.with_index_uid([self.uid.as_str()]);
+        query.with_index_uid([self.uid.as_str()]);
 
-        task
+        self.client.get_tasks(&query).await
+
+        // pub async fn get_tasks(
+        //     &self,
+        //     mut tasks_query: &mut TasksQuery<'_>,
+        // ) -> Result<TasksResults, Error> {
+        //     tasks_query.with_index_uid([self.uid.as_str()]);
+
+        //     self.client.get_tasks(&tasks_query).await
+        // }
     }
 
     /// Get stats of an index.

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -764,7 +764,6 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    /// TODO: how to pass a tasks_query?
     pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
         let mut query = TasksQuery::new(&self.client);
         query.with_index_uid([self.uid.as_str()]);
@@ -1100,14 +1099,6 @@ mod tests {
         assert!(index.created_at.is_some());
         assert!(index.primary_key.is_none());
     }
-
-    // #[meilisearch_test]
-    // TODO: when implementing the filters in get_tasks
-    // async fn test_get_tasks_no_docs(index: Index) {
-    //     // The at this point the only task that is supposed to exist is the creation of the index
-    //     let status = index.get_tasks().await.unwrap();
-    //     assert_eq!(status.results.len(), 1);
-    // }
 
     #[meilisearch_test]
     async fn test_get_one_task(client: Client, index: Index) -> Result<(), Error> {

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -758,20 +758,18 @@ impl Index {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
-    /// let tasks = index.get_tasks().await.unwrap();
+    /// let tasks = index.get_tasks().execute().await.unwrap();
     ///
     /// assert!(tasks.results.len() > 0);
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
-        request::<(), TasksResults>(
-            &format!("{}/tasks", self.client.host),
-            &self.client.api_key,
-            Method::Get(()),
-            200,
-        )
-        .await
+    pub fn get_tasks(&self) -> TasksQuery {
+        let mut task = self.client.get_tasks();
+
+        task.with_index_uid([self.uid.as_str()]);
+
+        task
     }
 
     /// Get stats of an index.

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -758,7 +758,7 @@ impl Index {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
-    /// let tasks = index.get_tasks().execute().await.unwrap();
+    /// let tasks = index.get_tasks().await.unwrap();
     ///
     /// assert!(tasks.results.len() > 0);
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -767,19 +767,42 @@ impl Index {
     /// TODO: how to pass a tasks_query?
     pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
         let mut query = TasksQuery::new(&self.client);
-
         query.with_index_uid([self.uid.as_str()]);
 
-        self.client.get_tasks(&query).await
+        self.client.get_tasks_with(&query).await
+    }
 
-        // pub async fn get_tasks(
-        //     &self,
-        //     mut tasks_query: &mut TasksQuery<'_>,
-        // ) -> Result<TasksResults, Error> {
-        //     tasks_query.with_index_uid([self.uid.as_str()]);
+    /// Get the status of all tasks in a given index.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use serde::{Serialize, Deserialize};
+    /// # use meilisearch_sdk::{client::*, indexes::*, tasks::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client.create_index("get_tasks_with", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
+    ///
+    /// let mut query = TasksQuery::new(&client);
+    /// query.with_index_uid(["none_existant"]);
+    /// let tasks = index.get_tasks_with(&query).await.unwrap();
+    ///
+    /// assert!(tasks.results.len() > 0);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn get_tasks_with(
+        &self,
+        tasks_query: &TasksQuery<'_>,
+    ) -> Result<TasksResults, Error> {
+        let mut query = tasks_query.clone();
+        query.with_index_uid([self.uid.as_str()]);
 
-        //     self.client.get_tasks(&tasks_query).await
-        // }
+        self.client.get_tasks_with(&query).await
     }
 
     /// Get stats of an index.

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1093,10 +1093,42 @@ mod tests {
         let status = index.get_task(task).await?;
 
         match status {
-            Task::Enqueued { content } => assert_eq!(content.index_uid, *index.uid),
-            Task::Processing { content } => assert_eq!(content.index_uid, *index.uid),
-            Task::Failed { content } => assert_eq!(content.task.index_uid, *index.uid),
-            Task::Succeeded { content } => assert_eq!(content.index_uid, *index.uid),
+            Task::Enqueued {
+                content:
+                    EnqueuedTask {
+                        index_uid: Some(index_uid),
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            Task::Processing {
+                content:
+                    EnqueuedTask {
+                        index_uid: Some(index_uid),
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            Task::Failed {
+                content:
+                    FailedTask {
+                        task:
+                            SucceededTask {
+                                index_uid: Some(index_uid),
+                                ..
+                            },
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            Task::Succeeded {
+                content:
+                    SucceededTask {
+                        index_uid: Some(index_uid),
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            task => panic!(
+                "The task should have an index_uid that is not null {:?}",
+                task
+            ),
         }
         Ok(())
     }

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -769,13 +769,13 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
-        Ok(request::<(), TasksResults>(
+        request::<(), TasksResults>(
             &format!("{}/tasks", self.client.host),
             &self.client.api_key,
             Method::Get(()),
             200,
         )
-        .await?)
+        .await
     }
 
     /// Get stats of an index.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,11 @@ mod request;
 pub mod search;
 /// Module containing [settings::Settings].
 pub mod settings;
+/// Module representing the [task_info::TaskInfo]s.
+pub mod task_info;
 /// Module representing the [tasks::Task]s.
 pub mod tasks;
 /// Module that generates tenant tokens.
 mod tenant_tokens;
+/// Module containing utilies functions.
+mod utils;

--- a/src/search.rs
+++ b/src/search.rs
@@ -113,7 +113,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///     .with_offset(42)
 ///     .with_limit(21)
 ///
-/// let res = query.execute().await?.unwrap()
+/// let res = query.execute().await?.unwrap();
 /// ```
 ///
 /// ```

--- a/src/search.rs
+++ b/src/search.rs
@@ -112,7 +112,8 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///     .with_query("space")
 ///     .with_offset(42)
 ///     .with_limit(21)
-///     .build(); // you can also execute() instead of build()
+///
+/// let res = query.execute().await?.unwrap()
 /// ```
 ///
 /// ```

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::Error,
     indexes::Index,
     request::{request, Method},
-    tasks::Task,
+    task_info::TaskInfo,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -478,8 +478,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn set_settings(&self, settings: &Settings) -> Result<Task, Error> {
-        request::<&Settings, Task>(
+    pub async fn set_settings(&self, settings: &Settings) -> Result<TaskInfo, Error> {
+        request::<&Settings, TaskInfo>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
             Method::Post(settings),
@@ -515,8 +515,8 @@ impl Index {
     pub async fn set_synonyms(
         &self,
         synonyms: &HashMap<String, Vec<String>>,
-    ) -> Result<Task, Error> {
-        request::<&HashMap<String, Vec<String>>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<&HashMap<String, Vec<String>>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
@@ -551,8 +551,8 @@ impl Index {
     pub async fn set_stop_words(
         &self,
         stop_words: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
@@ -601,8 +601,8 @@ impl Index {
     pub async fn set_ranking_rules(
         &self,
         ranking_rules: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
@@ -642,8 +642,8 @@ impl Index {
     pub async fn set_filterable_attributes(
         &self,
         filterable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
@@ -683,8 +683,8 @@ impl Index {
     pub async fn set_sortable_attributes(
         &self,
         sortable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
@@ -723,8 +723,8 @@ impl Index {
     pub async fn set_distinct_attribute(
         &self,
         distinct_attribute: impl AsRef<str>,
-    ) -> Result<Task, Error> {
-        request::<String, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<String, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
@@ -758,8 +758,8 @@ impl Index {
     pub async fn set_searchable_attributes(
         &self,
         searchable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
@@ -798,8 +798,8 @@ impl Index {
     pub async fn set_displayed_attributes(
         &self,
         displayed_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
@@ -836,8 +836,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_settings(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_settings(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
             Method::Delete,
@@ -865,8 +865,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_synonyms(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_synonyms(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
@@ -897,8 +897,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_stop_words(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_stop_words(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
@@ -930,8 +930,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_ranking_rules(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_ranking_rules(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
@@ -962,8 +962,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_filterable_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_filterable_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
@@ -994,8 +994,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_sortable_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_sortable_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
@@ -1026,8 +1026,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_distinct_attribute(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_distinct_attribute(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
@@ -1058,8 +1058,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_searchable_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_searchable_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
@@ -1090,8 +1090,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_displayed_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_displayed_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -1,0 +1,221 @@
+use serde::Deserialize;
+use std::time::Duration;
+use time::OffsetDateTime;
+
+use crate::{client::Client, errors::Error, tasks::*};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskInfo {
+    #[serde(with = "time::serde::rfc3339")]
+    pub enqueued_at: OffsetDateTime,
+    pub index_uid: String,
+    pub status: String,
+    #[serde(flatten)]
+    pub update_type: TaskType,
+    pub task_uid: u32,
+}
+
+impl AsRef<u32> for TaskInfo {
+    fn as_ref(&self) -> &u32 {
+        &self.task_uid
+    }
+}
+
+impl AsRef<str> for TaskInfo {
+    fn as_ref(&self) -> &str {
+        self.get_index_uid()
+    }
+}
+
+impl TaskInfo {
+    pub fn get_task_uid(&self) -> u32 {
+        self.task_uid
+    }
+
+    pub fn get_index_uid(&self) -> &str {
+        &self.index_uid
+    }
+
+    /// Wait until Meilisearch processes a task provided by [TaskInfo], and get its status.
+    ///
+    /// `interval` = The frequency at which the server should be polled. Default = 50ms
+    /// `timeout` = The maximum time to wait for processing to complete. Default = 5000ms
+    ///
+    /// If the waited time exceeds `timeout` then an [Error::Timeout] will be returned.
+    ///
+    /// See also [Client::wait_for_task, Index::wait_for_task].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, tasks::Task, task_info::TaskInfo};
+    /// # use serde::{Serialize, Deserialize};
+    /// #
+    /// # #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// # struct Document {
+    /// #    id: usize,
+    /// #    value: String,
+    /// #    kind: String,
+    /// # }
+    /// #
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let movies = client.index("movies_wait_for_completion");
+    ///
+    /// let status = movies.add_documents(&[
+    ///     Document { id: 0, kind: "title".into(), value: "The Social Network".to_string() },
+    ///     Document { id: 1, kind: "title".into(), value: "Harry Potter and the Sorcerer's Stone".to_string() },
+    /// ], None)
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// assert!(matches!(status, Task::Succeeded { .. }));
+    /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn wait_for_completion(
+        self,
+        client: &Client,
+        interval: Option<Duration>,
+        timeout: Option<Duration>,
+    ) -> Result<Task, Error> {
+        client.wait_for_task(self, interval, timeout).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        client::*,
+        errors::{ErrorCode, ErrorType},
+        indexes::Index,
+    };
+    use meilisearch_test_macro::meilisearch_test;
+    use serde::{Deserialize, Serialize};
+    use std::time::Duration;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Document {
+        id: usize,
+        value: String,
+        kind: String,
+    }
+
+    #[test]
+    fn test_deserialize_task_info() {
+        let datetime = OffsetDateTime::parse(
+            "2022-02-03T13:02:38.369634Z",
+            &::time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+
+        let task_info: TaskInfo = serde_json::from_str(
+            r#"
+{
+  "enqueuedAt": "2022-02-03T13:02:38.369634Z",
+  "indexUid": "mieli",
+  "status": "enqueued",
+  "type": "documentAdditionOrUpdate",
+  "taskUid": 12
+}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            task_info,
+            TaskInfo {
+                enqueued_at,
+                index_uid,
+                task_uid: 12,
+                update_type: TaskType::DocumentAdditionOrUpdate { details: None },
+                status: _,
+            }
+        if enqueued_at == datetime && index_uid == "mieli"));
+    }
+
+    #[meilisearch_test]
+    async fn test_wait_for_pending_updates_with_args(
+        client: Client,
+        movies: Index,
+    ) -> Result<(), Error> {
+        let task = movies
+            .add_documents(
+                &[
+                    Document {
+                        id: 0,
+                        kind: "title".into(),
+                        value: "The Social Network".to_string(),
+                    },
+                    Document {
+                        id: 1,
+                        kind: "title".into(),
+                        value: "Harry Potter and the Sorcerer's Stone".to_string(),
+                    },
+                ],
+                None,
+            )
+            .await?
+            .wait_for_completion(
+                &client,
+                Some(Duration::from_millis(1)),
+                Some(Duration::from_millis(6000)),
+            )
+            .await?;
+
+        assert!(matches!(task, Task::Succeeded { .. }));
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_wait_for_pending_updates_time_out(
+        client: Client,
+        movies: Index,
+    ) -> Result<(), Error> {
+        let task_info = movies
+            .add_documents(
+                &[
+                    Document {
+                        id: 0,
+                        kind: "title".into(),
+                        value: "The Social Network".to_string(),
+                    },
+                    Document {
+                        id: 1,
+                        kind: "title".into(),
+                        value: "Harry Potter and the Sorcerer's Stone".to_string(),
+                    },
+                ],
+                None,
+            )
+            .await?;
+
+        let error = client
+            .wait_for_task(
+                task_info,
+                Some(Duration::from_millis(1)),
+                Some(Duration::from_nanos(1)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, Error::Timeout));
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_failing_update(client: Client, movies: Index) -> Result<(), Error> {
+        let task = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
+        let status = client.wait_for_task(task, None, None).await?;
+
+        let error = status.unwrap_failure();
+        assert_eq!(error.error_code, ErrorCode::InvalidRankingRule);
+        assert_eq!(error.error_type, ErrorType::InvalidRequest);
+        Ok(())
+    }
+}

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -9,7 +9,7 @@ use crate::{client::Client, errors::Error, tasks::*};
 pub struct TaskInfo {
     #[serde(with = "time::serde::rfc3339")]
     pub enqueued_at: OffsetDateTime,
-    pub index_uid: String,
+    pub index_uid: Option<String>,
     pub status: String,
     #[serde(flatten)]
     pub update_type: TaskType,
@@ -22,19 +22,9 @@ impl AsRef<u32> for TaskInfo {
     }
 }
 
-impl AsRef<str> for TaskInfo {
-    fn as_ref(&self) -> &str {
-        self.get_index_uid()
-    }
-}
-
 impl TaskInfo {
     pub fn get_task_uid(&self) -> u32 {
         self.task_uid
-    }
-
-    pub fn get_index_uid(&self) -> &str {
-        &self.index_uid
     }
 
     /// Wait until Meilisearch processes a task provided by [TaskInfo], and get its status.
@@ -131,12 +121,12 @@ mod test {
             task_info,
             TaskInfo {
                 enqueued_at,
-                index_uid,
+                index_uid: Some(index_uid),
                 task_uid: 12,
                 update_type: TaskType::DocumentAdditionOrUpdate { details: None },
-                status: _,
+                status,
             }
-        if enqueued_at == datetime && index_uid == "mieli"));
+        if enqueued_at == datetime && index_uid == "mieli" && status == "enqueued"));
     }
 
     #[meilisearch_test]

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -270,7 +270,7 @@ impl Task {
     /// # let task = client.create_index("unwrap_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
-    ///
+    /// // TODO: fails until http method are implemented
     /// let task = index.set_ranking_rules(["wrong_ranking_rule"])
     ///   .await
     ///   .unwrap()

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -103,7 +103,7 @@ pub struct SucceededTask {
     pub started_at: OffsetDateTime,
     #[serde(with = "time::serde::rfc3339")]
     pub finished_at: OffsetDateTime,
-    pub index_uid: String,
+    pub index_uid: Option<String>,
     #[serde(flatten)]
     pub update_type: TaskType,
     pub uid: u32,
@@ -120,7 +120,7 @@ impl AsRef<u32> for SucceededTask {
 pub struct EnqueuedTask {
     #[serde(with = "time::serde::rfc3339")]
     pub enqueued_at: OffsetDateTime,
-    pub index_uid: String,
+    pub index_uid: Option<String>,
     #[serde(flatten)]
     pub update_type: TaskType,
     pub uid: u32,
@@ -248,7 +248,7 @@ impl Task {
                         update_type: TaskType::IndexCreation { .. },
                         ..
                     },
-            } => Ok(client.index(index_uid)),
+            } => Ok(client.index(index_uid.unwrap())),
             _ => Err(self),
         }
     }
@@ -434,7 +434,7 @@ mod test {
             Task::Enqueued {
                 content: EnqueuedTask {
                     enqueued_at,
-                    index_uid,
+                    index_uid: Some(index_uid),
                     update_type: TaskType::DocumentAdditionOrUpdate { details: None },
                     uid: 12,
                 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -456,7 +456,7 @@ impl<'a> TasksQuery<'a> {
     }
 
     pub async fn execute(&'a self) -> Result<TasksResults, Error> {
-        self.client.get_tasks(self).await
+        self.client.get_tasks_with(self).await
     }
 }
 
@@ -621,8 +621,7 @@ mod test {
         let path = "/tasks";
 
         let mock_res = mock("GET", path).with_status(200).create();
-        let query = TasksQuery::new(&client);
-        let _ = client.get_tasks(&query).await;
+        let _ = client.get_tasks().await;
         mock_res.assert();
 
         Ok(())
@@ -645,7 +644,7 @@ mod test {
             .with_from(1)
             .with_limit(0);
 
-        let _ = client.get_tasks(&query).await;
+        let _ = client.get_tasks_with(&query).await;
 
         mock_res.assert();
         Ok(())
@@ -676,7 +675,19 @@ mod test {
     async fn test_get_tasks_with_none_existant_index_uid(client: Client) -> Result<(), Error> {
         let mut query = TasksQuery::new(&client);
         query.with_index_uid(["no_name"]);
-        let tasks = client.get_tasks(&query).await.unwrap();
+        let tasks = client.get_tasks_with(&query).await.unwrap();
+
+        assert_eq!(tasks.results.len(), 0);
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_get_tasks_with_execute(client: Client) -> Result<(), Error> {
+        let tasks = TasksQuery::new(&client)
+            .with_index_uid(["no_name"])
+            .execute()
+            .await
+            .unwrap();
 
         assert_eq!(tasks.results.len(), 0);
         Ok(())

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -516,10 +516,7 @@ mod test {
     }
 
     #[meilisearch_test]
-    async fn test_wait_for_pending_updates_with_args(
-        client: Client,
-        movies: Index,
-    ) -> Result<(), Error> {
+    async fn test_wait_for_task_with_args(client: Client, movies: Index) -> Result<(), Error> {
         let task_info = movies
             .add_documents(
                 &[
@@ -553,14 +550,14 @@ mod test {
     }
 
     #[meilisearch_test]
+    // TODO: failing because settings routes now uses PUT instead of POST as http method
     async fn test_failing_update(client: Client, movies: Index) -> Result<(), Error> {
         let task_info = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
 
         let task = client.get_task(task_info).await?;
+        let task = client.wait_for_task(task, None, None).await?;
 
-        let status = client.wait_for_task(task, None, None).await?;
-
-        let error = status.unwrap_failure();
+        let error = task.unwrap_failure();
         assert_eq!(error.error_code, ErrorCode::InvalidRankingRule);
         assert_eq!(error.error_type, ErrorType::InvalidRequest);
         Ok(())

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::time::Duration;
 use time::OffsetDateTime;
 
@@ -389,6 +389,44 @@ impl AsRef<u32> for Task {
             Self::Failed { content } => content.as_ref(),
         }
     }
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TasksQuery<'a> {
+    // Index uids array to only retrieve the tasks of the indexes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_uid: Option<&'a [&'a str]>,
+    // Statuses array to only retrieve the tasks with these statuses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<&'a [&'a str]>,
+    // Types array to only retrieve the tasks with these [TaskType].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<&'a [&'a str]>,
+}
+
+#[allow(missing_docs)]
+impl<'a> TasksQuery<'a> {
+    pub fn new() -> TasksQuery<'a> {
+        TasksQuery {
+            index_uid: None,
+            status: None,
+            r#type: None,
+        }
+    }
+    pub fn with_index_uid<'b>(&'b mut self, index_uid: &'a [&'a str]) -> &'b mut TasksQuery<'a> {
+        self.index_uid = Some(index_uid);
+        self
+    }
+    pub fn with_status<'b>(&'b mut self, status: &'a [&'a str]) -> &'b mut TasksQuery<'a> {
+        self.status = Some(status);
+        self
+    }
+    pub fn with_type<'b>(&'b mut self, r#type: &'a [&'a str]) -> &'b mut TasksQuery<'a> {
+        self.r#type = Some(r#type);
+        self
+    }
+    // execute
 }
 
 #[cfg(test)]

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -408,7 +408,7 @@ pub struct TasksQuery<'a> {
     // Maximum number of tasks to return
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
-    // The if og the first task uid that should be returned
+    // The first task uid that should be returned
     #[serde(skip_serializing_if = "Option::is_none")]
     pub from: Option<u32>,
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,4 +1,4 @@
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::time::Duration;
 use time::OffsetDateTime;
 
@@ -560,7 +560,7 @@ mod test {
 
     #[meilisearch_test]
     async fn test_wait_for_task_with_args(client: Client, movies: Index) -> Result<(), Error> {
-        let task_info = movies
+        let task = movies
             .add_documents(
                 &[
                     Document {
@@ -576,10 +576,6 @@ mod test {
                 ],
                 None,
             )
-            .await?;
-
-        let task = client
-            .get_task(task_info)
             .await?
             .wait_for_completion(
                 &client,
@@ -602,10 +598,6 @@ mod test {
         let _ = client.get_tasks().execute().await;
         mock_res.assert();
 
-        // let _ = mockRes.req.await;
-        // mockRes.m.assert();
-        // assert_eq!(tasks,);
-        // assert!(matches!(tasks, TasksResults { results.. } ));
         Ok(())
     }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -398,13 +398,13 @@ pub struct TasksQuery<'a> {
     pub client: &'a Client,
     // Index uids array to only retrieve the tasks of the indexes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub index_uid: Option<&'a [&'a str]>,
+    pub index_uid: Option<Vec<&'a str>>,
     // Statuses array to only retrieve the tasks with these statuses.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<&'a [&'a str]>,
+    pub status: Option<Vec<&'a str>>,
     // Types array to only retrieve the tasks with these [TaskType].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub r#type: Option<&'a [&'a str]>,
+    pub r#type: Option<Vec<&'a str>>,
 }
 
 #[allow(missing_docs)]
@@ -417,16 +417,25 @@ impl<'a> TasksQuery<'a> {
             r#type: None,
         }
     }
-    pub fn with_index_uid<'b>(&'b mut self, index_uid: &'a [&'a str]) -> &'b mut TasksQuery<'a> {
-        self.index_uid = Some(index_uid);
+    pub fn with_index_uid<'b>(
+        &'b mut self,
+        index_uid: impl IntoIterator<Item = &'a str>,
+    ) -> &'b mut TasksQuery<'a> {
+        self.index_uid = Some(index_uid.into_iter().collect());
         self
     }
-    pub fn with_status<'b>(&'b mut self, status: &'a [&'a str]) -> &'b mut TasksQuery<'a> {
-        self.status = Some(status);
+    pub fn with_status<'b>(
+        &'b mut self,
+        status: impl IntoIterator<Item = &'a str>,
+    ) -> &'b mut TasksQuery<'a> {
+        self.status = Some(status.into_iter().collect());
         self
     }
-    pub fn with_type<'b>(&'b mut self, r#type: &'a [&'a str]) -> &'b mut TasksQuery<'a> {
-        self.r#type = Some(r#type);
+    pub fn with_type<'b>(
+        &'b mut self,
+        r#type: impl IntoIterator<Item = &'a str>,
+    ) -> &'b mut TasksQuery<'a> {
+        self.r#type = Some(r#type.into_iter().collect());
         self
     }
     pub async fn execute(&'a self) -> Result<TasksResults, Error> {
@@ -610,9 +619,9 @@ mod test {
         let mock_res = mock("GET", path).with_status(200).create();
         let _ = client
             .get_tasks()
-            .with_index_uid(&["movies", "test"])
-            .with_status(&["equeued"])
-            .with_type(&["documentDeletion"])
+            .with_index_uid(["movies", "test"])
+            .with_status(["equeued"])
+            .with_type(["documentDeletion"])
             .execute()
             .await;
         mock_res.assert();
@@ -623,7 +632,7 @@ mod test {
     async fn test_get_tasks_with_none_existant_index_uid(client: Client) -> Result<(), Error> {
         let tasks = client
             .get_tasks()
-            .with_index_uid(&["no_name"])
+            .with_index_uid(["no_name"])
             .execute()
             .await
             .unwrap();

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -34,8 +34,8 @@ pub enum TaskType {
 pub struct TasksResults {
     pub results: Vec<Task>,
     pub limit: u32,
-    pub from: u32,
-    pub next: u32,
+    pub from: Option<u32>,
+    pub next: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -620,22 +620,15 @@ mod test {
     }
 
     #[meilisearch_test]
-    // TODO: Will un ignore when pagination is added in TaskResults
-    #[ignore]
-    async fn test_get_tasks_with_params_2(client: Client, index: Index) -> Result<(), Error> {
+    async fn test_get_tasks_with_none_existant_index_uid(client: Client) -> Result<(), Error> {
         let tasks = client
             .get_tasks()
-            .with_index_uid(&[index.uid.as_str()])
+            .with_index_uid(&["no_name"])
             .execute()
             .await
             .unwrap();
 
-        // let _ = mockRes.req.await;
-        // mockRes.m.assert();
-        // assert_eq!(tasks,);
-        // assert!(matches!(tasks, TasksResults { results.. } ));
-        dbg!(&tasks);
-        assert_eq!(tasks.results.len(), 1);
+        assert_eq!(tasks.results.len(), 0);
         Ok(())
     }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -11,18 +11,37 @@ use crate::{
 pub enum TaskType {
     ClearAll,
     Customs,
-    DocumentAddition { details: Option<DocumentAddition> },
-    DocumentPartial { details: Option<DocumentAddition> },
-    DocumentDeletion { details: Option<DocumentDeletion> },
-    IndexCreation { details: Option<IndexCreation> },
-    IndexUpdate { details: Option<IndexUpdate> },
-    IndexDeletion { details: Option<IndexDeletion> },
-    SettingsUpdate { details: Option<Settings> },
+    DocumentAdditionOrUpdate {
+        details: Option<DocumentAdditionOrUpdate>,
+    },
+    DocumentDeletion {
+        details: Option<DocumentDeletion>,
+    },
+    IndexCreation {
+        details: Option<IndexCreation>,
+    },
+    IndexUpdate {
+        details: Option<IndexUpdate>,
+    },
+    IndexDeletion {
+        details: Option<IndexDeletion>,
+    },
+    SettingsUpdate {
+        details: Option<Settings>,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TasksResults {
+    pub results: Vec<Task>,
+    pub limit: u32,
+    pub from: u32,
+    pub next: u32,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DocumentAddition {
+pub struct DocumentAdditionOrUpdate {
     pub indexed_documents: Option<usize>,
     pub received_documents: usize,
 }
@@ -59,8 +78,8 @@ pub struct FailedTask {
     pub task: ProcessedTask,
 }
 
-impl AsRef<u64> for FailedTask {
-    fn as_ref(&self) -> &u64 {
+impl AsRef<u32> for FailedTask {
+    fn as_ref(&self) -> &u32 {
         &self.task.uid
     }
 }
@@ -88,11 +107,11 @@ pub struct ProcessedTask {
     pub index_uid: String,
     #[serde(flatten)]
     pub update_type: TaskType,
-    pub uid: u64,
+    pub uid: u32,
 }
 
-impl AsRef<u64> for ProcessedTask {
-    fn as_ref(&self) -> &u64 {
+impl AsRef<u32> for ProcessedTask {
+    fn as_ref(&self) -> &u32 {
         &self.uid
     }
 }
@@ -105,11 +124,11 @@ pub struct EnqueuedTask {
     pub index_uid: String,
     #[serde(flatten)]
     pub update_type: TaskType,
-    pub uid: u64,
+    pub uid: u32,
 }
 
-impl AsRef<u64> for EnqueuedTask {
-    fn as_ref(&self) -> &u64 {
+impl AsRef<u32> for EnqueuedTask {
+    fn as_ref(&self) -> &u32 {
         &self.uid
     }
 }
@@ -136,7 +155,7 @@ pub enum Task {
 }
 
 impl Task {
-    pub fn get_uid(&self) -> u64 {
+    pub fn get_uid(&self) -> u32 {
         match self {
             Self::Enqueued { content } | Self::Processing { content } => *content.as_ref(),
             Self::Failed { content } => *content.as_ref(),
@@ -303,6 +322,7 @@ impl Task {
     /// assert!(task.is_failure());
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
+    /// ```
     pub fn is_failure(&self) -> bool {
         matches!(self, Self::Failed { .. })
     }
@@ -330,6 +350,7 @@ impl Task {
     /// assert!(task.is_success());
     /// # task.try_make_index(&client).unwrap().delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
+    /// ```
     pub fn is_success(&self) -> bool {
         matches!(self, Self::Succeeded { .. })
     }
@@ -337,8 +358,9 @@ impl Task {
     /// Returns `true` if the [Task] is pending ([Self::Enqueued] or [Self::Processing]).
     ///
     /// # Example
-    ///
-    /// ```
+    /// ```no_run
+    /// # // The test is not run because it checks for an enqueued or processed status
+    /// # // and the task might already be processed when checking the status after the get_task call
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
@@ -346,55 +368,28 @@ impl Task {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    /// let task = client
+    /// let task_info = client
     ///   .create_index("is_pending", None)
     ///   .await
     ///   .unwrap();
-    ///
+    /// let task = client.get_task(task_info).await.unwrap();
     /// assert!(task.is_pending());
     /// # task.wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap().delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
+    /// ```
     pub fn is_pending(&self) -> bool {
         matches!(self, Self::Enqueued { .. } | Self::Processing { .. })
     }
 }
 
-impl AsRef<u64> for Task {
-    fn as_ref(&self) -> &u64 {
+impl AsRef<u32> for Task {
+    fn as_ref(&self) -> &u32 {
         match self {
             Self::Enqueued { content } | Self::Processing { content } => content.as_ref(),
             Self::Succeeded { content } => content.as_ref(),
             Self::Failed { content } => content.as_ref(),
         }
     }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) async fn async_sleep(interval: Duration) {
-    let (sender, receiver) = futures::channel::oneshot::channel::<()>();
-    std::thread::spawn(move || {
-        std::thread::sleep(interval);
-        let _ = sender.send(());
-    });
-    let _ = receiver.await;
-}
-
-#[cfg(target_arch = "wasm32")]
-pub(crate) async fn async_sleep(interval: Duration) {
-    use std::convert::TryInto;
-    use wasm_bindgen_futures::JsFuture;
-
-    JsFuture::from(js_sys::Promise::new(&mut |yes, _| {
-        web_sys::window()
-            .unwrap()
-            .set_timeout_with_callback_and_timeout_and_arguments_0(
-                &yes,
-                interval.as_millis().try_into().unwrap(),
-            )
-            .unwrap();
-    }))
-    .await
-    .unwrap();
 }
 
 #[cfg(test)]
@@ -406,7 +401,7 @@ mod test {
     };
     use meilisearch_test_macro::meilisearch_test;
     use serde::{Deserialize, Serialize};
-    use std::time::{self, Duration};
+    use std::time::Duration;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Document {
@@ -429,7 +424,7 @@ mod test {
   "enqueuedAt": "2022-02-03T13:02:38.369634Z",
   "indexUid": "mieli",
   "status": "enqueued",
-  "type": "documentAddition",
+  "type": "documentAdditionOrUpdate",
   "uid": 12
 }"#,
         )
@@ -441,7 +436,7 @@ mod test {
                 content: EnqueuedTask {
                     enqueued_at,
                     index_uid,
-                    update_type: TaskType::DocumentAddition { details: None },
+                    update_type: TaskType::DocumentAdditionOrUpdate { details: None },
                     uid: 12,
                 }
             }
@@ -460,7 +455,7 @@ mod test {
   "indexUid": "mieli",
   "startedAt": "2022-02-03T15:17:02.812338Z",
   "status": "processing",
-  "type": "documentAddition",
+  "type": "documentAdditionOrUpdate",
   "uid": 14
 }"#,
         )
@@ -470,8 +465,8 @@ mod test {
             task,
             Task::Processing {
                 content: EnqueuedTask {
-                    update_type: TaskType::DocumentAddition {
-                        details: Some(DocumentAddition {
+                    update_type: TaskType::DocumentAdditionOrUpdate {
+                        details: Some(DocumentAdditionOrUpdate {
                             received_documents: 19547,
                             indexed_documents: None,
                         })
@@ -495,7 +490,7 @@ mod test {
   "indexUid": "mieli",
   "startedAt": "2022-02-03T15:17:02.812338Z",
   "status": "succeeded",
-  "type": "documentAddition",
+  "type": "documentAdditionOrUpdate",
   "uid": 14
 }"#,
         )
@@ -505,8 +500,8 @@ mod test {
             task,
             Task::Succeeded {
                 content: ProcessedTask {
-                    update_type: TaskType::DocumentAddition {
-                        details: Some(DocumentAddition {
+                    update_type: TaskType::DocumentAdditionOrUpdate {
+                        details: Some(DocumentAdditionOrUpdate {
                             received_documents: 19547,
                             indexed_documents: Some(19546),
                         })
@@ -525,7 +520,7 @@ mod test {
         client: Client,
         movies: Index,
     ) -> Result<(), Error> {
-        let status = movies
+        let task_info = movies
             .add_documents(
                 &[
                     Document {
@@ -541,6 +536,10 @@ mod test {
                 ],
                 None,
             )
+            .await?;
+
+        let task = client
+            .get_task(task_info)
             .await?
             .wait_for_completion(
                 &client,
@@ -549,59 +548,16 @@ mod test {
             )
             .await?;
 
-        assert!(matches!(status, Task::Succeeded { .. }));
+        assert!(matches!(task, Task::Succeeded { .. }));
         Ok(())
-    }
-
-    #[meilisearch_test]
-    async fn test_wait_for_pending_updates_time_out(
-        client: Client,
-        movies: Index,
-    ) -> Result<(), Error> {
-        let task = movies
-            .add_documents(
-                &[
-                    Document {
-                        id: 0,
-                        kind: "title".into(),
-                        value: "The Social Network".to_string(),
-                    },
-                    Document {
-                        id: 1,
-                        kind: "title".into(),
-                        value: "Harry Potter and the Sorcerer's Stone".to_string(),
-                    },
-                ],
-                None,
-            )
-            .await?;
-
-        let error = client
-            .wait_for_task(
-                task,
-                Some(Duration::from_millis(1)),
-                Some(Duration::from_nanos(1)),
-            )
-            .await
-            .unwrap_err();
-
-        assert!(matches!(error, Error::Timeout));
-        Ok(())
-    }
-
-    #[meilisearch_test]
-    async fn test_async_sleep() {
-        let sleep_duration = time::Duration::from_millis(10);
-        let now = time::Instant::now();
-
-        async_sleep(sleep_duration).await;
-
-        assert!(now.elapsed() >= sleep_duration);
     }
 
     #[meilisearch_test]
     async fn test_failing_update(client: Client, movies: Index) -> Result<(), Error> {
-        let task = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
+        let task_info = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
+
+        let task = client.get_task(task_info).await?;
+
         let status = client.wait_for_task(task, None, None).await?;
 
         let error = status.unwrap_failure();

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -403,8 +403,8 @@ pub struct TasksQuery<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<Vec<&'a str>>,
     // Types array to only retrieve the tasks with these [TaskType].
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub r#type: Option<Vec<&'a str>>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    pub task_type: Option<Vec<&'a str>>,
     // Maximum number of tasks to return
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
@@ -420,7 +420,7 @@ impl<'a> TasksQuery<'a> {
             client,
             index_uid: None,
             status: None,
-            r#type: None,
+            task_type: None,
             limit: None,
             from: None,
         }
@@ -441,9 +441,9 @@ impl<'a> TasksQuery<'a> {
     }
     pub fn with_type<'b>(
         &'b mut self,
-        r#type: impl IntoIterator<Item = &'a str>,
+        task_type: impl IntoIterator<Item = &'a str>,
     ) -> &'b mut TasksQuery<'a> {
-        self.r#type = Some(r#type.into_iter().collect());
+        self.task_type = Some(task_type.into_iter().collect());
         self
     }
     pub fn with_limit<'b>(&'b mut self, limit: u32) -> &'b mut TasksQuery<'a> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn async_sleep(interval: Duration) {
+    let (sender, receiver) = futures::channel::oneshot::channel::<()>();
+    std::thread::spawn(move || {
+        std::thread::sleep(interval);
+        let _ = sender.send(());
+    });
+    let _ = receiver.await;
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn async_sleep(interval: Duration) {
+    use std::convert::TryInto;
+    use wasm_bindgen_futures::JsFuture;
+
+    JsFuture::from(js_sys::Promise::new(&mut |yes, _| {
+        web_sys::window()
+            .unwrap()
+            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                &yes,
+                interval.as_millis().try_into().unwrap(),
+            )
+            .unwrap();
+    }))
+    .await
+    .unwrap();
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use meilisearch_test_macro::meilisearch_test;
+
+    #[meilisearch_test]
+    async fn test_async_sleep() {
+        let sleep_duration = std::time::Duration::from_millis(10);
+        let now = time::Instant::now();
+
+        async_sleep(sleep_duration).await;
+
+        assert!(now.elapsed() >= sleep_duration);
+    }
+}


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## Breaking

- [x]  Actions that create a task in Meilisearch now return a `TaskInfo` and not a `Task` object anymore. (ex: add_documents).
- [x]  `get_tasks` now returns a `TasksResults` where the tasks are contained inside the `results` field.
- [x]  `task_id` in `Task` and`TaskInfo` is now a `u32` instead of a `u64`
- [x]  `index_uid` in `Task` and `TaskInfo` is now an Optionnal.
- [x]   TaskType `documentAddition` is replaced with `DocumentAdditionOrUpdate`
- [x] Add pagination to `get_tasks` based of [this](https://github.com/meilisearch/specifications/pull/115) using `limit`, `from`, `next` metadata in the response.
- [x] Rename these task types:
   - documentPartial -> documentAdditionOrUpdate
   - documentAddition -> documentAdditionOrUpdate
   - clearAll -> documentDeletion
- [x]  Possibility to filter the tasks when using `get_tasks` on `indexUid`, `status` and `type`.



// `get_tasks`
```rust
let tasks = client.get_tasks().await.unwrap()
```

// `get_tasks_with`
```rust
let mut query = tasks::TasksQuery::new(&client);
query.with_index_uid(["get_tasks_with"]);
let tasks = client.get_tasks_with(&query).await.unwrap();
```

// get tasks using `execute`
```rust
let mut query = tasks::TasksQuery::new(&client)
   .with_index_uid(["get_tasks_with"])
   .execute()
   .await
   .unwrap();
```

## Routes changes

- [x] `index.get_task` & `index.wait_for_task` now use `GET /tasks/:task_uid`
