### PR TITLE
Fix wasm failing build due to getrandom in uuid library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ serde_json = "1.0"
 time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing"] }
 jsonwebtoken = { version = "8", default-features = false }
 yaup = "0.2.0"
-uuid = { version = "1.1.2", features =  ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures = "0.3"
 isahc = { version = "1.0", features = ["http2", "text-decoding"], default_features = false }
+uuid = { version = "1.1.2", features =  ["v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.47"

--- a/src/client.rs
+++ b/src/client.rs
@@ -810,6 +810,7 @@ impl Client {
     /// let client = client::Client::new(MEILISEARCH_HOST, token);
     /// # });
     /// ```
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn generate_tenant_token(
         &self,
         api_key_uid: String,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,6 +37,7 @@ pub enum Error {
     // The library formating the query parameters encountered an error.
     Yaup(yaup::Error),
     // The library validating the format of an uuid.
+    #[cfg(not(target_arch = "wasm32"))]
     Uuid(uuid::Error),
     // Error thrown in case the version of the Uuid is not v4.
     InvalidUuid4Version,
@@ -79,6 +80,7 @@ impl From<yaup::Error> for Error {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<uuid::Error> for Error {
     fn from(error: uuid::Error) -> Error {
         Error::Uuid(error)
@@ -205,6 +207,7 @@ impl std::fmt::Display for Error {
             Error::TenantTokensExpiredSignature => write!(fmt, "The provided expires_at is already expired."),
             Error::InvalidTenantToken(e) => write!(fmt, "Impossible to generate the token, jsonwebtoken encountered an error: {}", e),
             Error::Yaup(e) => write!(fmt, "Internal Error: could not parse the query parameters: {}", e),
+            #[cfg(not(target_arch = "wasm32"))]
             Error::Uuid(e) => write!(fmt, "The uid of the token has bit an uuid4 format: {}", e),
             Error::InvalidUuid4Version => write!(fmt, "The uid provided to the token is not of version uuidv4")
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -112,7 +112,7 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
     let user_agent = qualified_version();
 
     // The 2 following unwraps should not be able to fail
-
+    let mut mut_url = url.clone().to_string();
     let headers = Headers::new().unwrap();
     headers.append("Authorization: Bearer", apikey).unwrap();
     headers.append("User-Agent", &user_agent).unwrap();
@@ -121,7 +121,15 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
     request.headers(&headers);
 
     match &method {
-        Method::Get => {
+        Method::Get(query) => {
+            let query = yaup::to_string(query)?;
+
+            mut_url = if query.is_empty() {
+                mut_url.to_string()
+            } else {
+                format!("{}?{}", mut_url, query)
+            };
+
             request.method("GET");
         }
         Method::Delete => {
@@ -145,13 +153,14 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
     }
 
     let window = web_sys::window().unwrap(); // TODO remove this unwrap
-    let response = match JsFuture::from(window.fetch_with_str_and_init(url, &request)).await {
-        Ok(response) => Response::from(response),
-        Err(e) => {
-            error!("Network error: {:?}", e);
-            return Err(Error::UnreachableServer);
-        }
-    };
+    let response =
+        match JsFuture::from(window.fetch_with_str_and_init(mut_url.as_str(), &request)).await {
+            Ok(response) => Response::from(response),
+            Err(e) => {
+                error!("Network error: {:?}", e);
+                return Err(Error::UnreachableServer);
+            }
+        };
     let status = response.status() as u16;
     let text = match response.text() {
         Ok(text) => match JsFuture::from(text).await {

--- a/src/tenant_tokens.rs
+++ b/src/tenant_tokens.rs
@@ -3,6 +3,7 @@ use jsonwebtoken::{encode, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use time::OffsetDateTime;
+#[cfg(not(target_arch = "wasm32"))]
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/tenant_tokens.rs
+++ b/src/tenant_tokens.rs
@@ -6,6 +6,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg(not(target_arch = "wasm32"))]
 #[serde(rename_all = "camelCase")]
 struct TenantTokenClaim {
     api_key_uid: String,
@@ -14,6 +15,7 @@ struct TenantTokenClaim {
     exp: Option<OffsetDateTime>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn generate_tenant_token(
     api_key_uid: String,
     search_rules: Value,


### PR DESCRIPTION
Fixes the wasm fail that was caused by
- the uuid library using the `get_random` dependency
- The Request library of wasm that was not up to date