### PR TITLE
Add yaup to format query parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing"] }
 jsonwebtoken = { version = "8", default-features = false }
+yaup = "0.2.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures = "0.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -630,7 +630,7 @@ impl Client {
         let tasks = request::<(), Tasks>(
             &format!("{}/tasks", self.host),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await?;
@@ -733,31 +733,31 @@ mod tests {
                 mock("GET", path)
                     .match_header("User-Agent", user_agent)
                     .create(),
-                request::<String, ()>(address, "", Method::Get("".to_string()), 200),
+                request::<(), ()>(address, "", Method::Get(()), 200),
             ),
             (
                 mock("POST", path)
                     .match_header("User-Agent", user_agent)
                     .create(),
-                request::<String, ()>(address, "", Method::Post("".to_string()), 200),
+                request::<(), ()>(address, "", Method::Post(()), 200),
             ),
             (
                 mock("DELETE", path)
                     .match_header("User-Agent", user_agent)
                     .create(),
-                request::<String, ()>(address, "", Method::Delete, 200),
+                request::<(), ()>(address, "", Method::Delete, 200),
             ),
             (
                 mock("PUT", path)
                     .match_header("User-Agent", user_agent)
                     .create(),
-                request::<String, ()>(address, "", Method::Put("".to_string()), 200),
+                request::<(), ()>(address, "", Method::Put(()), 200),
             ),
             (
                 mock("PATCH", path)
                     .match_header("User-Agent", user_agent)
                     .create(),
-                request::<String, ()>(address, "", Method::Patch("".to_string()), 200),
+                request::<(), ()>(address, "", Method::Patch(()), 200),
             ),
         ];
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -76,7 +76,7 @@ impl Client {
         let json_indexes = request::<(), Vec<Value>>(
             &format!("{}/indexes", self.host),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await?;
@@ -131,7 +131,7 @@ impl Client {
         request::<(), Value>(
             &format!("{}/indexes/{}", self.host, uid.as_ref()),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -225,10 +225,10 @@ impl Client {
     /// # });
     /// ```
     pub async fn get_stats(&self) -> Result<ClientStats, Error> {
-        request::<serde_json::Value, ClientStats>(
+        request::<(), ClientStats>(
             &format!("{}/stats", self.host),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -248,10 +248,10 @@ impl Client {
     /// # });
     /// ```
     pub async fn health(&self) -> Result<Health, Error> {
-        request::<serde_json::Value, Health>(
+        request::<(), Health>(
             &format!("{}/health", self.host),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -305,7 +305,7 @@ impl Client {
         let keys = request::<(), Keys>(
             &format!("{}/keys", self.host),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await?;
@@ -336,7 +336,7 @@ impl Client {
         request::<(), Key>(
             &format!("{}/keys/{}", self.host, key.as_ref()),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -451,7 +451,7 @@ impl Client {
         request::<(), Version>(
             &format!("{}/version", self.host),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -545,7 +545,7 @@ impl Client {
         request::<(), Task>(
             &format!("{}/tasks/{}", self.host, task_id.as_ref()),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -654,9 +654,9 @@ mod tests {
         key::{Action, KeyBuilder},
     };
     use meilisearch_test_macro::meilisearch_test;
-    use time::OffsetDateTime;
     use mockito::mock;
     use std::mem;
+    use time::OffsetDateTime;
 
     #[meilisearch_test]
     async fn test_methods_has_qualified_version_as_header() {
@@ -667,25 +667,35 @@ mod tests {
 
         let assertions = vec![
             (
-                mock("GET", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Get, 200)
+                mock("GET", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, "", Method::Get("".to_string()), 200),
             ),
             (
-                mock("POST", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Post("".to_string()), 200)
+                mock("POST", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, "", Method::Post("".to_string()), 200),
             ),
             (
-                mock("DELETE", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Delete, 200)
+                mock("DELETE", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, "", Method::Delete, 200),
             ),
             (
-                mock("PUT", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Put("".to_string()), 200)
+                mock("PUT", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, "", Method::Put("".to_string()), 200),
             ),
             (
-                mock("PATCH", path).match_header("User-Agent", user_agent).create(),
-                request::<String, ()>(address, "", Method::Patch("".to_string()), 200)
-            )
+                mock("PATCH", path)
+                    .match_header("User-Agent", user_agent)
+                    .create(),
+                request::<String, ()>(address, "", Method::Patch("".to_string()), 200),
+            ),
         ];
 
         for (m, req) in assertions {

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -116,7 +116,7 @@ impl Client {
         request::<(), DumpInfo>(
             &format!("{}/dumps/{}/status", self.host, dump_uid.as_ref()),
             &self.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,7 +24,7 @@ pub enum Error {
     TenantTokensInvalidApiKey,
     /// It is not possible to generate an already expired tenant token.
     TenantTokensExpiredSignature,
-    
+
     /// When jsonwebtoken cannot generate the token successfully.
     InvalidTenantToken(jsonwebtoken::errors::Error),
 
@@ -34,6 +34,8 @@ pub enum Error {
     /// The http client encountered an error.
     #[cfg(target_arch = "wasm32")]
     HttpError(String),
+    // TODO: comment
+    Yaup(yaup::Error),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -64,6 +66,12 @@ impl From<MeilisearchError> for Error {
 impl From<jsonwebtoken::errors::Error> for Error {
     fn from(error: jsonwebtoken::errors::Error) -> Error {
         Error::InvalidTenantToken(error)
+    }
+}
+
+impl From<yaup::Error> for Error {
+    fn from(error: yaup::Error) -> Error {
+        Error::Yaup(error)
     }
 }
 
@@ -185,7 +193,8 @@ impl std::fmt::Display for Error {
             Error::Timeout => write!(fmt, "A task did not succeed in time."),
             Error::TenantTokensInvalidApiKey => write!(fmt, "The provided api_key is invalid."),
             Error::TenantTokensExpiredSignature => write!(fmt, "The provided expires_at is already expired."),
-            Error::InvalidTenantToken(e) => write!(fmt, "Impossible to generate the token, jsonwebtoken encountered an error: {}", e)
+            Error::InvalidTenantToken(e) => write!(fmt, "Impossible to generate the token, jsonwebtoken encountered an error: {}", e),
+            Error::Yaup(e) => write!(fmt, "Internal Error: could not parse the query parameters: {}", e)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,7 +34,7 @@ pub enum Error {
     /// The http client encountered an error.
     #[cfg(target_arch = "wasm32")]
     HttpError(String),
-    // TODO: comment
+    // The library formating the query parameters encountered an error.
     Yaup(yaup::Error),
 }
 

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -240,7 +240,7 @@ impl Index {
                 self.client.host, self.uid, uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -302,7 +302,7 @@ impl Index {
             url.push_str("attributesToRetrieve=");
             url.push_str(attributes_to_retrieve);
         }
-        request::<(), Vec<T>>(&url, &self.client.api_key, Method::Get, 200).await
+        request::<(), Vec<T>>(&url, &self.client.api_key, Method::Get(()), 200).await
     }
 
     /// Add a list of [Document]s or replace them if they already exist.
@@ -688,7 +688,7 @@ impl Index {
                 uid.as_ref()
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -725,7 +725,7 @@ impl Index {
         Ok(request::<(), AllTasks>(
             &format!("{}/indexes/{}/tasks", self.client.host, self.uid),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await?
@@ -749,10 +749,10 @@ impl Index {
     /// # });
     /// ```
     pub async fn get_stats(&self) -> Result<IndexStats, Error> {
-        request::<serde_json::Value, IndexStats>(
+        request::<(), IndexStats>(
             &format!("{}/indexes/{}/stats", self.client.host, self.uid),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await

--- a/src/request.rs
+++ b/src/request.rs
@@ -35,8 +35,6 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
                 format!("{}?{}", url, query)
             };
 
-            dbg!(&url);
-
             Request::get(url)
                 .header(header::AUTHORIZATION, auth)
                 .header(header::USER_AGENT, user_agent)

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,7 +5,7 @@ use serde_json::{from_str, to_string};
 
 #[derive(Debug)]
 pub(crate) enum Method<T: Serialize> {
-    Get,
+    Get(T),
     Post(T),
     Patch(T),
     Put(T),
@@ -26,7 +26,17 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
     let user_agent = qualified_version();
 
     let mut response = match &method {
-        Method::Get => {
+        Method::Get(query) => {
+            let query = yaup::to_string(query)?;
+
+            let url = if query.is_empty() {
+                url.to_string()
+            } else {
+                format!("{}?{}", url, query)
+            };
+
+            dbg!(&url);
+
             Request::get(url)
                 .header(header::AUTHORIZATION, auth)
                 .header(header::USER_AGENT, user_agent)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -212,7 +212,7 @@ impl Index {
         request::<(), Settings>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -237,7 +237,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -262,7 +262,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -287,7 +287,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -312,7 +312,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -337,7 +337,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -362,7 +362,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -387,7 +387,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await
@@ -412,7 +412,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Get,
+            Method::Get(()),
             200,
         )
         .await


### PR DESCRIPTION
In preparation of the v0.28.0 compatibility update with Meilisearch, we added `yaup` to handle the future requirements in query parameter formating. 

Currently it was done by hand, example: 

https://github.com/meilisearch/meilisearch-rust/blob/6f98caff09c2439002ac53307d1748a849c9e600/src/indexes.rs#L312-L334

But, with the new version of Meilisearch a lot of query parameters are added in multiple routes. 
To avoid having to do this tedious task over and over again we are using `yaup` that is maintained by Meilisearch and that formats query parameters in a meilisearch compatible way.

Test are failing because they are done against Meilisearch v0.28 and not Meilisearch v0.27. Prouf of successful tests: 

<img width="870" alt="Screenshot 2022-08-02 at 18 46 06" src="https://user-images.githubusercontent.com/33010418/182429120-d2d2f06d-8338-4660-9ab2-e14dcf4f67f0.png">

 