### PR TITLE
Send documents as jsonlines for POST and PUT requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Also, the WASM example compilation should be checked:
 
 ```bash
 rustup target add wasm32-unknown-unknown
-cargo check --example web_app --target wasm32-unknown-unknown --features=sync
+cargo check -p web_app --target wasm32-unknown-unknown
 ```
 
 Each PR should pass the tests to be accepted.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-sdk"
-version = "0.17.0"
+version = "0.19.0"
 authors = ["Mubelotix <mubelotix@gmail.com>"]
 edition = "2018"
 description = "Rust wrapper for the Meilisearch API. Meilisearch is a powerful, fast, open-source, easy to use and deploy search engine."
@@ -19,10 +19,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing"] }
 jsonwebtoken = { version = "8", default-features = false }
+yaup = "0.2.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures = "0.3"
 isahc = { version = "1.0", features = ["http2", "text-decoding"], default_features = false }
+uuid = { version = "1.1.2", features =  ["v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.47"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.17.0"
+meilisearch-sdk = "0.19.0"
 ```
 
 The following optional dependencies may also be useful:
@@ -224,7 +224,7 @@ Json output:
   ],
   "offset": 0,
   "limit": 20,
-  "nbHits": 1,
+  "estimatedTotalHits": 1,
   "processingTimeMs": 0,
   "query": "wonder"
 }
@@ -242,7 +242,7 @@ WARNING: `meilisearch-sdk` will panic if no Window is available (ex: Web extensi
 
 ## 🤖 Compatibility with Meilisearch
 
-This package only guarantees the compatibility with the [version v0.27.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0).
+This package only guarantees the compatibility with the [version v0.28.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0).
 
 ## ⚙️ Development Workflow and Contributing
 

--- a/README.tpl
+++ b/README.tpl
@@ -50,7 +50,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.17.0"
+meilisearch-sdk = "0.19.0"
 ```
 
 The following optional dependencies may also be useful:
@@ -97,7 +97,7 @@ WARNING: `meilisearch-sdk` will panic if no Window is available (ex: Web extensi
 
 ## 🤖 Compatibility with Meilisearch
 
-This package only guarantees the compatibility with the [version v0.27.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0).
+This package only guarantees the compatibility with the [version v0.28.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0).
 
 ## ⚙️ Development Workflow and Contributing
 

--- a/examples/web_app/README.md
+++ b/examples/web_app/README.md
@@ -11,7 +11,7 @@ The Rust source files are compiled into WebAssembly and so can be readable by th
 If you only want to check if this example compiles, you can run:
 
 ```console
-cargo build --example web_app
+cargo build
 ```
 
 ## Building
@@ -23,7 +23,7 @@ curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 ```
 
 ```console
-wasm-pack build examples/web_app/ --target=web --no-typescript
+wasm-pack build . --target=web --no-typescript
 ```
 
 The compiled files will be stored in the `examples/web_app/pkg` folder.

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -15,10 +15,7 @@ mod document;
 use crate::document::{display, Crate};
 
 lazy_static! {
-    static ref CLIENT: Client = Client::new(
-        "https://finding-demos.meilisearch.com",
-        "2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3",
-    );
+    static ref CLIENT: Client = Client::new("http://localhost:7700", "masterKey",);
 }
 
 struct Model {

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -25,7 +25,7 @@ async fn test_get_tasks() -> Result<(), Error> {
 
   let tasks = index.get_tasks().await?;
   // The only task is the creation of the index
-  assert_eq!(status.len(), 1);
+  assert_eq!(status.results.len(), 1);
 
   index.delete()
     .await?
@@ -52,7 +52,7 @@ With this macro, all these problems are solved. See a rewrite of this test:
 async fn test_get_tasks(index: Index, client: Client) -> Result<(), Error> {
   let tasks = index.get_tasks().await?;
   // The only task is the creation of the index
-  assert_eq!(status.len(), 1);
+  assert_eq!(status.results.len(), 1);
 }
 ```
 

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -1,0 +1,319 @@
+use crate::{errors::Error, indexes::Index};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DocumentsResults<T> {
+    pub results: Vec<T>,
+    pub limit: u32,
+    pub offset: u32,
+    pub total: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DocumentQuery<'a> {
+    #[serde(skip_serializing)]
+    pub index: &'a Index,
+
+    /// The fields that should appear in the documents. By default all of the fields are present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<&'a str>>,
+}
+
+impl<'a> DocumentQuery<'a> {
+    pub fn new(index: &Index) -> DocumentQuery {
+        DocumentQuery {
+            index,
+            fields: None,
+        }
+    }
+
+    /// Specify the fields to return in the document.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let index = client.index("document_query_with_fields");
+    /// let mut document_query = DocumentQuery::new(&index);
+    ///
+    /// document_query.with_fields(["title"]);
+    /// ```
+    pub fn with_fields(
+        &mut self,
+        fields: impl IntoIterator<Item = &'a str>,
+    ) -> &mut DocumentQuery<'a> {
+        self.fields = Some(fields.into_iter().collect());
+        self
+    }
+
+    /// Execute the get document query.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// # use serde::{Deserialize, Serialize};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///
+    /// # futures::executor::block_on(async move {
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// struct MyObject {
+    ///     id: String,
+    ///     kind: String,
+    /// }
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// struct MyObjectReduced {
+    ///     id: String,
+    /// }
+    ///
+    /// # let index = client.index("document_query_execute");
+    /// # index.add_or_replace(&[MyObject{id:"1".to_string(), kind:String::from("a kind")},MyObject{id:"2".to_string(), kind:String::from("some kind")}], None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    ///
+    /// let document = DocumentQuery::new(&index).with_fields(["id"]).execute::<MyObjectReduced>("1").await.unwrap();
+    ///
+    /// assert_eq!(
+    ///    document,
+    ///    MyObjectReduced { id: "1".to_string() }
+    /// );
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    pub async fn execute<T: DeserializeOwned + 'static>(
+        &self,
+        document_id: &str,
+    ) -> Result<T, Error> {
+        self.index.get_document_with::<T>(document_id, self).await
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DocumentsQuery<'a> {
+    #[serde(skip_serializing)]
+    pub index: &'a Index,
+
+    /// The number of documents to skip.
+    /// If the value of the parameter `offset` is `n`, the `n` first documents will not be returned.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you want to skip the first document, set offset to `1`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+
+    /// The maximum number of documents returned.
+    /// If the value of the parameter `limit` is `n`, there will never be more than `n` documents in the response.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you don't want to get more than two documents, set limit to `2`.
+    /// Default: `20`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+
+    /// The fields that should appear in the documents. By default all of the fields are present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<&'a str>>,
+}
+
+impl<'a> DocumentsQuery<'a> {
+    pub fn new(index: &Index) -> DocumentsQuery {
+        DocumentsQuery {
+            index,
+            offset: None,
+            limit: None,
+            fields: None,
+        }
+    }
+
+    /// Specify the offset.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let index = client.index("my_index");
+    ///
+    /// let mut documents_query = DocumentsQuery::new(&index).with_offset(1);
+    /// ```
+    pub fn with_offset(&mut self, offset: usize) -> &mut DocumentsQuery<'a> {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Specify the limit.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let index = client.index("my_index");
+    ///
+    /// let mut documents_query = DocumentsQuery::new(&index);
+    ///
+    /// documents_query.with_limit(1);
+    /// ```
+    pub fn with_limit(&mut self, limit: usize) -> &mut DocumentsQuery<'a> {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Specify the fields to return in the documents.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let index = client.index("my_index");
+    ///
+    /// let mut documents_query = DocumentsQuery::new(&index);
+    ///
+    /// documents_query.with_fields(["title"]);
+    /// ```
+    pub fn with_fields(
+        &mut self,
+        fields: impl IntoIterator<Item = &'a str>,
+    ) -> &mut DocumentsQuery<'a> {
+        self.fields = Some(fields.into_iter().collect());
+        self
+    }
+
+    /// Execute the get documents query.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// # use serde::{Deserialize, Serialize};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///
+    /// # futures::executor::block_on(async move {
+    /// # let index = client.create_index("documents_query_execute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// struct MyObject {
+    ///     id: Option<usize>,
+    ///     kind: String,
+    /// }
+    /// let index = client.index("documents_query_execute");
+    ///
+    /// let document = DocumentsQuery::new(&index)
+    ///   .with_offset(1)
+    ///   .execute::<MyObject>()
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn execute<T: DeserializeOwned + 'static>(
+        &self,
+    ) -> Result<DocumentsResults<T>, Error> {
+        self.index.get_documents_with::<T>(self).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{client::*, indexes::*};
+    use meilisearch_test_macro::meilisearch_test;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct MyObject {
+        id: Option<usize>,
+        kind: String,
+    }
+
+    async fn setup_test_index(client: &Client, index: &Index) -> Result<(), Error> {
+        let t0 = index
+            .add_documents(
+                &[
+                    MyObject {
+                        id: Some(0),
+                        kind: "text".into(),
+                    },
+                    MyObject {
+                        id: Some(1),
+                        kind: "text".into(),
+                    },
+                    MyObject {
+                        id: Some(2),
+                        kind: "title".into(),
+                    },
+                    MyObject {
+                        id: Some(3),
+                        kind: "title".into(),
+                    },
+                ],
+                None,
+            )
+            .await?;
+
+        t0.wait_for_completion(client, None, None).await?;
+
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_get_documents_with_execute(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_index(&client, &index).await?;
+        // let documents = index.get_documents(None, None, None).await.unwrap();
+        let documents = DocumentsQuery::new(&index)
+            .with_limit(1)
+            .with_offset(1)
+            .with_fields(["kind"])
+            .execute::<MyObject>()
+            .await
+            .unwrap();
+
+        assert_eq!(documents.limit, 1);
+        assert_eq!(documents.offset, 1);
+        assert_eq!(documents.results.len(), 1);
+
+        Ok(())
+    }
+    #[meilisearch_test]
+    async fn test_get_documents_with_only_one_param(
+        client: Client,
+        index: Index,
+    ) -> Result<(), Error> {
+        setup_test_index(&client, &index).await?;
+        // let documents = index.get_documents(None, None, None).await.unwrap();
+        let documents = DocumentsQuery::new(&index)
+            .with_limit(1)
+            .execute::<MyObject>()
+            .await
+            .unwrap();
+
+        assert_eq!(documents.limit, 1);
+        assert_eq!(documents.offset, 0);
+        assert_eq!(documents.results.len(), 1);
+
+        Ok(())
+    }
+}

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -92,10 +92,10 @@ impl Client {
     /// # });
     /// ```
     pub async fn create_dump(&self) -> Result<DumpInfo, Error> {
-        request::<(), DumpInfo>(
+        request::<Option<()>, (), DumpInfo>(
             &format!("{}/dumps", self.host),
             &self.api_key,
-            Method::Post(()),
+            Method::Post(Data::NonIterable(())),
             202,
         )
         .await
@@ -123,7 +123,7 @@ impl Client {
     /// # });
     /// ```
     pub async fn get_dump_status(&self, dump_uid: impl AsRef<str>) -> Result<DumpInfo, Error> {
-        request::<(), DumpInfo>(
+        request::<Option<()>, (), DumpInfo>(
             &format!("{}/dumps/{}/status", self.host, dump_uid.as_ref()),
             &self.api_key,
             Method::Get,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,6 +34,13 @@ pub enum Error {
     /// The http client encountered an error.
     #[cfg(target_arch = "wasm32")]
     HttpError(String),
+    // The library formating the query parameters encountered an error.
+    Yaup(yaup::Error),
+    // The library validating the format of an uuid.
+    #[cfg(not(target_arch = "wasm32"))]
+    Uuid(uuid::Error),
+    // Error thrown in case the version of the Uuid is not v4.
+    InvalidUuid4Version,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -64,6 +71,19 @@ impl From<MeilisearchError> for Error {
 impl From<jsonwebtoken::errors::Error> for Error {
     fn from(error: jsonwebtoken::errors::Error) -> Error {
         Error::InvalidTenantToken(error)
+    }
+}
+
+impl From<yaup::Error> for Error {
+    fn from(error: yaup::Error) -> Error {
+        Error::Yaup(error)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<uuid::Error> for Error {
+    fn from(error: uuid::Error) -> Error {
+        Error::Uuid(error)
     }
 }
 
@@ -185,7 +205,11 @@ impl std::fmt::Display for Error {
             Error::Timeout => write!(fmt, "A task did not succeed in time."),
             Error::TenantTokensInvalidApiKey => write!(fmt, "The provided api_key is invalid."),
             Error::TenantTokensExpiredSignature => write!(fmt, "The provided expires_at is already expired."),
-            Error::InvalidTenantToken(e) => write!(fmt, "Impossible to generate the token, jsonwebtoken encountered an error: {}", e)
+            Error::InvalidTenantToken(e) => write!(fmt, "Impossible to generate the token, jsonwebtoken encountered an error: {}", e),
+            Error::Yaup(e) => write!(fmt, "Internal Error: could not parse the query parameters: {}", e),
+            #[cfg(not(target_arch = "wasm32"))]
+            Error::Uuid(e) => write!(fmt, "The uid of the token has bit an uuid4 format: {}", e),
+            Error::InvalidUuid4Version => write!(fmt, "The uid provided to the token is not of version uuidv4")
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,7 +24,7 @@ pub enum Error {
     TenantTokensInvalidApiKey,
     /// It is not possible to generate an already expired tenant token.
     TenantTokensExpiredSignature,
-    
+
     /// When jsonwebtoken cannot generate the token successfully.
     InvalidTenantToken(jsonwebtoken::errors::Error),
 

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1,7 +1,14 @@
-use crate::{client::Client, errors::Error, request::*, search::*, tasks::*};
+use crate::{
+    client::Client,
+    documents::{DocumentQuery, DocumentsQuery, DocumentsResults},
+    errors::Error,
+    request::*,
+    search::*,
+    task_info::TaskInfo,
+    tasks::*,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::json;
-use std::{collections::HashMap, fmt::Display, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt::Display, time::Duration};
 use time::OffsetDateTime;
 
 /// An index containing [Document]s.
@@ -37,7 +44,7 @@ use time::OffsetDateTime;
 /// # });
 /// ```
 ///
-/// Or, if you know the index already exist remotely you can create an `Index` with the [Client::index] function.
+/// Or, if you know the index already exist remotely you can create an [Index] with its builder.
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// #
@@ -47,27 +54,39 @@ use time::OffsetDateTime;
 /// # futures::executor::block_on(async move {
 /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
 ///
-/// // use the implicit index creation if the index already exist or
 /// // Meilisearch would be able to create the index if it does not exist during:
 /// // - the documents addition (add and update routes)
 /// // - the settings update
-/// let movies = client.index("index");
+/// let movies = Index::new("movies", client);
 ///
-/// // do something with the index
+/// assert_eq!(movies.uid, "movies");
 /// # });
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Index {
-    pub(crate) uid: Arc<String>,
-    pub(crate) client: Client,
-    pub(crate) primary_key: Option<String>,
-    pub created_at: Option<OffsetDateTime>,
+    #[serde(skip_serializing)]
+    pub client: Client,
+    pub uid: String,
+    #[serde(with = "time::serde::rfc3339::option")]
     pub updated_at: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub created_at: Option<OffsetDateTime>,
+    pub primary_key: Option<String>,
 }
 
 impl Index {
+    pub fn new(uid: impl Into<String>, client: Client) -> Index {
+        Index {
+            uid: uid.into(),
+            client,
+            primary_key: None,
+            created_at: None,
+            updated_at: None,
+        }
+    }
     /// Internal Function to create an [Index] from `serde_json::Value` and [Client]
-    pub(crate) fn from_value(v: serde_json::Value, client: Client) -> Result<Index, Error> {
+    pub(crate) fn from_value(raw_index: serde_json::Value, client: Client) -> Result<Index, Error> {
         #[derive(Deserialize, Debug)]
         #[allow(non_snake_case)]
         struct IndexFromSerde {
@@ -79,10 +98,10 @@ impl Index {
             primaryKey: Option<String>,
         }
 
-        let i: IndexFromSerde = serde_json::from_value(v).map_err(Error::ParseError)?;
+        let i: IndexFromSerde = serde_json::from_value(raw_index).map_err(Error::ParseError)?;
 
         Ok(Index {
-            uid: Arc::new(i.uid),
+            uid: i.uid,
             client,
             created_at: i.createdAt,
             updated_at: i.updatedAt,
@@ -90,20 +109,50 @@ impl Index {
         })
     }
 
-    /// Set the primary key of the index.
+    /// Update an [Index].
     ///
-    /// If you prefer, you can use the method [Index::set_primary_key], which is an alias.
-    pub async fn update(&self, primary_key: impl AsRef<str>) -> Result<(), Error> {
-        request::<Option<()>, serde_json::Value, serde_json::Value>(
-            &format!("{}/indexes/{}", self.client.host, self.uid),
-            &self.client.api_key,
-            Method::Put(Data::NonIterable(
-                json!({ "primaryKey": primary_key.as_ref() }),
-            )),
-            200,
-        )
-        .await?;
-        Ok(())
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, task_info::*, tasks::{Task, SucceededTask}};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let mut index = client
+    /// #   .create_index("index_update", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// # // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///
+    /// index.primary_key = Some("special_id".to_string());
+    /// let task = index.update()
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// let index = client.get_index("index_update").await.unwrap();
+    /// assert_eq!(index.primary_key, Some("special_id".to_string()));
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn update(&self) -> Result<TaskInfo, Error> {
+        let mut index_update = IndexUpdater::new(self, &self.client);
+
+        if let Some(ref primary_key) = self.primary_key {
+            index_update.with_primary_key(primary_key);
+        }
+
+        index_update.execute().await
     }
 
     /// Delete the index.
@@ -126,8 +175,8 @@ impl Index {
     /// client.wait_for_task(task, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn delete(self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn delete(self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!("{}/indexes/{}", self.client.host, self.uid),
             &self.client.api_key,
             Method::Delete,
@@ -236,13 +285,11 @@ impl Index {
     /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// #[derive(Serialize, Deserialize, Debug)]
-    /// # #[derive(PartialEq)]
+    /// #[derive(Serialize, Deserialize, Debug, PartialEq)]
     /// struct Movie {
     ///    name: String,
-    ///    description: String,
+    ///    description: String
     /// }
-    ///
     ///
     /// # futures::executor::block_on(async move {
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
@@ -254,30 +301,81 @@ impl Index {
     ///
     /// assert_eq!(interstellar, Movie {
     ///     name: String::from("Interstellar"),
-    ///     description: String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")
+    ///     description: String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage."),
     /// });
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn get_document<T: 'static + DeserializeOwned>(&self, uid: &str) -> Result<T, Error> {
-        request::<Option<()>, (), T>(
-            &format!(
-                "{}/indexes/{}/documents/{}",
-                self.client.host, self.uid, uid
-            ),
+    pub async fn get_document<T: 'static + DeserializeOwned>(
+        &self,
+        document_id: &str,
+    ) -> Result<T, Error> {
+        let url = format!(
+            "{}/indexes/{}/documents/{}",
+            self.client.host, self.uid, document_id
+        );
+
+        request::<Option<()>, (), T>(&url, &self.client.api_key, Method::Get(()), 200).await
+    }
+
+    /// Get one document with parameters.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// # use serde::{Deserialize, Serialize};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///
+    /// # futures::executor::block_on(async move {
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// struct MyObject {
+    ///     id: String,
+    ///     kind: String,
+    /// }
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// struct MyObjectReduced {
+    ///     id: String,
+    /// }
+    ///
+    /// # let index = client.index("document_query_execute");
+    /// # index.add_or_replace(&[MyObject{id:"1".to_string(), kind:String::from("a kind")},MyObject{id:"2".to_string(), kind:String::from("some kind")}], None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    ///
+    /// let mut document_query = DocumentQuery::new(&index);
+    /// document_query.with_fields(["id"]);
+    ///
+    /// let document = index.get_document_with::<MyObjectReduced>("1", &document_query).await.unwrap();
+    ///
+    /// assert_eq!(
+    ///    document,
+    ///    MyObjectReduced { id: "1".to_string() }
+    /// );
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    pub async fn get_document_with<T: 'static + DeserializeOwned>(
+        &self,
+        document_id: &str,
+        document_query: &DocumentQuery<'_>,
+    ) -> Result<T, Error> {
+        let url = format!(
+            "{}/indexes/{}/documents/{}",
+            self.client.host, self.uid, document_id
+        );
+
+        request::<Option<()>, &DocumentQuery, T>(
+            &url,
             &self.client.api_key,
-            Method::Get,
+            Method::Get(document_query),
             200,
         )
         .await
     }
 
     /// Get [Document]s by batch.
-    ///
-    /// Using the optional parameters offset and limit, you can browse through all your documents.
-    /// If None, offset will be set to 0, limit to 20, and all attributes will be retrieved.
-    ///
-    /// *Note: Documents are ordered by Meilisearch depending on the hash of their id.*
     ///
     /// # Example
     ///
@@ -305,34 +403,76 @@ impl Index {
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
     /// // retrieve movies (you have to put some movies in the index before)
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
     ///
-    /// assert!(movies.len() > 0);
+    /// assert!(movies.results.len() > 0);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
     pub async fn get_documents<T: DeserializeOwned + 'static>(
         &self,
-        offset: Option<usize>,
-        limit: Option<usize>,
-        attributes_to_retrieve: Option<&str>,
-    ) -> Result<Vec<T>, Error> {
-        let mut url = format!("{}/indexes/{}/documents?", self.client.host, self.uid);
-        if let Some(offset) = offset {
-            url.push_str("offset=");
-            url.push_str(offset.to_string().as_str());
-            url.push('&');
-        }
-        if let Some(limit) = limit {
-            url.push_str("limit=");
-            url.push_str(limit.to_string().as_str());
-            url.push('&');
-        }
-        if let Some(attributes_to_retrieve) = attributes_to_retrieve {
-            url.push_str("attributesToRetrieve=");
-            url.push_str(attributes_to_retrieve);
-        }
-        request::<Option<()>, (), Vec<T>>(&url, &self.client.api_key, Method::Get, 200).await
+    ) -> Result<DocumentsResults<T>, Error> {
+        let url = format!("{}/indexes/{}/documents", self.client.host, self.uid);
+
+        request::<Option<()>, (), DocumentsResults<T>>(
+            &url,
+            &self.client.api_key,
+            Method::Get(()),
+            200,
+        )
+        .await
+    }
+
+    /// Get [Document]s by batch with parameters.
+    /// ```
+    /// use serde::{Serialize, Deserialize};
+    ///
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    ///
+    /// #[derive(Serialize, Deserialize, Debug)]
+    /// # #[derive(PartialEq)]
+    /// struct Movie {
+    ///    name: String,
+    ///    description: String,
+    /// }
+    ///
+    /// #[derive(Deserialize, Debug, PartialEq)]
+    /// struct ReturnedMovie {
+    ///    name: String,
+    /// }
+    ///
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let movie_index = client.index("get_documents");
+    ///
+    /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    ///
+    /// let mut query = DocumentsQuery::new(&movie_index);
+    /// query.with_limit(1);
+    /// query.with_fields(["name"]);
+    /// // retrieve movies (you have to put some movies in the index before)
+    /// let movies = movie_index.get_documents_with::<ReturnedMovie>(&query).await.unwrap();
+    ///
+    /// assert!(movies.results.len() == 1);
+    /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn get_documents_with<T: DeserializeOwned + 'static>(
+        &self,
+        documents_query: &DocumentsQuery<'_>,
+    ) -> Result<DocumentsResults<T>, Error> {
+        let url = format!("{}/indexes/{}/documents", self.client.host, self.uid);
+        request::<Option<()>, &DocumentsQuery, DocumentsResults<T>>(
+            &url,
+            &self.client.api_key,
+            Method::Get(documents_query),
+            200,
+        )
+        .await
     }
 
     /// Add a list of [Document]s or replace them if they already exist.
@@ -384,8 +524,8 @@ impl Index {
     /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed
     /// client.wait_for_task(task, None, None).await.unwrap();
     ///
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert!(movies.len() >= 3);
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert!(movies.results.len() >= 3);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
@@ -393,7 +533,7 @@ impl Index {
         &self,
         documents: &[T],
         primary_key: Option<&str>,
-    ) -> Result<Task, Error> {
+    ) -> Result<TaskInfo, Error> {
         let url = if let Some(primary_key) = primary_key {
             format!(
                 "{}/indexes/{}/documents?primaryKey={}",
@@ -402,7 +542,7 @@ impl Index {
         } else {
             format!("{}/indexes/{}/documents", self.client.host, self.uid)
         };
-        request::<&[T], (), Task>(
+        request::<&[T], (), TaskInfo>(
             &url,
             &self.client.api_key,
             Method::Post(Data::Iterable(documents)),
@@ -416,7 +556,7 @@ impl Index {
         &self,
         documents: &[T],
         primary_key: Option<&str>,
-    ) -> Result<Task, Error> {
+    ) -> Result<TaskInfo, Error> {
         self.add_or_replace(documents, primary_key).await
     }
 
@@ -468,8 +608,8 @@ impl Index {
     /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed
     /// client.wait_for_task(task, None, None).await.unwrap();
     ///
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert!(movies.len() >= 3);
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert!(movies.results.len() >= 3);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
@@ -477,7 +617,7 @@ impl Index {
         &self,
         documents: &[T],
         primary_key: Option<impl AsRef<str>>,
-    ) -> Result<Task, Error> {
+    ) -> Result<TaskInfo, Error> {
         let url = if let Some(primary_key) = primary_key {
             format!(
                 "{}/indexes/{}/documents?primaryKey={}",
@@ -488,7 +628,7 @@ impl Index {
         } else {
             format!("{}/indexes/{}/documents", self.client.host, self.uid)
         };
-        request::<&[T], (), Task>(
+        request::<&[T], (), TaskInfo>(
             &url,
             &self.client.api_key,
             Method::Put(Data::Iterable(documents)),
@@ -529,13 +669,13 @@ impl Index {
     ///   .wait_for_completion(&client, None, None)
     ///   .await
     ///   .unwrap();
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert_eq!(movies.len(), 0);
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert_eq!(movies.results.len(), 0);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn delete_all_documents(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn delete_all_documents(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!("{}/indexes/{}/documents", self.client.host, self.uid),
             &self.client.api_key,
             Method::Delete,
@@ -579,8 +719,8 @@ impl Index {
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn delete_document<T: Display>(&self, uid: T) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn delete_document<T: Display>(&self, uid: T) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/documents/{}",
                 self.client.host, self.uid, uid
@@ -631,8 +771,8 @@ impl Index {
     pub async fn delete_documents<T: Display + Serialize + std::fmt::Debug>(
         &self,
         uids: &[T],
-    ) -> Result<Task, Error> {
-        request::<&[T], (), Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<&[T], (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/documents/delete-batch",
                 self.client.host, self.uid
@@ -645,8 +785,13 @@ impl Index {
     }
 
     /// Alias for the [Index::update] method.
-    pub async fn set_primary_key(&self, primary_key: impl AsRef<str>) -> Result<(), Error> {
-        self.update(primary_key).await
+    pub async fn set_primary_key(
+        &mut self,
+        primary_key: impl AsRef<str>,
+    ) -> Result<TaskInfo, Error> {
+        self.primary_key = Some(primary_key.as_ref().to_string());
+
+        self.update().await
     }
 
     /// Fetch the information of the index as a raw JSON [Index], this index should already exist.
@@ -673,7 +818,7 @@ impl Index {
     /// ```
     /// If you use it directly from the [Client], you can use the method [Client::get_raw_index], which is the equivalent method from the client.
     pub async fn fetch_info(&mut self) -> Result<(), Error> {
-        let v = self.client.get_raw_index(self.uid.as_ref()).await?;
+        let v = self.client.get_raw_index(&self.uid).await?;
         *self = Index::from_value(v, self.client.clone())?;
         Ok(())
     }
@@ -743,20 +888,15 @@ impl Index {
     ///    Task::Succeeded { content } => content.uid,
     /// };
     ///
-    /// assert_eq!(task.get_uid(), from_index);
+    /// assert_eq!(task.get_task_uid(), from_index);
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn get_task(&self, uid: impl AsRef<u64>) -> Result<Task, Error> {
+    pub async fn get_task(&self, uid: impl AsRef<u32>) -> Result<Task, Error> {
         request::<Option<()>, (), Task>(
-            &format!(
-                "{}/indexes/{}/tasks/{}",
-                self.client.host,
-                self.uid,
-                uid.as_ref()
-            ),
+            &format!("{}/tasks/{}", self.client.host, uid.as_ref()),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -777,30 +917,50 @@ impl Index {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
-    /// let status = index.get_tasks().await.unwrap();
-    /// assert!(status.len() == 1); // the index was created
+    /// let tasks = index.get_tasks().await.unwrap();
     ///
-    /// index.set_ranking_rules(["wrong_ranking_rule"]).await.unwrap();
-    ///
-    /// let status = index.get_tasks().await.unwrap();
-    /// assert!(status.len() == 2);
+    /// assert!(tasks.results.len() > 0);
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn get_tasks(&self) -> Result<Vec<Task>, Error> {
-        #[derive(Deserialize)]
-        struct AllTasks {
-            results: Vec<Task>,
-        }
+    pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
+        let mut query = TasksQuery::new(&self.client);
+        query.with_index_uid([self.uid.as_str()]);
 
-        Ok(request::<Option<()>, (), AllTasks>(
-            &format!("{}/indexes/{}/tasks", self.client.host, self.uid),
-            &self.client.api_key,
-            Method::Get,
-            200,
-        )
-        .await?
-        .results)
+        self.client.get_tasks_with(&query).await
+    }
+
+    /// Get the status of all tasks in a given index.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use serde::{Serialize, Deserialize};
+    /// # use meilisearch_sdk::{client::*, indexes::*, tasks::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client.create_index("get_tasks_with", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
+    ///
+    /// let mut query = TasksQuery::new(&client);
+    /// query.with_index_uid(["none_existant"]);
+    /// let tasks = index.get_tasks_with(&query).await.unwrap();
+    ///
+    /// assert!(tasks.results.len() > 0);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn get_tasks_with(
+        &self,
+        tasks_query: &TasksQuery<'_>,
+    ) -> Result<TasksResults, Error> {
+        let mut query = tasks_query.clone();
+        query.with_index_uid([self.uid.as_str()]);
+
+        self.client.get_tasks_with(&query).await
     }
 
     /// Get stats of an index.
@@ -823,10 +983,10 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_stats(&self) -> Result<IndexStats, Error> {
-        request::<Option<()>, serde_json::Value, IndexStats>(
+        request::<Option<()>, (), IndexStats>(
             &format!("{}/indexes/{}/stats", self.client.host, self.uid),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -875,7 +1035,7 @@ impl Index {
     /// ```
     pub async fn wait_for_task(
         &self,
-        task_id: impl AsRef<u64>,
+        task_id: impl AsRef<u32>,
         interval: Option<Duration>,
         timeout: Option<Duration>,
     ) -> Result<Task, Error> {
@@ -928,8 +1088,8 @@ impl Index {
     ///
     /// client.wait_for_task(tasks.last().unwrap(), None, None).await.unwrap();
     ///
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert!(movies.len() >= 3);
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert!(movies.results.len() >= 3);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None,
     /// None).await.unwrap();
     /// # });
@@ -939,7 +1099,7 @@ impl Index {
         documents: &[T],
         batch_size: Option<usize>,
         primary_key: Option<&str>,
-    ) -> Result<Vec<Task>, Error> {
+    ) -> Result<Vec<TaskInfo>, Error> {
         let mut task = Vec::with_capacity(documents.len());
         for document_batch in documents.chunks(batch_size.unwrap_or(1000)) {
             task.push(self.add_documents(document_batch, primary_key).await?);
@@ -993,8 +1153,8 @@ impl Index {
     ///
     /// client.wait_for_task(tasks.last().unwrap(), None, None).await.unwrap();
     ///
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert!(movies.len() >= 3);
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert!(movies.results.len() >= 3);
     ///
     /// let updated_movies = [
     ///  Movie {
@@ -1015,10 +1175,10 @@ impl Index {
     ///
     /// client.wait_for_task(tasks.last().unwrap(), None, None).await.unwrap();
     ///
-    /// let movies_updated = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert!(movies_updated.len() >= 3);
+    /// let movies_updated = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert!(movies_updated.results.len() >= 3);
     ///
-    /// assert!(&movies_updated[..] == &updated_movies[..]);
+    /// assert!(&movies_updated.results[..] == &updated_movies[..]);
     ///
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None,
     /// None).await.unwrap();
@@ -1029,7 +1189,7 @@ impl Index {
         documents: &[T],
         batch_size: Option<usize>,
         primary_key: Option<&str>,
-    ) -> Result<Vec<Task>, Error> {
+    ) -> Result<Vec<TaskInfo>, Error> {
         let mut task = Vec::with_capacity(documents.len());
         for document_batch in documents.chunks(batch_size.unwrap_or(1000)) {
             task.push(self.add_or_update(document_batch, primary_key).await?);
@@ -1044,6 +1204,163 @@ impl AsRef<str> for Index {
     }
 }
 
+/// An [IndexUpdater] used to update the specifics of an index
+///
+/// # Example
+///
+/// ```
+/// # use meilisearch_sdk::{client::*, indexes::*, task_info::*, tasks::{Task, SucceededTask}};
+/// #
+/// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+/// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+/// #
+/// # futures::executor::block_on(async move {
+/// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+/// # let index = client
+/// #   .create_index("index_updater", None)
+/// #   .await
+/// #   .unwrap()
+/// #   .wait_for_completion(&client, None, None)
+/// #   .await
+/// #   .unwrap()
+/// # // Once the task finished, we try to create an `Index` out of it
+/// #   .try_make_index(&client)
+/// #   .unwrap();
+///
+/// let task = IndexUpdater::new("index_updater", &client)
+///   .with_primary_key("special_id")
+///   .execute()
+///   .await
+///   .unwrap()
+///   .wait_for_completion(&client, None, None)
+///   .await
+///   .unwrap();
+///
+/// let index = client.get_index("index_updater").await.unwrap();
+/// assert_eq!(index.primary_key, Some("special_id".to_string()));
+/// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+/// # });
+/// ```
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexUpdater<'a> {
+    #[serde(skip)]
+    pub client: &'a Client,
+    #[serde(skip_serializing)]
+    pub uid: String,
+    pub primary_key: Option<String>,
+}
+
+impl<'a> IndexUpdater<'a> {
+    pub fn new(uid: impl AsRef<str>, client: &Client) -> IndexUpdater {
+        IndexUpdater {
+            client,
+            primary_key: None,
+            uid: uid.as_ref().to_string(),
+        }
+    }
+    /// Define the new primary_key to set on the [Index]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, task_info::*, tasks::{Task, SucceededTask}};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_updater_with_primary_key", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// # // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///
+    /// let task = IndexUpdater::new("index_updater_with_primary_key", &client)
+    ///   .with_primary_key("special_id")
+    ///   .execute()
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// let index = client.get_index("index_updater_with_primary_key").await.unwrap();
+    /// assert_eq!(index.primary_key, Some("special_id".to_string()));
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_primary_key(&mut self, primary_key: impl AsRef<str>) -> &mut Self {
+        self.primary_key = Some(primary_key.as_ref().to_string());
+        self
+    }
+
+    /// Execute the update of an [Index] using the [IndexUpdater]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, task_info::*, tasks::{Task, SucceededTask}};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_updater_execute", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// # // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///
+    /// let task = IndexUpdater::new("index_updater_execute", &client)
+    ///   .with_primary_key("special_id")
+    ///   .execute()
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// let index = client.get_index("index_updater_execute").await.unwrap();
+    /// assert_eq!(index.primary_key, Some("special_id".to_string()));
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn execute(&'a self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, &IndexUpdater, TaskInfo>(
+            &format!("{}/indexes/{}", self.client.host, self.uid),
+            &self.client.api_key,
+            Method::Patch(Data::NonIterable(self)),
+            202,
+        )
+        .await
+    }
+}
+
+impl AsRef<str> for IndexUpdater<'_> {
+    fn as_ref(&self) -> &str {
+        &self.uid
+    }
+}
+
+impl<'a> AsRef<IndexUpdater<'a>> for IndexUpdater<'a> {
+    fn as_ref(&self) -> &IndexUpdater<'a> {
+        self
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexStats {
@@ -1052,11 +1369,187 @@ pub struct IndexStats {
     pub field_distribution: HashMap<String, usize>,
 }
 
+// An [IndexesQuery] containing filter and pagination parameters when searching for [Index]es
+///
+/// # Example
+///
+/// ```
+/// # use meilisearch_sdk::{client::*, indexes::*};
+/// #
+/// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+/// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+/// #
+/// # futures::executor::block_on(async move {
+/// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+/// # let index = client
+/// #   .create_index("index_query_builder", None)
+/// #   .await
+/// #   .unwrap()
+/// #   .wait_for_completion(&client, None, None)
+/// #   .await
+/// #   .unwrap()
+/// #   // Once the task finished, we try to create an `Index` out of it
+/// #   .try_make_index(&client)
+/// #   .unwrap();
+///  let mut indexes = IndexesQuery::new(&client)
+///   .with_limit(1)
+///   .execute().await.unwrap();
+///
+/// # assert_eq!(indexes.results.len(), 1);
+/// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+/// # });
+/// ```
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexesQuery<'a> {
+    #[serde(skip_serializing)]
+    pub client: &'a Client,
+    /// The number of [Index]es to skip.
+    /// If the value of the parameter `offset` is `n`, the `n` first indexes will not be returned.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you want to skip the first index, set offset to `1`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+
+    /// The maximum number of [Index]es returned.
+    /// If the value of the parameter `limit` is `n`, there will never be more than `n` indexes in the response.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you don't want to get more than two indexes, set limit to `2`.
+    /// Default: `20`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
+impl<'a> IndexesQuery<'a> {
+    pub fn new(client: &Client) -> IndexesQuery {
+        IndexesQuery {
+            client,
+            offset: None,
+            limit: None,
+        }
+    }
+
+    /// Specify the offset.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_query_with_offset", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///
+    ///  let mut indexes = IndexesQuery::new(&client)
+    ///   .with_offset(1)
+    ///   .execute().await.unwrap();
+    ///
+    /// # assert_eq!(indexes.offset, 1);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_offset(&mut self, offset: usize) -> &mut IndexesQuery<'a> {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Specify the maximum number of [Index]es to return.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_query_with_limit", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///  let mut indexes = IndexesQuery::new(&client)
+    ///   .with_limit(1)
+    ///   .execute().await.unwrap();
+    ///
+    /// # assert_eq!(indexes.results.len(), 1);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_limit(&mut self, limit: usize) -> &mut IndexesQuery<'a> {
+        self.limit = Some(limit);
+        self
+    }
+    /// Get [Index]es.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{indexes::IndexesQuery, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_query_with_execute", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///  let mut indexes = IndexesQuery::new(&client)
+    ///   .with_limit(1)
+    ///   .execute().await.unwrap();
+    ///
+    /// # assert_eq!(indexes.results.len(), 1);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn execute(&self) -> Result<IndexesResults, Error> {
+        self.client.list_all_indexes_with(self).await
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IndexesResults {
+    pub results: Vec<Index>,
+    pub limit: u32,
+    pub offset: u32,
+    pub total: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use meilisearch_test_macro::meilisearch_test;
+    use serde_json::json;
 
     #[meilisearch_test]
     async fn test_from_value(client: Client) {
@@ -1073,7 +1566,7 @@ mod tests {
         });
 
         let idx = Index {
-            uid: Arc::new("test_from_value".to_string()),
+            uid: "test_from_value".to_string(),
             primary_key: None,
             created_at: Some(t),
             updated_at: Some(t),
@@ -1100,10 +1593,37 @@ mod tests {
     }
 
     #[meilisearch_test]
-    async fn test_get_tasks_no_docs(index: Index) {
-        // The at this point the only task that is supposed to exist is the creation of the index
-        let status = index.get_tasks().await.unwrap();
-        assert_eq!(status.len(), 1);
+    async fn test_get_documents(index: Index) {
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        struct Object {
+            id: usize,
+            value: String,
+            kind: String,
+        }
+        let res = index.get_documents::<Object>().await.unwrap();
+
+        assert_eq!(res.limit, 20)
+    }
+
+    #[meilisearch_test]
+    async fn test_get_documents_with(index: Index) {
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        struct Object {
+            id: usize,
+            value: String,
+            kind: String,
+        }
+
+        let mut documents_query = DocumentsQuery::new(&index);
+        documents_query.with_limit(1).with_offset(2);
+
+        let res = index
+            .get_documents_with::<Object>(&documents_query)
+            .await
+            .unwrap();
+
+        assert_eq!(res.limit, 1);
+        assert_eq!(res.offset, 2);
     }
 
     #[meilisearch_test]
@@ -1117,10 +1637,42 @@ mod tests {
         let status = index.get_task(task).await?;
 
         match status {
-            Task::Enqueued { content } => assert_eq!(content.index_uid, *index.uid),
-            Task::Processing { content } => assert_eq!(content.index_uid, *index.uid),
-            Task::Failed { content } => assert_eq!(content.task.index_uid, *index.uid),
-            Task::Succeeded { content } => assert_eq!(content.index_uid, *index.uid),
+            Task::Enqueued {
+                content:
+                    EnqueuedTask {
+                        index_uid: Some(index_uid),
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            Task::Processing {
+                content:
+                    EnqueuedTask {
+                        index_uid: Some(index_uid),
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            Task::Failed {
+                content:
+                    FailedTask {
+                        task:
+                            SucceededTask {
+                                index_uid: Some(index_uid),
+                                ..
+                            },
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            Task::Succeeded {
+                content:
+                    SucceededTask {
+                        index_uid: Some(index_uid),
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            task => panic!(
+                "The task should have an index_uid that is not null {:?}",
+                task
+            ),
         }
         Ok(())
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -6,20 +6,23 @@ use crate::{client::Client, errors::Error};
 /// Represent a [meilisearch key](https://docs.meilisearch.com/reference/api/keys.html#returned-fields)
 /// You can get a [Key] from the [Client::get_key] method.
 /// Or you can create a [Key] with the [KeyBuilder::create] or [Client::create_key] methods.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Key {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub actions: Vec<Action>,
     #[serde(skip_serializing, with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    pub description: String,
+    pub description: Option<String>,
+    pub name: Option<String>,
     #[serde(with = "time::serde::rfc3339::option")]
     pub expires_at: Option<OffsetDateTime>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub indexes: Vec<String>,
     #[serde(skip_serializing)]
     pub key: String,
+    #[serde(skip_serializing)]
+    pub uid: String,
     #[serde(skip_serializing, with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
 }
@@ -37,23 +40,23 @@ impl Key {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
+    /// let description = "My not so little lovely test key".to_string();
+    /// let mut key = KeyBuilder::new()
     ///   .with_action(Action::DocumentsAdd)
     ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
+    ///   .with_description(&description)
+    ///   .execute(&client).await.unwrap();
     ///
-    /// key.with_description("My not so little lovely test key");
-    /// # assert_eq!(key.description, "My not so little lovely test key".to_string());
+    /// # assert_eq!(key.description, Some(description));
     /// # client.delete_key(key).await.unwrap();
     /// # });
     /// ```
     pub fn with_description(&mut self, desc: impl AsRef<str>) -> &mut Self {
-        self.description = desc.as_ref().to_string();
+        self.description = Some(desc.as_ref().to_string());
         self
     }
 
-    /// Add a set of actions the [Key] will be able to execute.
+    /// Update the name of the key.
     ///
     /// # Example
     ///
@@ -65,134 +68,19 @@ impl Key {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
+    ///  let name = "lovely key".to_string();
+    ///  let mut key = KeyBuilder::new()
     ///   .with_action(Action::DocumentsAdd)
     ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
+    ///   .execute(&client).await.unwrap();
     ///
-    /// key.with_actions([Action::DocumentsGet, Action::DocumentsDelete]);
+    ///  key.with_name(&name);
+    /// # assert_eq!(key.name, Some(name));
     /// # client.delete_key(key).await.unwrap();
     /// # });
     /// ```
-    pub fn with_actions(&mut self, actions: impl IntoIterator<Item = Action>) -> &mut Self {
-        self.actions.extend(actions);
-        self
-    }
-
-    /// Add one action the [Key] will be able to execute.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
-    /// #
-    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// #
-    /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .with_action(Action::DocumentsAdd)
-    ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// key.with_action(Action::DocumentsGet);
-    /// # client.delete_key(key).await.unwrap();
-    /// # });
-    /// ```
-    pub fn with_action(&mut self, action: Action) -> &mut Self {
-        self.actions.push(action);
-        self
-    }
-
-    /// Update the expiration date of the [Key].
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
-    /// use time::{OffsetDateTime, Duration};
-    /// #
-    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// #
-    /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .with_action(Action::DocumentsAdd)
-    ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// // update the epiry date of the key to two weeks from now
-    /// key.with_expires_at(OffsetDateTime::now_utc() + Duration::WEEK * 2);
-    /// # client.delete_key(key).await.unwrap();
-    /// # });
-    /// ```
-    pub fn with_expires_at(&mut self, expires_at: OffsetDateTime) -> &mut Self {
-        self.expires_at = Some(expires_at);
-        self
-    }
-
-    /// Update the indexes the [Key] can manage.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
-    /// #
-    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// #
-    /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .with_action(Action::DocumentsAdd)
-    ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// key.with_indexes(vec!["test", "movies"]);
-    /// # client.delete_key(key).await.unwrap();
-    /// # });
-    /// ```
-    pub fn with_indexes(
-        &mut self,
-        indexes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> &mut Self {
-        self.indexes = indexes
-            .into_iter()
-            .map(|index| index.as_ref().to_string())
-            .collect();
-        self
-    }
-
-    /// Add one index the [Key] can manage.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
-    /// #
-    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// #
-    /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .with_action(Action::DocumentsAdd)
-    ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// key.with_index("test");
-    /// # client.delete_key(key).await.unwrap();
-    /// # });
-    /// ```
-    pub fn with_index(&mut self, index: impl AsRef<str>) -> &mut Self {
-        self.indexes.push(index.as_ref().to_string());
+    pub fn with_name(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.name = Some(desc.as_ref().to_string());
         self
     }
 
@@ -208,21 +96,50 @@ impl Key {
     /// #
     /// # futures::executor::block_on(async move {
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    /// let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// # assert_eq!(key.description, "My little lovely test key");
-    ///
-    /// key.with_description("My not so little lovely test key");
+    /// let mut key = KeyBuilder::new()
+    ///   .execute(&client).await.unwrap();
+    /// let description = "My not so little lovely test key".to_string();
+    /// key.with_description(&description);
     /// let key = key.update(&client).await.unwrap();
     ///
-    /// # assert_eq!(key.description, "My not so little lovely test key".to_string());
-    ///
+    /// # assert_eq!(key.description, Some(description));
     /// # client.delete_key(key).await.unwrap();
     /// # });
     /// ```
     pub async fn update(&self, client: &Client) -> Result<Key, Error> {
-        client.update_key(self).await
+        // only send description and name
+        let mut key_update = KeyUpdater::new(self);
+
+        if let Some(ref description) = self.description {
+            key_update.with_description(description);
+        }
+        if let Some(ref name) = self.name {
+            key_update.with_name(name);
+        }
+
+        key_update.execute(client).await
+    }
+
+    /// Delete the [Key].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let mut key = KeyBuilder::new()
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn delete(&self, client: &Client) -> Result<(), Error> {
+        client.delete_key(self).await
     }
 }
 
@@ -235,6 +152,236 @@ impl AsRef<str> for Key {
 impl AsRef<Key> for Key {
     fn as_ref(&self) -> &Key {
         self
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyUpdater {
+    pub description: Option<String>,
+    pub name: Option<String>,
+    #[serde(skip_serializing)]
+    pub key: String,
+}
+
+impl KeyUpdater {
+    pub fn new(key_or_uid: impl AsRef<str>) -> KeyUpdater {
+        KeyUpdater {
+            description: None,
+            name: None,
+            key: key_or_uid.as_ref().to_string(),
+        }
+    }
+
+    /// Update the description of the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client, key::KeyUpdater};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut new_key = KeyBuilder::new()
+    ///     .execute(&client)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let description = "My not so little lovely test key".to_string();
+    /// let mut key_update = KeyUpdater::new(new_key)
+    ///     .with_description(&description)
+    ///     .execute(&client)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// # assert_eq!(key_update.description, Some(description));
+    /// # client.delete_key(key_update).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_description(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.description = Some(desc.as_ref().to_string());
+        self
+    }
+
+    /// Update the name of the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client, key::KeyUpdater};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut new_key = KeyBuilder::new()
+    ///     .execute(&client)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let name = "lovely key".to_string();
+    ///
+    /// let mut key_update = KeyUpdater::new(new_key)
+    ///     .with_name(&name)
+    ///     .execute(&client)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// # assert_eq!(key_update.name, Some(name));
+    /// # client.delete_key(key_update).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_name(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.name = Some(desc.as_ref().to_string());
+        self
+    }
+
+    /// Update a [Key] using the [KeyUpdater].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::KeyUpdater, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let description = "My little lovely test key".to_string();
+    /// let key = KeyBuilder::new()
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// let mut key_update = KeyUpdater::new(&key.key);
+    /// key_update.with_description(&description).execute(&client).await;
+    ///
+    /// assert_eq!(key_update.description, Some(description));
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn execute(&self, client: &Client) -> Result<Key, Error> {
+        client.update_key(self).await
+    }
+}
+
+impl AsRef<str> for KeyUpdater {
+    fn as_ref(&self) -> &str {
+        &self.key
+    }
+}
+
+impl AsRef<KeyUpdater> for KeyUpdater {
+    fn as_ref(&self) -> &KeyUpdater {
+        self
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct KeysQuery {
+    /// The number of documents to skip.
+    /// If the value of the parameter `offset` is `n`, the `n` first documents (ordered by relevance) will not be returned.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you want to skip the first document, set offset to `1`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+    /// The maximum number of documents returned.
+    /// If the value of the parameter `limit` is `n`, there will never be more than `n` documents in the response.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you don't want to get more than two documents, set limit to `2`.
+    /// Default: `20`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
+impl KeysQuery {
+    /// Create a [KeysQuery] with only a description.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeysQuery};
+    /// let builder = KeysQuery::new();
+    /// ```
+    pub fn new() -> KeysQuery {
+        Self::default()
+    }
+
+    /// Specify the offset.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeysQuery, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut keys = KeysQuery::new()
+    ///   .with_offset(1)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(keys.offset, 1);
+    /// # });
+    /// ```
+    pub fn with_offset(&mut self, offset: usize) -> &mut KeysQuery {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Specify the maximum number of keys to return.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeysQuery, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut keys = KeysQuery::new()
+    ///   .with_limit(1)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(keys.results.len(), 1);
+    /// # });
+    /// ```
+    pub fn with_limit(&mut self, limit: usize) -> &mut KeysQuery {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Get [Key]'s.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeysQuery, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut keys = KeysQuery::new()
+    ///   .with_limit(1)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(keys.results.len(), 1);
+    /// # });
+    /// ```
+    pub async fn execute(&self, client: &Client) -> Result<KeysResults, Error> {
+        client.get_keys_with(self).await
     }
 }
 
@@ -251,42 +398,41 @@ impl AsRef<Key> for Key {
 /// #
 /// # futures::executor::block_on(async move {
 /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+/// let description = "My little lovely test key".to_string();
+/// let key = KeyBuilder::new()
+///   .with_description(&description)
+///   .execute(&client).await.unwrap();
 ///
-/// let key = KeyBuilder::new("My little lovely test key")
-///   .with_action(Action::DocumentsAdd)
-///   .with_index("*")
-///   .create(&client).await.unwrap();
-///
-/// assert_eq!(key.description, "My little lovely test key");
+/// # assert_eq!(key.description, Some(description));
 /// # client.delete_key(key).await.unwrap();
 /// # });
 /// ```
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyBuilder {
     pub actions: Vec<Action>,
-    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     #[serde(with = "time::serde::rfc3339::option")]
     pub expires_at: Option<OffsetDateTime>,
     pub indexes: Vec<String>,
 }
 
 impl KeyBuilder {
-    /// Create a [KeyBuilder] with only a description.
+    /// Create a [KeyBuilder].
     ///
     /// # Example
     ///
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder};
-    /// let builder = KeyBuilder::new("My little lovely test key");
+    /// let builder = KeyBuilder::new();
     /// ```
-    pub fn new(description: impl AsRef<str>) -> KeyBuilder {
-        Self {
-            actions: Vec::new(),
-            description: description.as_ref().to_string(),
-            expires_at: None,
-            indexes: Vec::new(),
-        }
+    pub fn new() -> KeyBuilder {
+        Self::default()
     }
 
     /// Declare a set of actions the [Key] will be able to execute.
@@ -295,7 +441,7 @@ impl KeyBuilder {
     ///
     /// ```
     /// # use meilisearch_sdk::key::{KeyBuilder, Action};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
+    /// let mut builder = KeyBuilder::new();
     /// builder.with_actions(vec![Action::Search, Action::DocumentsAdd]);
     /// ```
     pub fn with_actions(&mut self, actions: impl IntoIterator<Item = Action>) -> &mut Self {
@@ -309,7 +455,7 @@ impl KeyBuilder {
     ///
     /// ```
     /// # use meilisearch_sdk::key::{KeyBuilder, Action};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
+    /// let mut builder = KeyBuilder::new();
     /// builder.with_action(Action::DocumentsAdd);
     /// ```
     pub fn with_action(&mut self, action: Action) -> &mut Self {
@@ -324,7 +470,7 @@ impl KeyBuilder {
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder};
     /// use time::{OffsetDateTime, Duration};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
+    /// let mut builder = KeyBuilder::new();
     /// // create a key that expires in two weeks from now
     /// builder.with_expires_at(OffsetDateTime::now_utc() + Duration::WEEK * 2);
     /// ```
@@ -338,9 +484,22 @@ impl KeyBuilder {
     /// # Example
     ///
     /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
-    /// builder.with_indexes(vec!["test", "movies"]);
+    /// # use meilisearch_sdk::{key::KeyBuilder, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let mut key = KeyBuilder::new()
+    ///   .with_indexes(vec!["test", "movies"])
+    ///   .execute(&client)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// assert_eq!(vec!["test", "movies"], key.indexes);
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
     /// ```
     pub fn with_indexes(
         &mut self,
@@ -359,11 +518,93 @@ impl KeyBuilder {
     ///
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
+    /// let mut builder = KeyBuilder::new();
     /// builder.with_index("test");
     /// ```
     pub fn with_index(&mut self, index: impl AsRef<str>) -> &mut Self {
         self.indexes.push(index.as_ref().to_string());
+        self
+    }
+
+    /// Add a description to the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let description = "My not so little lovely test key".to_string();
+    ///
+    ///  let mut key = KeyBuilder::new()
+    ///   .with_description(&description)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(key.description, Some(description));
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_description(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.description = Some(desc.as_ref().to_string());
+        self
+    }
+
+    /// Add a name to the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let name = "lovely key".to_string();
+    ///
+    ///  let mut key = KeyBuilder::new()
+    ///   .with_name(&name)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(key.name, Some(name));
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_name(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.name = Some(desc.as_ref().to_string());
+        self
+    }
+
+    /// Add an uid to the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let uid = "93bcd7fb-2196-4fd9-acb7-3fca8a96e78f".to_string();
+    ///
+    ///  let mut key = KeyBuilder::new()
+    ///   .with_uid(&uid)
+    ///   .execute(&client).await.unwrap();
+    ///  
+    ///
+    /// # assert_eq!(key.uid, uid);
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_uid(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.uid = Some(desc.as_ref().to_string());
         self
     }
 
@@ -379,14 +620,16 @@ impl KeyBuilder {
     /// #
     /// # futures::executor::block_on(async move {
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    /// let key = KeyBuilder::new("My little lovely test key")
-    ///   .create(&client).await.unwrap();
+    /// let description = "My little lovely test key".to_string();
+    /// let key = KeyBuilder::new()
+    ///    .with_description(&description)
+    ///   .execute(&client).await.unwrap();
     ///
-    /// assert_eq!(key.description, "My little lovely test key");
+    /// # assert_eq!(key.description, Some(description));
     /// # client.delete_key(key).await.unwrap();
     /// # });
     /// ```
-    pub async fn create(&self, client: &Client) -> Result<Key, Error> {
+    pub async fn execute(&self, client: &Client) -> Result<Key, Error> {
         client.create_key(self).await
     }
 }
@@ -447,4 +690,23 @@ pub enum Action {
     /// Provides access to the [get Meilisearch version](https://docs.meilisearch.com/reference/api/version.md#get-version-of-meilisearch) endpoint.
     #[serde(rename = "version")]
     Version,
+    /// Provides access to the [get Key](https://docs.meilisearch.com/reference/api/keys.html#get-one-key) and [get Keys](https://docs.meilisearch.com/reference/api/keys.html#get-all-keys) endpoints.
+    #[serde(rename = "keys.get")]
+    KeyGet,
+    /// Provides access to the [create key](https://docs.meilisearch.com/reference/api/keys.html#create-a-key) endpoint.
+    #[serde(rename = "keys.create")]
+    KeyCreate,
+    /// Provides access to the [update key](https://docs.meilisearch.com/reference/api/keys.html#update-a-key) endpoint.
+    #[serde(rename = "keys.update")]
+    KeyUpdate,
+    /// Provides access to the [delete key](https://docs.meilisearch.com/reference/api/keys.html#delete-a-key) endpoint.
+    #[serde(rename = "keys.delete")]
+    KeyDelete,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KeysResults {
+    pub results: Vec<Key>,
+    pub limit: u32,
+    pub offset: u32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@
 //!   ],
 //!   "offset": 0,
 //!   "limit": 20,
-//!   "nbHits": 1,
+//!   "estimatedTotalHits": 1,
 //!   "processingTimeMs": 0,
 //!   "query": "wonder"
 //! }
@@ -225,6 +225,8 @@
 
 /// Module containing the [client::Client] struct.
 pub mod client;
+/// Module representing the [documents] structures.
+pub mod documents;
 /// Module containing the [document::Document] trait.
 pub mod dumps;
 /// Module containing the [errors::Error] struct.
@@ -238,7 +240,11 @@ mod request;
 pub mod search;
 /// Module containing [settings::Settings].
 pub mod settings;
+/// Module representing the [task_info::TaskInfo]s.
+pub mod task_info;
 /// Module representing the [tasks::Task]s.
 pub mod tasks;
 /// Module that generates tenant tokens.
 mod tenant_tokens;
+/// Module containing utilies functions.
+mod utils;

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize, Serializer};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct MatchRange {
     pub start: usize,
     pub length: usize,
@@ -20,8 +20,8 @@ pub struct SearchResult<T> {
     #[serde(rename = "_formatted")]
     pub formatted_result: Option<Map<String, Value>>,
     /// The object that contains information about the matches.
-    #[serde(rename = "_matchesInfo")]
-    pub matches_info: Option<HashMap<String, Vec<MatchRange>>>,
+    #[serde(rename = "_matchesPosition")]
+    pub matches_position: Option<HashMap<String, Vec<MatchRange>>>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -35,13 +35,9 @@ pub struct SearchResults<T> {
     /// Number of results returned
     pub limit: usize,
     /// Total number of matches
-    pub nb_hits: usize,
-    /// Whether nb_hits is exhaustive
-    pub exhaustive_nb_hits: bool,
+    pub estimated_total_hits: usize,
     /// Distribution of the given facets
-    pub facets_distribution: Option<HashMap<String, HashMap<String, usize>>>,
-    /// Whether facet_distribution is exhaustive
-    pub exhaustive_facets_count: Option<bool>,
+    pub facet_distribution: Option<HashMap<String, HashMap<String, usize>>>,
     /// Processing time of the query
     pub processing_time_ms: usize,
     /// Query originating the response
@@ -101,18 +97,40 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 /// # Examples
 ///
 /// ```
+/// use serde::{Serialize, Deserialize};
 /// # use meilisearch_sdk::{client::Client, search::Query, indexes::Index};
 /// #
 /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
+/// #[derive(Serialize, Deserialize, Debug)]
+/// struct Movie {
+///     name: String,
+///     description: String,
+/// }
+///
+/// # futures::executor::block_on(async move {
 /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-/// # let index = client.index("does not matter");
-/// let query = Query::new(&index)
+/// # let index = client
+/// #  .create_index("search_query_builder", None)
+/// #  .await
+/// #  .unwrap()
+/// #  .wait_for_completion(&client, None, None)
+/// #  .await.unwrap()
+/// #  .try_make_index(&client)
+/// #  .unwrap();
+///
+/// let mut res = Query::new(&index)
 ///     .with_query("space")
 ///     .with_offset(42)
 ///     .with_limit(21)
-///     .build(); // you can also execute() instead of build()
+///     .execute::<Movie>()
+///     .await
+///     .unwrap();
+///
+/// assert_eq!(res.limit, 21);
+/// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+/// # });
 /// ```
 ///
 /// ```
@@ -122,7 +140,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
 /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-/// # let index = client.index("does not matter");
+/// # let index = client.index("search_query_builder_build");
 /// let query = index.search()
 ///     .with_query("space")
 ///     .with_offset(42)
@@ -163,7 +181,7 @@ pub struct Query<'a> {
     /// Default: all attributes found in the documents.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(serialize_with = "serialize_with_wildcard")]
-    pub facets_distribution: Option<Selectors<&'a [&'a str]>>,
+    pub facets: Option<Selectors<&'a [&'a str]>>,
     /// Attributes to sort.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<&'a [&'a str]>,
@@ -215,7 +233,7 @@ pub struct Query<'a> {
     ///
     /// Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub matches: Option<bool>,
+    pub show_matches_position: Option<bool>,
 }
 
 #[allow(missing_docs)]
@@ -228,7 +246,7 @@ impl<'a> Query<'a> {
             limit: None,
             filter: None,
             sort: None,
-            facets_distribution: None,
+            facets: None,
             attributes_to_retrieve: None,
             attributes_to_crop: None,
             crop_length: None,
@@ -236,13 +254,14 @@ impl<'a> Query<'a> {
             attributes_to_highlight: None,
             highlight_pre_tag: None,
             highlight_post_tag: None,
-            matches: None,
+            show_matches_position: None,
         }
     }
     pub fn with_query<'b>(&'b mut self, query: &'a str) -> &'b mut Query<'a> {
         self.query = Some(query);
         self
     }
+
     pub fn with_offset<'b>(&'b mut self, offset: usize) -> &'b mut Query<'a> {
         self.offset = Some(offset);
         self
@@ -255,11 +274,8 @@ impl<'a> Query<'a> {
         self.filter = Some(filter);
         self
     }
-    pub fn with_facets_distribution<'b>(
-        &'b mut self,
-        facets_distribution: Selectors<&'a [&'a str]>,
-    ) -> &'b mut Query<'a> {
-        self.facets_distribution = Some(facets_distribution);
+    pub fn with_facets<'b>(&'b mut self, facets: Selectors<&'a [&'a str]>) -> &'b mut Query<'a> {
+        self.facets = Some(facets);
         self
     }
     pub fn with_sort<'b>(&'b mut self, sort: &'a [&'a str]) -> &'b mut Query<'a> {
@@ -309,8 +325,11 @@ impl<'a> Query<'a> {
         self.highlight_post_tag = Some(highlight_post_tag);
         self
     }
-    pub fn with_matches<'b>(&'b mut self, matches: bool) -> &'b mut Query<'a> {
-        self.matches = Some(matches);
+    pub fn with_show_matches_position<'b>(
+        &'b mut self,
+        show_matches_position: bool,
+    ) -> &'b mut Query<'a> {
+        self.show_matches_position = Some(show_matches_position);
         self
     }
     pub fn build(&mut self) -> Query<'a> {
@@ -373,6 +392,19 @@ mod tests {
         t1.wait_for_completion(client, None, None).await?;
         t0.wait_for_completion(client, None, None).await?;
 
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_query_builder(_client: Client, index: Index) -> Result<(), Error> {
+        let mut query = Query::new(&index);
+        query.with_query("space").with_offset(42).with_limit(21);
+
+        let res = query.execute::<Document>().await.unwrap();
+
+        assert_eq!(res.query, "space".to_string());
+        assert_eq!(res.limit, 21);
+        assert_eq!(res.offset, 42);
         Ok(())
     }
 
@@ -450,11 +482,11 @@ mod tests {
         setup_test_index(&client, &index).await?;
 
         let mut query = Query::new(&index);
-        query.with_facets_distribution(Selectors::All);
+        query.with_facets(Selectors::All);
         let results: SearchResults<Document> = index.execute_query(&query).await?;
         assert_eq!(
             results
-                .facets_distribution
+                .facet_distribution
                 .unwrap()
                 .get("kind")
                 .unwrap()
@@ -464,11 +496,11 @@ mod tests {
         );
 
         let mut query = Query::new(&index);
-        query.with_facets_distribution(Selectors::Some(&["kind"]));
+        query.with_facets(Selectors::Some(&["kind"]));
         let results: SearchResults<Document> = index.execute_query(&query).await?;
         assert_eq!(
             results
-                .facets_distribution
+                .facet_distribution
                 .clone()
                 .unwrap()
                 .get("kind")
@@ -479,7 +511,7 @@ mod tests {
         );
         assert_eq!(
             results
-                .facets_distribution
+                .facet_distribution
                 .unwrap()
                 .get("kind")
                 .unwrap()
@@ -609,7 +641,7 @@ mod tests {
         assert_eq!(
             &Document {
                 id: 0,
-                value: "(ꈍᴗꈍ)consectetur adipiscing elit, sed do eiusmod(ꈍᴗꈍ)".to_string(),
+                value: "(ꈍᴗꈍ) sed do eiusmod tempor incididunt ut(ꈍᴗꈍ)".to_string(),
                 kind: "text".to_string(),
                 nested: Nested {
                     child: "first".to_string()
@@ -634,7 +666,6 @@ mod tests {
         query.with_highlight_post_tag(" ⊂(´• ω •`⊂)");
 
         let results: SearchResults<Document> = index.execute_query(&query).await?;
-        dbg!(&results);
         assert_eq!(
             &Document {
                 id: 2,
@@ -689,17 +720,17 @@ mod tests {
     }
 
     #[meilisearch_test]
-    async fn test_query_matches(client: Client, index: Index) -> Result<(), Error> {
+    async fn test_query_show_matches_position(client: Client, index: Index) -> Result<(), Error> {
         setup_test_index(&client, &index).await?;
 
         let mut query = Query::new(&index);
         query.with_query("dolor text");
-        query.with_matches(true);
+        query.with_show_matches_position(true);
         let results: SearchResults<Document> = index.execute_query(&query).await?;
-        assert_eq!(results.hits[0].matches_info.as_ref().unwrap().len(), 2);
+        assert_eq!(results.hits[0].matches_position.as_ref().unwrap().len(), 2);
         assert_eq!(
             results.hits[0]
-                .matches_info
+                .matches_position
                 .as_ref()
                 .unwrap()
                 .get("value")
@@ -719,6 +750,7 @@ mod tests {
         let mut query = Query::new(&index);
         query.with_query("harry \"of Fire\"");
         let results: SearchResults<Document> = index.execute_query(&query).await?;
+
         assert_eq!(results.hits.len(), 1);
         Ok(())
     }
@@ -733,10 +765,10 @@ mod tests {
         setup_test_index(&client, &index).await?;
 
         let meilisearch_host = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-        let key = KeyBuilder::new("key for generate_tenant_token test")
+        let key = KeyBuilder::new()
             .with_action(Action::All)
             .with_index("*")
-            .create(&client)
+            .execute(&client)
             .await
             .unwrap();
         let allowed_client = Client::new(meilisearch_host, key.key);
@@ -751,9 +783,10 @@ mod tests {
 
         for rules in search_rules {
             let token = allowed_client
-                .generate_tenant_token(rules, None, None)
+                .generate_tenant_token(key.uid.clone(), rules, None, None)
                 .expect("Cannot generate tenant token.");
-            let new_client = Client::new(meilisearch_host, token);
+
+            let new_client = Client::new(meilisearch_host, token.clone());
 
             let result: SearchResults<Document> = new_client
                 .index(index.uid.to_string())

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::Error,
     indexes::Index,
-    request::{request, Method},
+    request::{request, Data, Method},
     tasks::Task,
 };
 use serde::{Deserialize, Serialize};
@@ -213,7 +213,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_settings(&self) -> Result<Settings, Error> {
-        request::<(), Settings>(
+        request::<Option<()>, (), Settings>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
             Method::Get,
@@ -239,7 +239,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_synonyms(&self) -> Result<HashMap<String, Vec<String>>, Error> {
-        request::<(), HashMap<String, Vec<String>>>(
+        request::<Option<()>, (), HashMap<String, Vec<String>>>(
             &format!(
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
@@ -268,7 +268,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_stop_words(&self) -> Result<Vec<String>, Error> {
-        request::<(), Vec<String>>(
+        request::<Option<()>, (), Vec<String>>(
             &format!(
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
@@ -297,7 +297,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_ranking_rules(&self) -> Result<Vec<String>, Error> {
-        request::<(), Vec<String>>(
+        request::<Option<()>, (), Vec<String>>(
             &format!(
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
@@ -326,7 +326,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_filterable_attributes(&self) -> Result<Vec<String>, Error> {
-        request::<(), Vec<String>>(
+        request::<Option<()>, (), Vec<String>>(
             &format!(
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
@@ -355,7 +355,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_sortable_attributes(&self) -> Result<Vec<String>, Error> {
-        request::<(), Vec<String>>(
+        request::<Option<()>, (), Vec<String>>(
             &format!(
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
@@ -384,7 +384,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_distinct_attribute(&self) -> Result<Option<String>, Error> {
-        request::<(), Option<String>>(
+        request::<Option<()>, (), Option<String>>(
             &format!(
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
@@ -413,7 +413,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_searchable_attributes(&self) -> Result<Vec<String>, Error> {
-        request::<(), Vec<String>>(
+        request::<Option<()>, (), Vec<String>>(
             &format!(
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
@@ -442,7 +442,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_displayed_attributes(&self) -> Result<Vec<String>, Error> {
-        request::<(), Vec<String>>(
+        request::<Option<()>, (), Vec<String>>(
             &format!(
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
@@ -479,10 +479,10 @@ impl Index {
     /// # });
     /// ```
     pub async fn set_settings(&self, settings: &Settings) -> Result<Task, Error> {
-        request::<&Settings, Task>(
+        request::<Option<()>, &Settings, Task>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
-            Method::Post(settings),
+            Method::Post(Data::NonIterable(settings)),
             202,
         )
         .await
@@ -516,13 +516,13 @@ impl Index {
         &self,
         synonyms: &HashMap<String, Vec<String>>,
     ) -> Result<Task, Error> {
-        request::<&HashMap<String, Vec<String>>, Task>(
+        request::<Option<()>, &HashMap<String, Vec<String>>, Task>(
             &format!(
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(synonyms),
+            Method::Post(Data::NonIterable(synonyms)),
             202,
         )
         .await
@@ -552,18 +552,18 @@ impl Index {
         &self,
         stop_words: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+        request::<Option<()>, Vec<String>, Task>(
             &format!(
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Post(Data::NonIterable(
                 stop_words
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
                     .collect(),
-            ),
+            )),
             202,
         )
         .await
@@ -602,18 +602,18 @@ impl Index {
         &self,
         ranking_rules: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+        request::<Option<()>, Vec<String>, Task>(
             &format!(
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Post(Data::NonIterable(
                 ranking_rules
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
                     .collect(),
-            ),
+            )),
             202,
         )
         .await
@@ -643,18 +643,18 @@ impl Index {
         &self,
         filterable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+        request::<Option<()>, Vec<String>, Task>(
             &format!(
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Post(Data::NonIterable(
                 filterable_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
                     .collect(),
-            ),
+            )),
             202,
         )
         .await
@@ -684,18 +684,18 @@ impl Index {
         &self,
         sortable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+        request::<Option<()>, Vec<String>, Task>(
             &format!(
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Post(Data::NonIterable(
                 sortable_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
                     .collect(),
-            ),
+            )),
             202,
         )
         .await
@@ -724,13 +724,13 @@ impl Index {
         &self,
         distinct_attribute: impl AsRef<str>,
     ) -> Result<Task, Error> {
-        request::<String, Task>(
+        request::<Option<()>, String, Task>(
             &format!(
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(distinct_attribute.as_ref().to_string()),
+            Method::Post(Data::NonIterable(distinct_attribute.as_ref().to_string())),
             202,
         )
         .await
@@ -759,18 +759,18 @@ impl Index {
         &self,
         searchable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+        request::<Option<()>, Vec<String>, Task>(
             &format!(
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Post(Data::NonIterable(
                 searchable_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
                     .collect(),
-            ),
+            )),
             202,
         )
         .await
@@ -799,18 +799,18 @@ impl Index {
         &self,
         displayed_attributes: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+        request::<Option<()>, Vec<String>, Task>(
             &format!(
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Post(Data::NonIterable(
                 displayed_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
                     .collect(),
-            ),
+            )),
             202,
         )
         .await
@@ -837,7 +837,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn reset_settings(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+        request::<Option<()>, (), Task>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
             Method::Delete,
@@ -866,7 +866,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn reset_synonyms(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+        request::<Option<()>, (), Task>(
             &format!(
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
@@ -898,7 +898,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn reset_stop_words(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+        request::<Option<()>, (), Task>(
             &format!(
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
@@ -931,7 +931,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn reset_ranking_rules(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+        request::<Option<()>, (), Task>(
             &format!(
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
@@ -963,7 +963,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn reset_filterable_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+        request::<Option<()>, (), Task>(
             &format!(
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
@@ -995,7 +995,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn reset_sortable_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+        request::<Option<()>, (), Task>(
             &format!(
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
@@ -1027,7 +1027,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn reset_distinct_attribute(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+        request::<Option<()>, (), Task>(
             &format!(
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
@@ -1059,7 +1059,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn reset_searchable_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+        request::<Option<()>, (), Task>(
             &format!(
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
@@ -1091,7 +1091,7 @@ impl Index {
     /// # });
     /// ```
     pub async fn reset_displayed_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+        request::<Option<()>, (), Task>(
             &format!(
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::Error,
     indexes::Index,
     request::{request, Data, Method},
-    tasks::Task,
+    task_info::TaskInfo,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -216,7 +216,7 @@ impl Index {
         request::<Option<()>, (), Settings>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -245,7 +245,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -274,7 +274,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -303,7 +303,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -332,7 +332,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -361,7 +361,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -390,7 +390,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -419,7 +419,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -448,7 +448,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -478,11 +478,11 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn set_settings(&self, settings: &Settings) -> Result<Task, Error> {
-        request::<Option<()>, &Settings, Task>(
+    pub async fn set_settings(&self, settings: &Settings) -> Result<TaskInfo, Error> {
+        request::<Option<()>, &Settings, TaskInfo>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
-            Method::Post(Data::NonIterable(settings)),
+            Method::Patch(Data::NonIterable(settings)),
             202,
         )
         .await
@@ -515,14 +515,14 @@ impl Index {
     pub async fn set_synonyms(
         &self,
         synonyms: &HashMap<String, Vec<String>>,
-    ) -> Result<Task, Error> {
-        request::<Option<()>, &HashMap<String, Vec<String>>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<&HashMap<String, Vec<String>>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(Data::NonIterable(synonyms)),
+            Method::Put(Data::Iterable(synonyms)),
             202,
         )
         .await
@@ -551,14 +551,14 @@ impl Index {
     pub async fn set_stop_words(
         &self,
         stop_words: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Option<()>, Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(Data::NonIterable(
+            Method::Put(Data::Iterable(
                 stop_words
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -601,14 +601,14 @@ impl Index {
     pub async fn set_ranking_rules(
         &self,
         ranking_rules: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Option<()>, Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(Data::NonIterable(
+            Method::Put(Data::Iterable(
                 ranking_rules
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -642,14 +642,14 @@ impl Index {
     pub async fn set_filterable_attributes(
         &self,
         filterable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Option<()>, Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(Data::NonIterable(
+            Method::Put(Data::Iterable(
                 filterable_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -683,14 +683,14 @@ impl Index {
     pub async fn set_sortable_attributes(
         &self,
         sortable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Option<()>, Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(Data::NonIterable(
+            Method::Put(Data::Iterable(
                 sortable_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -723,14 +723,14 @@ impl Index {
     pub async fn set_distinct_attribute(
         &self,
         distinct_attribute: impl AsRef<str>,
-    ) -> Result<Task, Error> {
-        request::<Option<()>, String, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Option<()>, String, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(Data::NonIterable(distinct_attribute.as_ref().to_string())),
+            Method::Put(Data::NonIterable(distinct_attribute.as_ref().to_string())),
             202,
         )
         .await
@@ -758,14 +758,14 @@ impl Index {
     pub async fn set_searchable_attributes(
         &self,
         searchable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Option<()>, Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(Data::NonIterable(
+            Method::Put(Data::Iterable(
                 searchable_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -798,14 +798,14 @@ impl Index {
     pub async fn set_displayed_attributes(
         &self,
         displayed_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Option<()>, Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(Data::NonIterable(
+            Method::Put(Data::Iterable(
                 displayed_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -836,8 +836,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_settings(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn reset_settings(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
             Method::Delete,
@@ -865,8 +865,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_synonyms(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn reset_synonyms(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
@@ -897,8 +897,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_stop_words(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn reset_stop_words(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
@@ -930,8 +930,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_ranking_rules(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn reset_ranking_rules(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
@@ -962,8 +962,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_filterable_attributes(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn reset_filterable_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
@@ -994,8 +994,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_sortable_attributes(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn reset_sortable_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
@@ -1026,8 +1026,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_distinct_attribute(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn reset_distinct_attribute(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
@@ -1058,8 +1058,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_searchable_attributes(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn reset_searchable_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
@@ -1090,8 +1090,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_displayed_attributes(&self) -> Result<Task, Error> {
-        request::<Option<()>, (), Task>(
+    pub async fn reset_displayed_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<Option<()>, (), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -1,0 +1,176 @@
+use serde::Deserialize;
+use std::time::Duration;
+use time::OffsetDateTime;
+
+use crate::{client::Client, errors::Error, tasks::*};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskInfo {
+    #[serde(with = "time::serde::rfc3339")]
+    pub enqueued_at: OffsetDateTime,
+    pub index_uid: Option<String>,
+    pub status: String,
+    #[serde(flatten)]
+    pub update_type: TaskType,
+    pub task_uid: u32,
+}
+
+impl AsRef<u32> for TaskInfo {
+    fn as_ref(&self) -> &u32 {
+        &self.task_uid
+    }
+}
+
+impl TaskInfo {
+    pub fn get_task_uid(&self) -> u32 {
+        self.task_uid
+    }
+
+    /// Wait until Meilisearch processes a task provided by [TaskInfo], and get its status.
+    ///
+    /// `interval` = The frequency at which the server should be polled. Default = 50ms
+    /// `timeout` = The maximum time to wait for processing to complete. Default = 5000ms
+    ///
+    /// If the waited time exceeds `timeout` then an [Error::Timeout] will be returned.
+    ///
+    /// See also [Client::wait_for_task, Index::wait_for_task].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, tasks::Task, task_info::TaskInfo};
+    /// # use serde::{Serialize, Deserialize};
+    /// #
+    /// # #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// # struct Document {
+    /// #    id: usize,
+    /// #    value: String,
+    /// #    kind: String,
+    /// # }
+    /// #
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let movies = client.index("movies_wait_for_completion");
+    ///
+    /// let status = movies.add_documents(&[
+    ///     Document { id: 0, kind: "title".into(), value: "The Social Network".to_string() },
+    ///     Document { id: 1, kind: "title".into(), value: "Harry Potter and the Sorcerer's Stone".to_string() },
+    /// ], None)
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// assert!(matches!(status, Task::Succeeded { .. }));
+    /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn wait_for_completion(
+        self,
+        client: &Client,
+        interval: Option<Duration>,
+        timeout: Option<Duration>,
+    ) -> Result<Task, Error> {
+        client.wait_for_task(self, interval, timeout).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        client::*,
+        errors::{ErrorCode, ErrorType},
+        indexes::Index,
+    };
+    use meilisearch_test_macro::meilisearch_test;
+    use serde::{Deserialize, Serialize};
+    use std::time::Duration;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Document {
+        id: usize,
+        value: String,
+        kind: String,
+    }
+
+    #[test]
+    fn test_deserialize_task_info() {
+        let datetime = OffsetDateTime::parse(
+            "2022-02-03T13:02:38.369634Z",
+            &::time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+
+        let task_info: TaskInfo = serde_json::from_str(
+            r#"
+{
+  "enqueuedAt": "2022-02-03T13:02:38.369634Z",
+  "indexUid": "mieli",
+  "status": "enqueued",
+  "type": "documentAdditionOrUpdate",
+  "taskUid": 12
+}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            task_info,
+            TaskInfo {
+                enqueued_at,
+                index_uid: Some(index_uid),
+                task_uid: 12,
+                update_type: TaskType::DocumentAdditionOrUpdate { details: None },
+                status,
+            }
+        if enqueued_at == datetime && index_uid == "mieli" && status == "enqueued"));
+    }
+
+    #[meilisearch_test]
+    async fn test_wait_for_task_with_args(client: Client, movies: Index) -> Result<(), Error> {
+        let task_info = movies
+            .add_documents(
+                &[
+                    Document {
+                        id: 0,
+                        kind: "title".into(),
+                        value: "The Social Network".to_string(),
+                    },
+                    Document {
+                        id: 1,
+                        kind: "title".into(),
+                        value: "Harry Potter and the Sorcerer's Stone".to_string(),
+                    },
+                ],
+                None,
+            )
+            .await?;
+
+        let task = client
+            .get_task(task_info)
+            .await?
+            .wait_for_completion(
+                &client,
+                Some(Duration::from_millis(1)),
+                Some(Duration::from_millis(6000)),
+            )
+            .await?;
+
+        assert!(matches!(task, Task::Succeeded { .. }));
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_failing_task(client: Client, movies: Index) -> Result<(), Error> {
+        let task_info = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
+        let task = client.wait_for_task(task_info, None, None).await?;
+
+        let error = task.unwrap_failure();
+        assert_eq!(error.error_code, ErrorCode::InvalidRankingRule);
+        assert_eq!(error.error_type, ErrorType::InvalidRequest);
+        Ok(())
+    }
+}

--- a/src/tenant_tokens.rs
+++ b/src/tenant_tokens.rs
@@ -1,13 +1,11 @@
-use crate::{
-    errors::* 
-};
-use serde::{Serialize, Deserialize};
-use jsonwebtoken::{encode, Header, EncodingKey};
-use time::{OffsetDateTime};
+use crate::errors::*;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use time::OffsetDateTime;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")] 
+#[serde(rename_all = "camelCase")]
 struct TenantTokenClaim {
     api_key_prefix: String,
     search_rules: Value,
@@ -15,20 +13,24 @@ struct TenantTokenClaim {
     exp: Option<OffsetDateTime>,
 }
 
-pub fn generate_tenant_token(search_rules: Value, api_key: impl AsRef<str>, expires_at: Option<OffsetDateTime>) -> Result<String, Error> {
+pub fn generate_tenant_token(
+    search_rules: Value,
+    api_key: impl AsRef<str>,
+    expires_at: Option<OffsetDateTime>,
+) -> Result<String, Error> {
     if api_key.as_ref().chars().count() < 8 {
-        return Err(Error::TenantTokensInvalidApiKey)
+        return Err(Error::TenantTokensInvalidApiKey);
     }
 
     if expires_at.map_or(false, |expires_at| OffsetDateTime::now_utc() > expires_at) {
-        return Err(Error::TenantTokensExpiredSignature)
+        return Err(Error::TenantTokensExpiredSignature);
     }
 
     let key_prefix = api_key.as_ref().chars().take(8).collect();
     let claims = TenantTokenClaim {
         api_key_prefix: key_prefix,
         exp: expires_at,
-        search_rules
+        search_rules,
     };
 
     let token = encode(
@@ -42,9 +44,9 @@ pub fn generate_tenant_token(search_rules: Value, api_key: impl AsRef<str>, expi
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
     use crate::tenant_tokens::*;
-    use jsonwebtoken::{decode, DecodingKey, Validation, Algorithm};
+    use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+    use serde_json::json;
     use std::collections::HashSet;
 
     const SEARCH_RULES: [&str; 1] = ["*"];
@@ -63,10 +65,14 @@ mod tests {
         let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, None).unwrap();
 
         let valid_key = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(VALID_KEY.as_ref()), &build_validation()
+            &token,
+            &DecodingKey::from_secret(VALID_KEY.as_ref()),
+            &build_validation(),
         );
         let invalid_key = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret("not-the-same-key".as_ref()), &build_validation()
+            &token,
+            &DecodingKey::from_secret("not-the-same-key".as_ref()),
+            &build_validation(),
         );
 
         assert!(valid_key.is_ok());
@@ -87,7 +93,9 @@ mod tests {
         let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, Some(exp)).unwrap();
 
         let decoded = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(VALID_KEY.as_ref()), &Validation::new(Algorithm::HS256)
+            &token,
+            &DecodingKey::from_secret(VALID_KEY.as_ref()),
+            &Validation::new(Algorithm::HS256),
         );
 
         assert!(decoded.is_ok());
@@ -106,8 +114,11 @@ mod tests {
         let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, None).unwrap();
 
         let decoded = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(VALID_KEY.as_ref()), &build_validation()
-        ).expect("Cannot decode the token");
+            &token,
+            &DecodingKey::from_secret(VALID_KEY.as_ref()),
+            &build_validation(),
+        )
+        .expect("Cannot decode the token");
 
         assert_eq!(decoded.claims.api_key_prefix, &VALID_KEY[..8]);
         assert_eq!(decoded.claims.search_rules, json!(SEARCH_RULES));
@@ -119,8 +130,11 @@ mod tests {
         let token = generate_tenant_token(json!(SEARCH_RULES), key, None).unwrap();
 
         let decoded = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(key.as_ref()), &build_validation()
-        ).expect("Cannot decode the token");
+            &token,
+            &DecodingKey::from_secret(key.as_ref()),
+            &build_validation(),
+        )
+        .expect("Cannot decode the token");
 
         assert_eq!(decoded.claims.api_key_prefix, "Ëa1ทt9bV");
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn async_sleep(interval: Duration) {
+    let (sender, receiver) = futures::channel::oneshot::channel::<()>();
+    std::thread::spawn(move || {
+        std::thread::sleep(interval);
+        let _ = sender.send(());
+    });
+    let _ = receiver.await;
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn async_sleep(interval: Duration) {
+    use std::convert::TryInto;
+    use wasm_bindgen_futures::JsFuture;
+
+    JsFuture::from(js_sys::Promise::new(&mut |yes, _| {
+        web_sys::window()
+            .unwrap()
+            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                &yes,
+                interval.as_millis().try_into().unwrap(),
+            )
+            .unwrap();
+    }))
+    .await
+    .unwrap();
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use meilisearch_test_macro::meilisearch_test;
+
+    #[meilisearch_test]
+    async fn test_async_sleep() {
+        let sleep_duration = std::time::Duration::from_millis(10);
+        let now = time::Instant::now();
+
+        async_sleep(sleep_duration).await;
+
+        assert!(now.elapsed() >= sleep_duration);
+    }
+}


### PR DESCRIPTION
This PR addresses #265.

The main obstacle I see is that `serde_json` does not offer a way to serialize data to jsonlines. For example, vectors are automatically serialized to json arrays by `serde_json.to_string()`.
A simple workaround is to iterate over the collection and serialize each item individually. Then we can join them using `\n` as the separator to obtain jsonlines:
```rust
let movies = vec![Movie { id: 1, name: String::from("Life of Pi") },
                  Movie { id: 2, name: String::from("Mad Max") },
                  Movie { id: 3, name: String::from("Moana") }];

let mut jsonlines = movies.iter().map(|x| serde_json::to_string(x).unwrap()).collect::<Vec<String>>().join("\n");
jsonlines.push('\n');
```
However, in the [`request`](https://github.com/meilisearch/meilisearch-rust/blob/6c7370d245265f41480595db26213b600d2c53c5/src/request.rs#L92) function, where the data is serialized, `Serialize` is the only trait bound for the data (`Input`). That means we cannot iterate over the data to obtain jsonlines as in the example above.

To work around this we could create another `request` function (and call it `request_jsonlines` or whatever) which only takes in data that is iterable. Then we would also have to create a new `Method` enum. I did not want to do this because it would entail a lot of duplicate code.
Another option would be to write a function that converts a json array to jsonlines. However, that would probably be less efficient than computing the jsonlines directly (as shown above).
Hence, I decided to adapt the `Method` enum, such that it can hold two different types. A type that is iterable (for jsonlines) and a type that is not necessary iterable (for all other calls to `request`).

Let me know what you think about this solution. I am open to suggestions :)
