### PR TITLE
Update document query for v0.28.0

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -306,13 +306,13 @@ search_parameter_guide_highlight_tag_1: |-
 search_parameter_guide_matches_1: |-
   let results: SearchResults<Movie> = client.index("movies").search()
     .with_query("winter feast")
-    .with_matches(true)
+    .with_show_matches_position(true)
     .execute()
     .await
     .unwrap();
 
   // Get the matches info
-  let matched_info: Vec<&HashMap<String, Vec<MatchRange>>> = results.hits.iter().map(|r| r.matches_info.as_ref().unwrap()).collect();
+  let matched_info: Vec<&HashMap<String, Vec<MatchRange>>> = results.hits.iter().map(|r| r.matches_position.as_ref().unwrap()).collect();
 settings_guide_synonyms_1: |-
   let mut synonyms = HashMap::new();
   synonyms.insert(String::from("sweater"), vec![String::from("jumper")]);
@@ -654,11 +654,11 @@ faceted_search_filter_1: |-
 faceted_search_facets_distribution_1: |-
   let results: SearchResults<Movie> = client.index("movies").search()
     .with_query("Batman")
-    .with_facets_distribution(Selectors::Some(&["genres"]))
+    .with_facets(Selectors::Some(&["genres"]))
     .execute()
     .await
     .unwrap();
-  let genres: &HashMap<String, usize> = results.facets_distribution.unwrap().get("genres").unwrap();
+  let genres: &HashMap<String, usize> = results.facet_distribution.unwrap().get("genres").unwrap();
 faceted_search_walkthrough_filter_1: |-
   let results: SearchResults<Movie> = client.index("movies").search()
     .with_query("thriller")

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -668,8 +668,6 @@ faceted_search_walkthrough_filter_1: |-
     .unwrap();
 post_dump_1: |-
   client.create_dump().await.unwrap();
-get_dump_status_1: |-
-  client.get_dump_status("20201101-110357260").await.unwrap();
 phrase_search_1: |-
   let results: SearchResults<Movie> = client.index("movies")
     .search()

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -6,7 +6,7 @@
 get_one_index_1: |-
   let movies: Index = client.get_index("movies").await.unwrap();
 list_all_indexes_1: |-
-  let indexes: Vec<Index> = client.list_all_indexes().await.unwrap();
+  let indexes: IndexesResults = client.list_all_indexes().await.unwrap();
 create_an_index_1: |-
   client.create_index("movies", Some("id")).await.unwrap();
 update_an_index_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -18,7 +18,7 @@ get_one_document_1: |-
 get_documents_1: |-
   let documents: Vec<Movie> = client.index("movies").get_documents(None, Some(2), None).await.unwrap();
 add_or_replace_documents_1: |-
-  let task: Task = client.index("movies").add_or_replace(&[
+  let task: TaskInfo = client.index("movies").add_or_replace(&[
     Movie {
       id: 287947,
       title: "Shazam".to_string(),
@@ -35,18 +35,18 @@ add_or_update_documents_1: |-
     title: String
   }
 
-  let task: Task = client.index("movies").add_or_update(&[
+  let task: TaskInfo = client.index("movies").add_or_update(&[
     IncompleteMovie {
       id: 287947,
       title: "Shazam ⚡️".to_string()
     }
   ], None).await.unwrap();
 delete_all_documents_1: |-
-  let task: Task = client.index("movies").delete_all_documents().await.unwrap();
+  let task: TaskInfo = client.index("movies").delete_all_documents().await.unwrap();
 delete_one_document_1: |-
-  let task: Task = client.index("movies").delete_document(25684).await.unwrap();
+  let task: TaskInfo = client.index("movies").delete_document(25684).await.unwrap();
 delete_documents_1: |-
-  let task: Task = client.index("movies").delete_documents(&[23488, 153738, 437035, 363869]).await.unwrap();
+  let task: TaskInfo = client.index("movies").delete_documents(&[23488, 153738, 437035, 363869]).await.unwrap();
 search_post_1: |-
   let results: SearchResults<Movie> = client.index("movies")
     .search()
@@ -57,9 +57,9 @@ search_post_1: |-
 get_task_by_index_1: |-
   let task: Task = client.index("movies").get_task(1).await.unwrap();
 get_all_tasks_by_index_1: |-
-  let tasks: Vec<Task> = client.index("movies").get_tasks().await.unwrap();
+  let tasks: TasksResults = client.index("movies").get_tasks().await.unwrap();
 get_all_tasks_1: |-
-  let tasks: Vec<Task> = client.get_tasks().await.unwrap();
+  let tasks: TasksResults = client.get_tasks().await.unwrap();
 get_task_1: |-
   let task: Task = client.get_task(1).await.unwrap();
 get_settings_1: |-
@@ -103,9 +103,9 @@ update_settings_1: |-
     ])
     .with_synonyms(synonyms);
 
-  let task: Task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 reset_settings_1: |-
-  let task: Task = client.index("movies").reset_settings().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_settings().await.unwrap();
 get_synonyms_1: |-
   let synonyms: HashMap<String, Vec<String>> = client.index("movies").get_synonyms().await.unwrap();
 update_synonyms_1: |-
@@ -114,16 +114,16 @@ update_synonyms_1: |-
   synonyms.insert(String::from("logan"), vec![String::from("xmen"), String::from("wolverine")]);
   synonyms.insert(String::from("wow"), vec![String::from("world of warcraft")]);
 
-  let task: Task = client.index("movies").set_synonyms(&synonyms).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_synonyms(&synonyms).await.unwrap();
 reset_synonyms_1: |-
-  let task: Task = client.index("movies").reset_synonyms().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_synonyms().await.unwrap();
 get_stop_words_1: |-
   let stop_words: Vec<String> = client.index("movies").get_stop_words().await.unwrap();
 update_stop_words_1: |-
   let stop_words = ["of", "the", "to"];
-  let task: Task = client.index("movies").set_stop_words(&stop_words).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_stop_words(&stop_words).await.unwrap();
 reset_stop_words_1: |-
-  let task: Task = client.index("movies").reset_stop_words().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_stop_words().await.unwrap();
 get_ranking_rules_1: |-
   let ranking_rules: Vec<String> = client.index("movies").get_ranking_rules().await.unwrap();
 update_ranking_rules_1: |-
@@ -138,15 +138,15 @@ update_ranking_rules_1: |-
     "rank:desc",
   ];
 
-  let task: Task = client.index("movies").set_ranking_rules(&ranking_rules).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_ranking_rules(&ranking_rules).await.unwrap();
 reset_ranking_rules_1: |-
-  let task: Task = client.index("movies").reset_ranking_rules().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_ranking_rules().await.unwrap();
 get_distinct_attribute_1: |-
   let distinct_attribute: Option<String> = client.index("shoes").get_distinct_attribute().await.unwrap();
 update_distinct_attribute_1: |-
-  let task: Task = client.index("shoes").set_distinct_attribute("skuid").await.unwrap();
+  let task: TaskInfo = client.index("shoes").set_distinct_attribute("skuid").await.unwrap();
 reset_distinct_attribute_1: |-
-  let task: Task = client.index("shoes").reset_distinct_attribute().await.unwrap();
+  let task: TaskInfo = client.index("shoes").reset_distinct_attribute().await.unwrap();
 get_searchable_attributes_1: |-
   let searchable_attributes: Vec<String> = client.index("movies").get_searchable_attributes().await.unwrap();
 update_searchable_attributes_1: |-
@@ -156,9 +156,9 @@ update_searchable_attributes_1: |-
     "genres"
   ];
 
-  let task: Task = client.index("movies").set_searchable_attributes(&searchable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_searchable_attributes(&searchable_attributes).await.unwrap();
 reset_searchable_attributes_1: |-
-  let task: Task = client.index("movies").reset_searchable_attributes().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_searchable_attributes().await.unwrap();
 get_filterable_attributes_1: |-
   let filterable_attributes: Vec<String> = client.index("movies").get_filterable_attributes().await.unwrap();
 update_filterable_attributes_1: |-
@@ -167,9 +167,9 @@ update_filterable_attributes_1: |-
     "director"
   ];
 
-  let task: Task = client.index("movies").set_filterable_attributes(&filterable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_filterable_attributes(&filterable_attributes).await.unwrap();
 reset_filterable_attributes_1: |-
-  let task: Task = client.index("movies").reset_filterable_attributes().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_filterable_attributes().await.unwrap();
 get_displayed_attributes_1: |-
   let displayed_attributes: Vec<String> = client.index("movies").get_displayed_attributes().await.unwrap();
 update_displayed_attributes_1: |-
@@ -180,9 +180,9 @@ update_displayed_attributes_1: |-
     "release_date"
   ];
 
-  let task: Task = client.index("movies").set_displayed_attributes(&displayed_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_displayed_attributes(&displayed_attributes).await.unwrap();
 reset_displayed_attributes_1: |-
-  let task: Task = client.index("movies").reset_displayed_attributes().await.unwrap();
+  let task: TaskInfo = client.index("movies").reset_displayed_attributes().await.unwrap();
 get_index_stats_1: |-
   let stats: IndexStats = client.index("movies").get_stats().await.unwrap();
 get_indexes_stats_1: |-
@@ -193,7 +193,7 @@ get_health_1: |-
 get_version_1: |-
   let version: Version = client.get_version().await.unwrap();
 distinct_attribute_guide_1: |-
-  let task: Task = client.index("jackets").set_distinct_attribute("product_id").await.unwrap();
+  let task: TaskInfo = client.index("jackets").set_distinct_attribute("product_id").await.unwrap();
 field_properties_guide_searchable_1: |-
   let searchable_attributes = [
     "title",
@@ -201,7 +201,7 @@ field_properties_guide_searchable_1: |-
     "genres"
   ];
 
-  let task: Task = client.index("movies").set_searchable_attributes(&searchable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_searchable_attributes(&searchable_attributes).await.unwrap();
 field_properties_guide_displayed_1: |-
   let displayed_attributes = [
     "title",
@@ -210,7 +210,7 @@ field_properties_guide_displayed_1: |-
     "release_date"
   ];
 
-  let task: Task = client.index("movies").set_displayed_attributes(&displayed_attributes).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_displayed_attributes(&displayed_attributes).await.unwrap();
 filtering_guide_1: |-
   let results: SearchResults<Movie> = client.index("movies").search()
     .with_query("Avengers")
@@ -330,7 +330,7 @@ settings_guide_stop_words_1: |-
       "an"
     ]);
 
-  let task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_filterable_attributes_1: |-
   let settings = Settings::new()
     .with_filterable_attributes([
@@ -338,7 +338,7 @@ settings_guide_filterable_attributes_1: |-
       "genres"
     ]);
 
-  let task: Task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_ranking_rules_1: |-
   let settings = Settings::new()
     .with_ranking_rules([
@@ -352,12 +352,12 @@ settings_guide_ranking_rules_1: |-
       "rank:desc",
     ]);
 
-  let task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_distinct_1: |-
   let settings = Settings::new()
     .with_distinct_attribute("product_id");
 
-  let task: Task = client.index("jackets").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("jackets").set_settings(&settings).await.unwrap();
 settings_guide_searchable_1: |-
   let settings = Settings::new()
     .with_searchable_attributes([
@@ -366,7 +366,7 @@ settings_guide_searchable_1: |-
       "genres"
     ]);
 
-  let task: Task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_displayed_1: |-
   let settings = Settings::new()
     .with_displayed_attributes([
@@ -376,7 +376,7 @@ settings_guide_displayed_1: |-
       "release_date"
     ]);
 
-  let task: Task = client.index("movies").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_settings(&settings).await.unwrap();
 settings_guide_sortable_1: |-
   let settings = Settings::new()
     .with_sortable_attributes([
@@ -384,7 +384,7 @@ settings_guide_sortable_1: |-
       "price"
     ]);
 
-  let task: Task = client.index("books").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("books").set_settings(&settings).await.unwrap();
 add_movies_json_1: |-
   use meilisearch_sdk::{
     indexes::*,
@@ -417,7 +417,7 @@ documents_guide_add_movie_1: |-
   }
 
   // Add a document to our index
-  let task: Task = client.index("movies").add_documents(&[
+  let task: TaskInfo = client.index("movies").add_documents(&[
     IncompleteMovie {
       id: "123sq178".to_string(),
       title: "Amélie Poulain".to_string(),
@@ -437,7 +437,7 @@ primary_field_guide_add_document_primary_key: |-
     price: f64
   }
 
-  let task: Task = client.index("books").add_documents(&[
+  let task: TaskInfo = client.index("books").add_documents(&[
     Book {
       reference_number: "287947".to_string(),
       title: "Diary of a Wimpy Kid".to_string(),
@@ -616,7 +616,7 @@ getting_started_configure_settings: |-
       "mass",
       "_geo"
     ])
-  let task: Task = client.index("meteorites").set_settings(&settings).await.unwrap();
+  let task: TaskInfo = client.index("meteorites").set_settings(&settings).await.unwrap();
 getting_started_geo_radius: |-
   let results: SearchResults<Meteorite> = client.index("meteorites").search()
     .with_filter("_geoRadius(46.9480, 7.4474, 210000)")
@@ -643,7 +643,7 @@ getting_started_filtering: |-
     .await
     .unwrap();
 faceted_search_update_settings_1: |-
-  let task: Task = client.index("movies").set_filterable_attributes(["director", "genres"]).await.unwrap();
+  let task: TaskInfo = client.index("movies").set_filterable_attributes(["director", "genres"]).await.unwrap();
 faceted_search_filter_1: |-
   let results: SearchResults<Movie> = client.index("movies").search()
     .with_query("thriller")
@@ -683,7 +683,7 @@ sorting_guide_update_sortable_attributes_1: |-
     "price"
   ];
 
-  let task: Task = client.index("books").set_sortable_attributes(&sortable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("books").set_sortable_attributes(&sortable_attributes).await.unwrap();
 sorting_guide_update_ranking_rules_1: |-
   let ranking_rules = [
     "words",
@@ -694,7 +694,7 @@ sorting_guide_update_ranking_rules_1: |-
     "exactness"
   ];
 
-  let task: Task = client.index("books").set_ranking_rules(&ranking_rules).await.unwrap();
+  let task: TaskInfo = client.index("books").set_ranking_rules(&ranking_rules).await.unwrap();
 sorting_guide_sort_parameter_1: |-
   let results: SearchResults<Books> = client.index("books").search()
     .with_query("science fiction")
@@ -717,9 +717,9 @@ update_sortable_attributes_1: |-
     "author"
   ];
 
-  let task: Task = client.index("books").set_sortable_attributes(&sortable_attributes).await.unwrap();
+  let task: TaskInfo = client.index("books").set_sortable_attributes(&sortable_attributes).await.unwrap();
 reset_sortable_attributes_1: |-
-  let task: Task = client.index("books").reset_sortable_attributes().await.unwrap();
+  let task: TaskInfo = client.index("books").reset_sortable_attributes().await.unwrap();
 search_parameter_guide_sort_1: |-
   let results: SearchResults<Books> = client.index("books").search()
     .with_query("science fiction")
@@ -728,7 +728,7 @@ search_parameter_guide_sort_1: |-
     .await
     .unwrap();
 geosearch_guide_filter_settings_1: |-
-  let task: Task = client.index("restaurants").set_filterable_attributes(&["_geo"]).await.unwrap();
+  let task: TaskInfo = client.index("restaurants").set_filterable_attributes(&["_geo"]).await.unwrap();
 geosearch_guide_filter_usage_1: |-
   let results: SearchResults<Restaurant> = client.index("restaurants").search()
     .with_filter("_geoRadius(45.472735, 9.184019, 2000)")
@@ -742,7 +742,7 @@ geosearch_guide_filter_usage_2: |-
     .await
     .unwrap();
 geosearch_guide_sort_settings_1: |-
-  let task: Task = client.index("restaurants").set_sortable_attributes(&["_geo"]).await.unwrap();
+  let task: TaskInfo = client.index("restaurants").set_sortable_attributes(&["_geo"]).await.unwrap();
 geosearch_guide_sort_usage_1: |-
   let results: SearchResults<Restaurant> = client.index("restaurants").search()
     .with_sort(&["_geoPoint(48.8561446, 2.2978204):asc"])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing"] }
 jsonwebtoken = { version = "8", default-features = false }
 yaup = "0.2.0"
+uuid = { version = "1.1.2", features =  ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ WARNING: `meilisearch-sdk` will panic if no Window is available (ex: Web extensi
 
 ## 🤖 Compatibility with Meilisearch
 
-This package only guarantees the compatibility with the [version v0.27.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0).
+This package only guarantees the compatibility with the [version v0.28.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0).
 
 ## ⚙️ Development Workflow and Contributing
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Json output:
   ],
   "offset": 0,
   "limit": 20,
-  "nbHits": 1,
+  "estimatedTotalHits": 1,
   "processingTimeMs": 0,
   "query": "wonder"
 }

--- a/README.tpl
+++ b/README.tpl
@@ -97,7 +97,7 @@ WARNING: `meilisearch-sdk` will panic if no Window is available (ex: Web extensi
 
 ## 🤖 Compatibility with Meilisearch
 
-This package only guarantees the compatibility with the [version v0.27.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0).
+This package only guarantees the compatibility with the [version v0.28.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0).
 
 ## ⚙️ Development Workflow and Contributing
 

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -25,7 +25,7 @@ async fn test_get_tasks() -> Result<(), Error> {
 
   let tasks = index.get_tasks().await?;
   // The only task is the creation of the index
-  assert_eq!(status.len(), 1);
+  assert_eq!(status.results.len(), 1);
 
   index.delete()
     .await?
@@ -52,7 +52,7 @@ With this macro, all these problems are solved. See a rewrite of this test:
 async fn test_get_tasks(index: Index, client: Client) -> Result<(), Error> {
   let tasks = index.get_tasks().await?;
   // The only task is the creation of the index
-  assert_eq!(status.len(), 1);
+  assert_eq!(status.results.len(), 1);
 }
 ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -450,7 +450,7 @@ impl Client {
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// let keys = client.get_keys().await.unwrap();
     ///
-    /// assert_eq!(keys.results.len(), 2);
+    /// assert_eq!(keys.limit, 20);
     /// # });
     /// ```
     pub async fn get_keys(&self) -> Result<KeysResults, Error> {
@@ -482,7 +482,7 @@ impl Client {
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// # let key = client.get_keys().await.unwrap().results.into_iter()
     ///     .find(|k| k.name.as_ref().map_or(false, |name| name.starts_with("Default Search API Key")));
-    /// let key_id = key.unwrap().key // enter your API key here, for the example we use the search API key.
+    /// let key_id = key.unwrap().key; // enter your API key here, for the example we use the search API key.
     /// let key = client.get_key(key_id).await.unwrap();
     ///
     /// assert_eq!(key.name, Some("Default Search API Key".to_string()));

--- a/src/client.rs
+++ b/src/client.rs
@@ -806,19 +806,21 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    /// let token = client.generate_tenant_token(serde_json::json!(["*"]), None, None).unwrap();
+    /// let api_key_uid = "76cf8b87-fd12-4688-ad34-260d930ca4f4".to_string();
+    /// let token = client.generate_tenant_token(api_key_uid, serde_json::json!(["*"]), None, None).unwrap();
     /// let client = client::Client::new(MEILISEARCH_HOST, token);
     /// # });
     /// ```
     pub fn generate_tenant_token(
         &self,
+        api_key_uid: String,
         search_rules: serde_json::Value,
         api_key: Option<&str>,
         expires_at: Option<OffsetDateTime>,
     ) -> Result<String, Error> {
         let api_key = api_key.unwrap_or(&self.api_key);
 
-        crate::tenant_tokens::generate_tenant_token(search_rules, api_key, expires_at)
+        crate::tenant_tokens::generate_tenant_token(api_key_uid, search_rules, api_key, expires_at)
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -481,9 +481,10 @@ impl Client {
     /// # futures::executor::block_on(async move {
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// # let key = client.get_keys().await.unwrap().results.into_iter()
-    ///     .find(|k| k.name.as_ref().map_or(false, |name| name.starts_with("Default Search API Key")));
-    /// let key_id = key.unwrap().key; // enter your API key here, for the example we use the search API key.
-    /// let key = client.get_key(key_id).await.unwrap();
+    ///     .find(|k| k.name.as_ref().map_or(false, |name| name.starts_with("Default Search API Key")))
+    ///     .unwrap();
+    ///
+    /// let key = client.get_key(key).await.unwrap();
     ///
     /// assert_eq!(key.name, Some("Default Search API Key".to_string()));
     /// # });
@@ -741,12 +742,10 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = client::Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///
     /// let mut query = tasks::TasksQuery::new(&client);
     /// query.with_index_uid(["get_tasks_with"]);
     /// let tasks = client.get_tasks_with(&query).await.unwrap();
-    ///
-    /// # assert!(tasks.results.len() > 0);
-    /// # client.index("get_tasks_with").delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
     pub async fn get_tasks_with(

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -1,0 +1,232 @@
+use crate::{errors::Error, indexes::Index};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DocumentsResults<T> {
+    pub results: Vec<T>,
+    pub limit: u32,
+    pub offset: u32,
+    pub total: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DocumentsQuery<'a> {
+    #[serde(skip_serializing)]
+    pub index: &'a Index,
+
+    /// The number of documents to skip.
+    /// If the value of the parameter `offset` is `n`, the `n` first documents will not be returned.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you want to skip the first document, set offset to `1`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+
+    /// The maximum number of documents returned.
+    /// If the value of the parameter `limit` is `n`, there will never be more than `n` documents in the response.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you don't want to get more than two documents, set limit to `2`.
+    /// Default: `20`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+
+    /// The fields that should appear in the documents. By default all of the fields are present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<&'a str>>,
+}
+
+impl<'a> DocumentsQuery<'a> {
+    pub fn new(index: &Index) -> DocumentsQuery {
+        DocumentsQuery {
+            index,
+            offset: None,
+            limit: None,
+            fields: None,
+        }
+    }
+
+    /// Specify the offset.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let index = client.index("my_index");
+    ///
+    /// let mut documents_query = DocumentsQuery::new(&index);
+    ///
+    /// documents_query.with_offset(1);
+    /// ```
+    pub fn with_offset(&mut self, offset: usize) -> &mut DocumentsQuery<'a> {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Specify the limit.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let index = client.index("my_index");
+    ///
+    /// let mut documents_query = DocumentsQuery::new(&index);
+    ///
+    /// documents_query.with_limit(1);
+    /// ```
+    pub fn with_limit(&mut self, limit: usize) -> &mut DocumentsQuery<'a> {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Specify the fields to return in the documents.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let index = client.index("my_index");
+    ///
+    /// let mut documents_query = DocumentsQuery::new(&index);
+    ///
+    /// documents_query.with_fields(["title"]);
+    /// ```
+    pub fn with_fields(
+        &mut self,
+        fields: impl IntoIterator<Item = &'a str>,
+    ) -> &mut DocumentsQuery<'a> {
+        self.fields = Some(fields.into_iter().collect());
+        self
+    }
+
+    /// Execute the get documents query.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// # use serde::{Deserialize, Serialize};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///
+    /// # futures::executor::block_on(async move {
+    /// # let index = client.create_index("documents_query_execute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// struct MyObject {
+    ///     id: Option<usize>,
+    ///     kind: String,
+    /// }
+    /// let index = client.index("documents_query_execute");
+    ///
+    /// let mut documents_query = DocumentsQuery::new(&index);
+    ///
+    /// documents_query.with_offset(1).execute::<MyObject>().await.unwrap();
+    /// # });
+    /// ```
+    pub async fn execute<T: DeserializeOwned + 'static>(
+        &self,
+    ) -> Result<DocumentsResults<T>, Error> {
+        self.index.get_documents_with::<T>(self).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{client::*, indexes::*};
+    use meilisearch_test_macro::meilisearch_test;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct MyObject {
+        id: Option<usize>,
+        kind: String,
+    }
+
+    async fn setup_test_index(client: &Client, index: &Index) -> Result<(), Error> {
+        let t0 = index
+            .add_documents(
+                &[
+                    MyObject {
+                        id: Some(0),
+                        kind: "text".into(),
+                    },
+                    MyObject {
+                        id: Some(1),
+                        kind: "text".into(),
+                    },
+                    MyObject {
+                        id: Some(2),
+                        kind: "title".into(),
+                    },
+                    MyObject {
+                        id: Some(3),
+                        kind: "title".into(),
+                    },
+                ],
+                None,
+            )
+            .await?;
+
+        t0.wait_for_completion(client, None, None).await?;
+
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_get_documents_with_execute(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_index(&client, &index).await?;
+        // let documents = index.get_documents(None, None, None).await.unwrap();
+        let documents = DocumentsQuery::new(&index)
+            .with_limit(1)
+            .with_offset(1)
+            .with_fields(["kind"])
+            .execute::<MyObject>()
+            .await
+            .unwrap();
+
+        assert_eq!(documents.limit, 1);
+        assert_eq!(documents.offset, 1);
+        assert_eq!(documents.results.len(), 1);
+
+        Ok(())
+    }
+    #[meilisearch_test]
+    async fn test_get_documents_with_only_one_param(
+        client: Client,
+        index: Index,
+    ) -> Result<(), Error> {
+        setup_test_index(&client, &index).await?;
+        // let documents = index.get_documents(None, None, None).await.unwrap();
+        let documents = DocumentsQuery::new(&index)
+            .with_limit(1)
+            .execute::<MyObject>()
+            .await
+            .unwrap();
+
+        assert_eq!(documents.limit, 1);
+        assert_eq!(documents.offset, 0);
+        assert_eq!(documents.results.len(), 1);
+
+        Ok(())
+    }
+}

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -10,6 +10,13 @@ pub struct DocumentsResults<T> {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct DocumentQuery<'a> {
+    /// The fields that should appear in the documents. By default all of the fields are present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<&'a str>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct DocumentsQuery<'a> {
     #[serde(skip_serializing)]
     pub index: &'a Index,

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -11,9 +11,87 @@ pub struct DocumentsResults<T> {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DocumentQuery<'a> {
+    #[serde(skip_serializing)]
+    pub index: &'a Index,
+
     /// The fields that should appear in the documents. By default all of the fields are present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<Vec<&'a str>>,
+}
+
+impl<'a> DocumentQuery<'a> {
+    pub fn new(index: &Index) -> DocumentQuery {
+        DocumentQuery {
+            index,
+            fields: None,
+        }
+    }
+
+    /// Specify the fields to return in the document.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let index = client.index("document_query_with_fields");
+    /// let mut document_query = DocumentQuery::new(&index);
+    ///
+    /// document_query.with_fields(["title"]);
+    /// ```
+    pub fn with_fields(
+        &mut self,
+        fields: impl IntoIterator<Item = &'a str>,
+    ) -> &mut DocumentQuery<'a> {
+        self.fields = Some(fields.into_iter().collect());
+        self
+    }
+
+    /// Execute the get document query.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// # use serde::{Deserialize, Serialize};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///
+    /// # futures::executor::block_on(async move {
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// struct MyObject {
+    ///     id: String,
+    ///     kind: String,
+    /// }
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// struct MyObjectReduced {
+    ///     id: String,
+    /// }
+    ///
+    /// # let index = client.index("document_query_execute");
+    /// # index.add_or_replace(&[MyObject{id:"1".to_string(), kind:String::from("a kind")},MyObject{id:"2".to_string(), kind:String::from("some kind")}], None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    ///
+    /// let document = DocumentQuery::new(&index).with_fields(["id"]).execute::<MyObjectReduced>("1").await.unwrap();
+    ///
+    /// assert_eq!(
+    ///    document,
+    ///    MyObjectReduced { id: "1".to_string() }
+    /// );
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    pub async fn execute<T: DeserializeOwned + 'static>(
+        &self,
+        document_id: &str,
+    ) -> Result<T, Error> {
+        self.index.get_document_with::<T>(document_id, self).await
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -147,6 +225,7 @@ impl<'a> DocumentsQuery<'a> {
     /// let mut documents_query = DocumentsQuery::new(&index);
     ///
     /// documents_query.with_offset(1).execute::<MyObject>().await.unwrap();
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
     pub async fn execute<T: DeserializeOwned + 'static>(

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -15,7 +15,7 @@
 //! # Example
 //!
 //! ```no_run
-//! # use meilisearch_sdk::{client::*, errors::*, dumps::*};
+//! # use meilisearch_sdk::{client::*, errors::*, dumps::*, dumps::*, task_info::*, tasks::*};
 //! # use futures_await_test::async_test;
 //! # use std::{thread::sleep, time::Duration};
 //! # futures::executor::block_on(async move {
@@ -26,46 +26,18 @@
 //! let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
 //!
 //! // Create a dump
-//! let dump_info = client.create_dump().await.unwrap();
-//! assert!(matches!(dump_info.status, DumpStatus::InProgress));
-//!
-//! // Wait for Meilisearch to proceed
-//! sleep(Duration::from_secs(5));
-//!
-//! // Check the status of the dump
-//! let dump_info = client.get_dump_status(&dump_info.uid).await.unwrap();
-//! assert!(matches!(dump_info.status, DumpStatus::Done));
+//! let task_info = client.create_dump().await.unwrap();
+//! assert!(matches!(
+//!    task_info,
+//!    TaskInfo {
+//!        update_type: TaskType::DumpCreation { .. },
+//!        ..
+//!    }
+//!));
 //! # });
 //! ```
 
-use crate::{client::Client, errors::Error, request::*};
-use serde::Deserialize;
-
-/// The status of a dump.\
-/// Contained in [`DumpInfo`].
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum DumpStatus {
-    /// Dump creation is in progress.
-    Done,
-    /// Dump creation is in progress.
-    InProgress,
-    /// An error occured during dump process, and the task was aborted.
-    Failed,
-}
-
-/// Limited informations about a dump.\
-/// Can be obtained with [create_dump](Client::create_dump) and [get_dump_status](Client::get_dump_status) methods.
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct DumpInfo {
-    pub uid: String,
-    pub status: DumpStatus,
-    pub error: Option<serde_json::Value>,
-    pub started_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub finished_at: Option<String>,
-}
+use crate::{client::Client, errors::Error, request::*, task_info::TaskInfo};
 
 /// Dump related methods.\
 /// See the [dumps](crate::dumps) module.
@@ -77,7 +49,7 @@ impl Client {
     /// # Example
     ///
     /// ```no_run
-    /// # use meilisearch_sdk::{client::*, errors::*, dumps::*};
+    /// # use meilisearch_sdk::{client::*, errors::*, dumps::*, dumps::*, task_info::*, tasks::*};
     /// # use futures_await_test::async_test;
     /// # use std::{thread::sleep, time::Duration};
     /// # futures::executor::block_on(async move {
@@ -87,12 +59,18 @@ impl Client {
     /// #
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// #
-    /// let dump_info = client.create_dump().await.unwrap();
-    /// assert!(matches!(dump_info.status, DumpStatus::InProgress));
+    /// let task_info = client.create_dump().await.unwrap();
+    /// assert!(matches!(
+    ///    task_info,
+    ///    TaskInfo {
+    ///        update_type: TaskType::DumpCreation { .. },
+    ///        ..
+    ///    }
+    /// ));
     /// # });
     /// ```
-    pub async fn create_dump(&self) -> Result<DumpInfo, Error> {
-        request::<(), DumpInfo>(
+    pub async fn create_dump(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!("{}/dumps", self.host),
             &self.api_key,
             Method::Post(()),
@@ -100,72 +78,47 @@ impl Client {
         )
         .await
     }
-
-    /// Get the status of a dump creation process using [the uid](DumpInfo::uid) returned after calling the [dump creation method](Client::create_dump).
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use meilisearch_sdk::{client::*, errors::*, dumps::*};
-    /// # use futures_await_test::async_test;
-    /// # use std::{thread::sleep, time::Duration};
-    /// #
-    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// #
-    /// # futures::executor::block_on(async move {
-    /// #
-    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    /// # let dump_info = client.create_dump().await.unwrap();
-    /// # sleep(Duration::from_secs(5));
-    /// #
-    /// let dump_info = client.get_dump_status(&dump_info.uid).await.unwrap();
-    /// # });
-    /// ```
-    pub async fn get_dump_status(&self, dump_uid: impl AsRef<str>) -> Result<DumpInfo, Error> {
-        request::<(), DumpInfo>(
-            &format!("{}/dumps/{}/status", self.host, dump_uid.as_ref()),
-            &self.api_key,
-            Method::Get(()),
-            200,
-        )
-        .await
-    }
 }
 
 /// Alias for [create_dump](Client::create_dump).
-pub async fn create_dump(client: &Client) -> Result<DumpInfo, Error> {
+pub async fn create_dump(client: &Client) -> Result<TaskInfo, Error> {
     client.create_dump().await
-}
-
-/// Alias for [get_dump_status](Client::get_dump_status).
-pub async fn get_dump_status(
-    client: &Client,
-    dump_uid: impl AsRef<str>,
-) -> Result<DumpInfo, Error> {
-    client.get_dump_status(dump_uid).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::*;
+    use crate::{client::*, tasks::*};
     use meilisearch_test_macro::meilisearch_test;
-    use std::{thread::sleep, time::Duration};
+    use std::time::Duration;
 
     #[meilisearch_test]
-    async fn test_dumps(client: Client) {
-        // Create a dump
-        let dump_info = client.create_dump().await.unwrap();
-        assert!(matches!(dump_info.status, DumpStatus::InProgress));
+    async fn test_dumps_success_creation(client: Client) -> Result<(), Error> {
+        let task = client
+            .create_dump()
+            .await?
+            .wait_for_completion(
+                &client,
+                Some(Duration::from_millis(1)),
+                Some(Duration::from_millis(6000)),
+            )
+            .await?;
 
-        // Wait for Meilisearch to do the dump
-        sleep(Duration::from_secs(5));
+        assert!(matches!(task, Task::Succeeded { .. }));
+        Ok(())
+    }
 
-        // Assert that the dump was successful
-        let new_dump_info = client.get_dump_status(&dump_info.uid).await.unwrap();
-        assert!(matches!(new_dump_info.status, DumpStatus::Done));
-        assert!(new_dump_info.finished_at.is_some());
-        assert!(new_dump_info.started_at.is_some());
+    #[meilisearch_test]
+    async fn test_dumps_correct_update_type(client: Client) -> Result<(), Error> {
+        let task_info = client.create_dump().await.unwrap();
+
+        assert!(matches!(
+            task_info,
+            TaskInfo {
+                update_type: TaskType::DumpCreation { .. },
+                ..
+            }
+        ));
+        Ok(())
     }
 }

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -43,7 +43,7 @@ use serde::Deserialize;
 
 /// The status of a dump.\
 /// Contained in [`DumpInfo`].
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum DumpStatus {
     /// Dump creation is in progress.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,6 +36,10 @@ pub enum Error {
     HttpError(String),
     // The library formating the query parameters encountered an error.
     Yaup(yaup::Error),
+    // The library validating the format of an uuid.
+    Uuid(uuid::Error),
+    // Error thrown in case the version of the Uuid is not v4.
+    InvalidUuid4Version,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -72,6 +76,12 @@ impl From<jsonwebtoken::errors::Error> for Error {
 impl From<yaup::Error> for Error {
     fn from(error: yaup::Error) -> Error {
         Error::Yaup(error)
+    }
+}
+
+impl From<uuid::Error> for Error {
+    fn from(error: uuid::Error) -> Error {
+        Error::Uuid(error)
     }
 }
 
@@ -194,7 +204,9 @@ impl std::fmt::Display for Error {
             Error::TenantTokensInvalidApiKey => write!(fmt, "The provided api_key is invalid."),
             Error::TenantTokensExpiredSignature => write!(fmt, "The provided expires_at is already expired."),
             Error::InvalidTenantToken(e) => write!(fmt, "Impossible to generate the token, jsonwebtoken encountered an error: {}", e),
-            Error::Yaup(e) => write!(fmt, "Internal Error: could not parse the query parameters: {}", e)
+            Error::Yaup(e) => write!(fmt, "Internal Error: could not parse the query parameters: {}", e),
+            Error::Uuid(e) => write!(fmt, "The uid of the token has bit an uuid4 format: {}", e),
+            Error::InvalidUuid4Version => write!(fmt, "The uid provided to the token is not of version uuidv4")
         }
     }
 }

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -370,10 +370,8 @@ impl Index {
 
         request::<(), DocumentsResults<T>>(&url, &self.client.api_key, Method::Get(()), 200).await
     }
+
     /// Get [Document]s by batch with parameters.
-    ///
-    /// # Example
-    ///
     /// ```
     /// use serde::{Serialize, Deserialize};
     ///
@@ -409,7 +407,6 @@ impl Index {
     pub async fn get_documents_with<T: DeserializeOwned + 'static>(
         &self,
         documents_query: &DocumentsQuery<'_>,
-    ) -> Result<DocumentsResults<T>, Error> {
         let url = format!("{}/indexes/{}/documents", self.client.host, self.uid);
         request::<&DocumentsQuery, DocumentsResults<T>>(
             &url,

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::Client,
-    documents::{DocumentsQuery, DocumentsResults},
+    documents::{DocumentQuery, DocumentsQuery, DocumentsResults},
     errors::Error,
     request::*,
     search::*,
@@ -285,40 +285,48 @@ impl Index {
     /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// #[derive(Serialize, Deserialize, Debug)]
-    /// # #[derive(PartialEq)]
+    /// #[derive(Serialize, Debug)]
     /// struct Movie {
     ///    name: String,
     ///    description: String,
+    ///    age: Option<usize>
+    /// }
+    ///
+    /// #[derive(Deserialize, Debug, PartialEq)]
+    /// struct ReturnedMovie {
+    ///    name: String,
+    ///    description: String
     /// }
     ///
     ///
     /// # futures::executor::block_on(async move {
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// let movies = client.index("get_document");
-    /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage."), age: Some(1)}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
     /// // retrieve a document (you have to put the document in the index before)
-    /// let interstellar = movies.get_document::<Movie>("Interstellar").await.unwrap();
+    /// let interstellar = movies.get_document::<ReturnedMovie>("Interstellar", Some(["name", "description"].to_vec())).await.unwrap();
     ///
-    /// assert_eq!(interstellar, Movie {
+    /// assert_eq!(interstellar, ReturnedMovie {
     ///     name: String::from("Interstellar"),
-    ///     description: String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")
+    ///     description: String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage."),
     /// });
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn get_document<T: 'static + DeserializeOwned>(&self, uid: &str) -> Result<T, Error> {
-        request::<(), T>(
-            &format!(
-                "{}/indexes/{}/documents/{}",
-                self.client.host, self.uid, uid
-            ),
-            &self.client.api_key,
-            Method::Get(()),
-            200,
-        )
-        .await
+    pub async fn get_document<T: 'static + DeserializeOwned>(
+        &self,
+        document_id: &str,
+        fields: Option<Vec<&str>>,
+    ) -> Result<T, Error> {
+        let url = format!(
+            "{}/indexes/{}/documents/{}",
+            self.client.host, self.uid, document_id
+        );
+
+        let query = DocumentQuery { fields };
+
+        request::<&DocumentQuery, T>(&url, &self.client.api_key, Method::Get(&query), 200).await
     }
 
     /// Get [Document]s by batch.

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -97,7 +97,7 @@ impl Index {
         request::<serde_json::Value, serde_json::Value>(
             &format!("{}/indexes/{}", self.client.host, self.uid),
             &self.client.api_key,
-            Method::Put(json!({ "primaryKey": primary_key.as_ref() })),
+            Method::Patch(json!({ "primaryKey": primary_key.as_ref() })),
             200,
         )
         .await?;

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1,4 +1,4 @@
-use crate::{client::Client, errors::Error, request::*, search::*, tasks::*};
+use crate::{client::Client, errors::Error, request::*, search::*, task_info::TaskInfo, tasks::*};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 use std::{collections::HashMap, fmt::Display, sync::Arc, time::Duration};
@@ -124,8 +124,8 @@ impl Index {
     /// client.wait_for_task(task, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn delete(self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn delete(self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!("{}/indexes/{}", self.client.host, self.uid),
             &self.client.api_key,
             Method::Delete,
@@ -391,7 +391,7 @@ impl Index {
         &self,
         documents: &[T],
         primary_key: Option<&str>,
-    ) -> Result<Task, Error> {
+    ) -> Result<TaskInfo, Error> {
         let url = if let Some(primary_key) = primary_key {
             format!(
                 "{}/indexes/{}/documents?primaryKey={}",
@@ -400,7 +400,7 @@ impl Index {
         } else {
             format!("{}/indexes/{}/documents", self.client.host, self.uid)
         };
-        request::<&[T], Task>(&url, &self.client.api_key, Method::Post(documents), 202).await
+        request::<&[T], TaskInfo>(&url, &self.client.api_key, Method::Post(documents), 202).await
     }
 
     /// Alias for [Index::add_or_replace].
@@ -408,7 +408,7 @@ impl Index {
         &self,
         documents: &[T],
         primary_key: Option<&str>,
-    ) -> Result<Task, Error> {
+    ) -> Result<TaskInfo, Error> {
         self.add_or_replace(documents, primary_key).await
     }
 
@@ -469,7 +469,7 @@ impl Index {
         &self,
         documents: &[T],
         primary_key: Option<impl AsRef<str>>,
-    ) -> Result<Task, Error> {
+    ) -> Result<TaskInfo, Error> {
         let url = if let Some(primary_key) = primary_key {
             format!(
                 "{}/indexes/{}/documents?primaryKey={}",
@@ -480,7 +480,7 @@ impl Index {
         } else {
             format!("{}/indexes/{}/documents", self.client.host, self.uid)
         };
-        request::<&[T], Task>(&url, &self.client.api_key, Method::Put(documents), 202).await
+        request::<&[T], TaskInfo>(&url, &self.client.api_key, Method::Put(documents), 202).await
     }
 
     /// Delete all documents in the index.
@@ -520,8 +520,8 @@ impl Index {
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn delete_all_documents(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn delete_all_documents(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!("{}/indexes/{}/documents", self.client.host, self.uid),
             &self.client.api_key,
             Method::Delete,
@@ -565,8 +565,8 @@ impl Index {
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn delete_document<T: Display>(&self, uid: T) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn delete_document<T: Display>(&self, uid: T) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/documents/{}",
                 self.client.host, self.uid, uid
@@ -617,8 +617,8 @@ impl Index {
     pub async fn delete_documents<T: Display + Serialize + std::fmt::Debug>(
         &self,
         uids: &[T],
-    ) -> Result<Task, Error> {
-        request::<&[T], Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<&[T], TaskInfo>(
             &format!(
                 "{}/indexes/{}/documents/delete-batch",
                 self.client.host, self.uid
@@ -729,18 +729,13 @@ impl Index {
     ///    Task::Succeeded { content } => content.uid,
     /// };
     ///
-    /// assert_eq!(task.get_uid(), from_index);
+    /// assert_eq!(task.get_task_uid(), from_index);
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn get_task(&self, uid: impl AsRef<u64>) -> Result<Task, Error> {
+    pub async fn get_task(&self, uid: impl AsRef<u32>) -> Result<Task, Error> {
         request::<(), Task>(
-            &format!(
-                "{}/indexes/{}/tasks/{}",
-                self.client.host,
-                self.uid,
-                uid.as_ref()
-            ),
+            &format!("{}/tasks/{}", self.client.host, uid.as_ref()),
             &self.client.api_key,
             Method::Get(()),
             200,
@@ -763,30 +758,50 @@ impl Index {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
-    /// let status = index.get_tasks().await.unwrap();
-    /// assert!(status.len() == 1); // the index was created
+    /// let tasks = index.get_tasks().await.unwrap();
     ///
-    /// index.set_ranking_rules(["wrong_ranking_rule"]).await.unwrap();
-    ///
-    /// let status = index.get_tasks().await.unwrap();
-    /// assert!(status.len() == 2);
+    /// assert!(tasks.results.len() > 0);
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn get_tasks(&self) -> Result<Vec<Task>, Error> {
-        #[derive(Deserialize)]
-        struct AllTasks {
-            results: Vec<Task>,
-        }
+    pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
+        let mut query = TasksQuery::new(&self.client);
+        query.with_index_uid([self.uid.as_str()]);
 
-        Ok(request::<(), AllTasks>(
-            &format!("{}/indexes/{}/tasks", self.client.host, self.uid),
-            &self.client.api_key,
-            Method::Get(()),
-            200,
-        )
-        .await?
-        .results)
+        self.client.get_tasks_with(&query).await
+    }
+
+    /// Get the status of all tasks in a given index.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use serde::{Serialize, Deserialize};
+    /// # use meilisearch_sdk::{client::*, indexes::*, tasks::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client.create_index("get_tasks_with", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
+    ///
+    /// let mut query = TasksQuery::new(&client);
+    /// query.with_index_uid(["none_existant"]);
+    /// let tasks = index.get_tasks_with(&query).await.unwrap();
+    ///
+    /// assert!(tasks.results.len() > 0);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn get_tasks_with(
+        &self,
+        tasks_query: &TasksQuery<'_>,
+    ) -> Result<TasksResults, Error> {
+        let mut query = tasks_query.clone();
+        query.with_index_uid([self.uid.as_str()]);
+
+        self.client.get_tasks_with(&query).await
     }
 
     /// Get stats of an index.
@@ -861,7 +876,7 @@ impl Index {
     /// ```
     pub async fn wait_for_task(
         &self,
-        task_id: impl AsRef<u64>,
+        task_id: impl AsRef<u32>,
         interval: Option<Duration>,
         timeout: Option<Duration>,
     ) -> Result<Task, Error> {
@@ -925,7 +940,7 @@ impl Index {
         documents: &[T],
         batch_size: Option<usize>,
         primary_key: Option<&str>,
-    ) -> Result<Vec<Task>, Error> {
+    ) -> Result<Vec<TaskInfo>, Error> {
         let mut task = Vec::with_capacity(documents.len());
         for document_batch in documents.chunks(batch_size.unwrap_or(1000)) {
             task.push(self.add_documents(document_batch, primary_key).await?);
@@ -1015,7 +1030,7 @@ impl Index {
         documents: &[T],
         batch_size: Option<usize>,
         primary_key: Option<&str>,
-    ) -> Result<Vec<Task>, Error> {
+    ) -> Result<Vec<TaskInfo>, Error> {
         let mut task = Vec::with_capacity(documents.len());
         for document_batch in documents.chunks(batch_size.unwrap_or(1000)) {
             task.push(self.add_or_update(document_batch, primary_key).await?);
@@ -1086,13 +1101,6 @@ mod tests {
     }
 
     #[meilisearch_test]
-    async fn test_get_tasks_no_docs(index: Index) {
-        // The at this point the only task that is supposed to exist is the creation of the index
-        let status = index.get_tasks().await.unwrap();
-        assert_eq!(status.len(), 1);
-    }
-
-    #[meilisearch_test]
     async fn test_get_one_task(client: Client, index: Index) -> Result<(), Error> {
         let task = index
             .delete_all_documents()
@@ -1103,10 +1111,42 @@ mod tests {
         let status = index.get_task(task).await?;
 
         match status {
-            Task::Enqueued { content } => assert_eq!(content.index_uid, *index.uid),
-            Task::Processing { content } => assert_eq!(content.index_uid, *index.uid),
-            Task::Failed { content } => assert_eq!(content.task.index_uid, *index.uid),
-            Task::Succeeded { content } => assert_eq!(content.index_uid, *index.uid),
+            Task::Enqueued {
+                content:
+                    EnqueuedTask {
+                        index_uid: Some(index_uid),
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            Task::Processing {
+                content:
+                    EnqueuedTask {
+                        index_uid: Some(index_uid),
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            Task::Failed {
+                content:
+                    FailedTask {
+                        task:
+                            SucceededTask {
+                                index_uid: Some(index_uid),
+                                ..
+                            },
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            Task::Succeeded {
+                content:
+                    SucceededTask {
+                        index_uid: Some(index_uid),
+                        ..
+                    },
+            } => assert_eq!(index_uid, *index.uid),
+            task => panic!(
+                "The task should have an index_uid that is not null {:?}",
+                task
+            ),
         }
         Ok(())
     }

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1,7 +1,6 @@
 use crate::{client::Client, errors::Error, request::*, search::*, task_info::TaskInfo, tasks::*};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::json;
-use std::{collections::HashMap, fmt::Display, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt::Display, time::Duration};
 use time::OffsetDateTime;
 
 /// An index containing [Document]s.
@@ -37,7 +36,7 @@ use time::OffsetDateTime;
 /// # });
 /// ```
 ///
-/// Or, if you know the index already exist remotely you can create an `Index` with the [Client::index] function.
+/// Or, if you know the index already exist remotely you can create an [Index] with its builder.
 /// ```
 /// # use meilisearch_sdk::{client::*, indexes::*};
 /// #
@@ -47,27 +46,39 @@ use time::OffsetDateTime;
 /// # futures::executor::block_on(async move {
 /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
 ///
-/// // use the implicit index creation if the index already exist or
 /// // Meilisearch would be able to create the index if it does not exist during:
 /// // - the documents addition (add and update routes)
 /// // - the settings update
-/// let movies = client.index("index");
+/// let movies = Index::new("movies", client);
 ///
-/// // do something with the index
+/// assert_eq!(movies.uid, "movies");
 /// # });
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Index {
-    pub(crate) uid: Arc<String>,
-    pub(crate) client: Client,
-    pub(crate) primary_key: Option<String>,
-    pub created_at: Option<OffsetDateTime>,
+    #[serde(skip_serializing)]
+    pub client: Client,
+    pub uid: String,
+    #[serde(with = "time::serde::rfc3339::option")]
     pub updated_at: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub created_at: Option<OffsetDateTime>,
+    pub primary_key: Option<String>,
 }
 
 impl Index {
+    pub fn new(uid: impl Into<String>, client: Client) -> Index {
+        Index {
+            uid: uid.into(),
+            client,
+            primary_key: None,
+            created_at: None,
+            updated_at: None,
+        }
+    }
     /// Internal Function to create an [Index] from `serde_json::Value` and [Client]
-    pub(crate) fn from_value(v: serde_json::Value, client: Client) -> Result<Index, Error> {
+    pub(crate) fn from_value(raw_index: serde_json::Value, client: Client) -> Result<Index, Error> {
         #[derive(Deserialize, Debug)]
         #[allow(non_snake_case)]
         struct IndexFromSerde {
@@ -79,10 +90,10 @@ impl Index {
             primaryKey: Option<String>,
         }
 
-        let i: IndexFromSerde = serde_json::from_value(v).map_err(Error::ParseError)?;
+        let i: IndexFromSerde = serde_json::from_value(raw_index).map_err(Error::ParseError)?;
 
         Ok(Index {
-            uid: Arc::new(i.uid),
+            uid: i.uid,
             client,
             created_at: i.createdAt,
             updated_at: i.updatedAt,
@@ -90,18 +101,50 @@ impl Index {
         })
     }
 
-    /// Set the primary key of the index.
+    /// Update an [Index].
     ///
-    /// If you prefer, you can use the method [Index::set_primary_key], which is an alias.
-    pub async fn update(&self, primary_key: impl AsRef<str>) -> Result<(), Error> {
-        request::<serde_json::Value, serde_json::Value>(
-            &format!("{}/indexes/{}", self.client.host, self.uid),
-            &self.client.api_key,
-            Method::Patch(json!({ "primaryKey": primary_key.as_ref() })),
-            200,
-        )
-        .await?;
-        Ok(())
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, task_info::*, tasks::{Task, SucceededTask}};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let mut index = client
+    /// #   .create_index("index_update", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// # // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///
+    /// index.primary_key = Some("special_id".to_string());
+    /// let task = index.update()
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// let index = client.get_index("index_update").await.unwrap();
+    /// assert_eq!(index.primary_key, Some("special_id".to_string()));
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn update(&self) -> Result<TaskInfo, Error> {
+        let mut index_update = IndexUpdater::new(self, &self.client);
+
+        if let Some(ref primary_key) = self.primary_key {
+            index_update.with_primary_key(primary_key);
+        }
+
+        index_update.execute().await
     }
 
     /// Delete the index.
@@ -631,8 +674,13 @@ impl Index {
     }
 
     /// Alias for the [Index::update] method.
-    pub async fn set_primary_key(&self, primary_key: impl AsRef<str>) -> Result<(), Error> {
-        self.update(primary_key).await
+    pub async fn set_primary_key(
+        &mut self,
+        primary_key: impl AsRef<str>,
+    ) -> Result<TaskInfo, Error> {
+        self.primary_key = Some(primary_key.as_ref().to_string());
+
+        self.update().await
     }
 
     /// Fetch the information of the index as a raw JSON [Index], this index should already exist.
@@ -659,7 +707,7 @@ impl Index {
     /// ```
     /// If you use it directly from the [Client], you can use the method [Client::get_raw_index], which is the equivalent method from the client.
     pub async fn fetch_info(&mut self) -> Result<(), Error> {
-        let v = self.client.get_raw_index(self.uid.as_ref()).await?;
+        let v = self.client.get_raw_index(&self.uid).await?;
         *self = Index::from_value(v, self.client.clone())?;
         Ok(())
     }
@@ -1045,6 +1093,163 @@ impl AsRef<str> for Index {
     }
 }
 
+/// An [IndexUpdater] used to update the specifics of an index
+///
+/// # Example
+///
+/// ```
+/// # use meilisearch_sdk::{client::*, indexes::*, task_info::*, tasks::{Task, SucceededTask}};
+/// #
+/// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+/// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+/// #
+/// # futures::executor::block_on(async move {
+/// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+/// # let index = client
+/// #   .create_index("index_updater", None)
+/// #   .await
+/// #   .unwrap()
+/// #   .wait_for_completion(&client, None, None)
+/// #   .await
+/// #   .unwrap()
+/// # // Once the task finished, we try to create an `Index` out of it
+/// #   .try_make_index(&client)
+/// #   .unwrap();
+///
+/// let task = IndexUpdater::new("index_updater", &client)
+///   .with_primary_key("special_id")
+///   .execute()
+///   .await
+///   .unwrap()
+///   .wait_for_completion(&client, None, None)
+///   .await
+///   .unwrap();
+///
+/// let index = client.get_index("index_updater").await.unwrap();
+/// assert_eq!(index.primary_key, Some("special_id".to_string()));
+/// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+/// # });
+/// ```
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexUpdater<'a> {
+    #[serde(skip)]
+    pub client: &'a Client,
+    #[serde(skip_serializing)]
+    pub uid: String,
+    pub primary_key: Option<String>,
+}
+
+impl<'a> IndexUpdater<'a> {
+    pub fn new(uid: impl AsRef<str>, client: &Client) -> IndexUpdater {
+        IndexUpdater {
+            client,
+            primary_key: None,
+            uid: uid.as_ref().to_string(),
+        }
+    }
+    /// Define the new primary_key to set on the [Index]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, task_info::*, tasks::{Task, SucceededTask}};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_updater_with_primary_key", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// # // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///
+    /// let task = IndexUpdater::new("index_updater_with_primary_key", &client)
+    ///   .with_primary_key("special_id")
+    ///   .execute()
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// let index = client.get_index("index_updater_with_primary_key").await.unwrap();
+    /// assert_eq!(index.primary_key, Some("special_id".to_string()));
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_primary_key(&mut self, primary_key: impl AsRef<str>) -> &mut Self {
+        self.primary_key = Some(primary_key.as_ref().to_string());
+        self
+    }
+
+    /// Execute the update of an [Index] using the [IndexUpdater]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, task_info::*, tasks::{Task, SucceededTask}};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_updater_execute", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// # // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///
+    /// let task = IndexUpdater::new("index_updater_execute", &client)
+    ///   .with_primary_key("special_id")
+    ///   .execute()
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// let index = client.get_index("index_updater_execute").await.unwrap();
+    /// assert_eq!(index.primary_key, Some("special_id".to_string()));
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn execute(&'a self) -> Result<TaskInfo, Error> {
+        request::<&IndexUpdater, TaskInfo>(
+            &format!("{}/indexes/{}", self.client.host, self.uid),
+            &self.client.api_key,
+            Method::Patch(self),
+            202,
+        )
+        .await
+    }
+}
+
+impl AsRef<str> for IndexUpdater<'_> {
+    fn as_ref(&self) -> &str {
+        &self.uid
+    }
+}
+
+impl<'a> AsRef<IndexUpdater<'a>> for IndexUpdater<'a> {
+    fn as_ref(&self) -> &IndexUpdater<'a> {
+        self
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexStats {
@@ -1053,11 +1258,187 @@ pub struct IndexStats {
     pub field_distribution: HashMap<String, usize>,
 }
 
+// An [IndexesQuery] containing filter and pagination parameters when searching for [Index]es
+///
+/// # Example
+///
+/// ```
+/// # use meilisearch_sdk::{client::*, indexes::*};
+/// #
+/// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+/// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+/// #
+/// # futures::executor::block_on(async move {
+/// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+/// # let index = client
+/// #   .create_index("index_query_builder", None)
+/// #   .await
+/// #   .unwrap()
+/// #   .wait_for_completion(&client, None, None)
+/// #   .await
+/// #   .unwrap()
+/// #   // Once the task finished, we try to create an `Index` out of it
+/// #   .try_make_index(&client)
+/// #   .unwrap();
+///  let mut indexes = IndexesQuery::new(&client)
+///   .with_limit(1)
+///   .execute().await.unwrap();
+///
+/// # assert_eq!(indexes.results.len(), 1);
+/// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+/// # });
+/// ```
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexesQuery<'a> {
+    #[serde(skip_serializing)]
+    pub client: &'a Client,
+    /// The number of [Index]es to skip.
+    /// If the value of the parameter `offset` is `n`, the `n` first indexes will not be returned.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you want to skip the first index, set offset to `1`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+
+    /// The maximum number of [Index]es returned.
+    /// If the value of the parameter `limit` is `n`, there will never be more than `n` indexes in the response.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you don't want to get more than two indexes, set limit to `2`.
+    /// Default: `20`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
+impl<'a> IndexesQuery<'a> {
+    pub fn new(client: &Client) -> IndexesQuery {
+        IndexesQuery {
+            client,
+            offset: None,
+            limit: None,
+        }
+    }
+
+    /// Specify the offset.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_query_with_offset", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///
+    ///  let mut indexes = IndexesQuery::new(&client)
+    ///   .with_offset(1)
+    ///   .execute().await.unwrap();
+    ///
+    /// # assert_eq!(indexes.offset, 1);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_offset(&mut self, offset: usize) -> &mut IndexesQuery<'a> {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Specify the maximum number of [Index]es to return.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_query_with_limit", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///  let mut indexes = IndexesQuery::new(&client)
+    ///   .with_limit(1)
+    ///   .execute().await.unwrap();
+    ///
+    /// # assert_eq!(indexes.results.len(), 1);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_limit(&mut self, limit: usize) -> &mut IndexesQuery<'a> {
+        self.limit = Some(limit);
+        self
+    }
+    /// Get [Index]es.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{indexes::IndexesQuery, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// # let index = client
+    /// #   .create_index("index_query_with_execute", None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   .wait_for_completion(&client, None, None)
+    /// #   .await
+    /// #   .unwrap()
+    /// #   // Once the task finished, we try to create an `Index` out of it
+    /// #   .try_make_index(&client)
+    /// #   .unwrap();
+    ///  let mut indexes = IndexesQuery::new(&client)
+    ///   .with_limit(1)
+    ///   .execute().await.unwrap();
+    ///
+    /// # assert_eq!(indexes.results.len(), 1);
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn execute(&self) -> Result<IndexesResults, Error> {
+        self.client.list_all_indexes_with(self).await
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IndexesResults {
+    pub results: Vec<Index>,
+    pub limit: u32,
+    pub offset: u32,
+    pub total: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use meilisearch_test_macro::meilisearch_test;
+    use serde_json::json;
 
     #[meilisearch_test]
     async fn test_from_value(client: Client) {
@@ -1074,7 +1455,7 @@ mod tests {
         });
 
         let idx = Index {
-            uid: Arc::new("test_from_value".to_string()),
+            uid: "test_from_value".to_string(),
             primary_key: None,
             created_at: Some(t),
             updated_at: Some(t),

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1,4 +1,12 @@
-use crate::{client::Client, errors::Error, request::*, search::*, task_info::TaskInfo, tasks::*};
+use crate::{
+    client::Client,
+    documents::{DocumentsQuery, DocumentsResults},
+    errors::Error,
+    request::*,
+    search::*,
+    task_info::TaskInfo,
+    tasks::*,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display, time::Duration};
 use time::OffsetDateTime;
@@ -315,11 +323,6 @@ impl Index {
 
     /// Get [Document]s by batch.
     ///
-    /// Using the optional parameters offset and limit, you can browse through all your documents.
-    /// If None, offset will be set to 0, limit to 20, and all attributes will be retrieved.
-    ///
-    /// *Note: Documents are ordered by Meilisearch depending on the hash of their id.*
-    ///
     /// # Example
     ///
     /// ```
@@ -346,34 +349,67 @@ impl Index {
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
     /// // retrieve movies (you have to put some movies in the index before)
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
     ///
-    /// assert!(movies.len() > 0);
+    /// assert!(movies.results.len() > 0);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
     pub async fn get_documents<T: DeserializeOwned + 'static>(
         &self,
-        offset: Option<usize>,
-        limit: Option<usize>,
-        attributes_to_retrieve: Option<&str>,
-    ) -> Result<Vec<T>, Error> {
-        let mut url = format!("{}/indexes/{}/documents?", self.client.host, self.uid);
-        if let Some(offset) = offset {
-            url.push_str("offset=");
-            url.push_str(offset.to_string().as_str());
-            url.push('&');
-        }
-        if let Some(limit) = limit {
-            url.push_str("limit=");
-            url.push_str(limit.to_string().as_str());
-            url.push('&');
-        }
-        if let Some(attributes_to_retrieve) = attributes_to_retrieve {
-            url.push_str("attributesToRetrieve=");
-            url.push_str(attributes_to_retrieve);
-        }
-        request::<(), Vec<T>>(&url, &self.client.api_key, Method::Get(()), 200).await
+    ) -> Result<DocumentsResults<T>, Error> {
+        let url = format!("{}/indexes/{}/documents", self.client.host, self.uid);
+
+        request::<(), DocumentsResults<T>>(&url, &self.client.api_key, Method::Get(()), 200).await
+    }
+    /// Get [Document]s by batch with parameters.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use serde::{Serialize, Deserialize};
+    ///
+    /// # use meilisearch_sdk::{client::*, indexes::*, documents::*};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    ///
+    /// #[derive(Serialize, Deserialize, Debug)]
+    /// # #[derive(PartialEq)]
+    /// struct Movie {
+    ///    name: String,
+    ///    description: String,
+    /// }
+    ///
+    ///
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let movie_index = client.index("get_documents");
+    ///
+    /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    ///
+    /// let mut query = DocumentsQuery::new(&movie_index);
+    /// query.with_limit(1);
+    /// // retrieve movies (you have to put some movies in the index before)
+    /// let movies = movie_index.get_documents_with::<Movie>(&query).await.unwrap();
+    ///
+    /// assert!(movies.results.len() == 1);
+    /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn get_documents_with<T: DeserializeOwned + 'static>(
+        &self,
+        documents_query: &DocumentsQuery<'_>,
+    ) -> Result<DocumentsResults<T>, Error> {
+        let url = format!("{}/indexes/{}/documents", self.client.host, self.uid);
+        request::<&DocumentsQuery, DocumentsResults<T>>(
+            &url,
+            &self.client.api_key,
+            Method::Get(documents_query),
+            200,
+        )
+        .await
     }
 
     /// Add a list of [Document]s or replace them if they already exist.
@@ -425,7 +461,7 @@ impl Index {
     /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed
     /// client.wait_for_task(task, None, None).await.unwrap();
     ///
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
     /// assert!(movies.len() >= 3);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
@@ -503,7 +539,7 @@ impl Index {
     /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed
     /// client.wait_for_task(task, None, None).await.unwrap();
     ///
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
     /// assert!(movies.len() >= 3);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
@@ -558,8 +594,8 @@ impl Index {
     ///   .wait_for_completion(&client, None, None)
     ///   .await
     ///   .unwrap();
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert_eq!(movies.len(), 0);
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert_eq!(movies.results.len(), 0);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
@@ -977,8 +1013,8 @@ impl Index {
     ///
     /// client.wait_for_task(tasks.last().unwrap(), None, None).await.unwrap();
     ///
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert!(movies.len() >= 3);
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert!(movies.results.len() >= 3);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None,
     /// None).await.unwrap();
     /// # });
@@ -1042,8 +1078,8 @@ impl Index {
     ///
     /// client.wait_for_task(tasks.last().unwrap(), None, None).await.unwrap();
     ///
-    /// let movies = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert!(movies.len() >= 3);
+    /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert!(movies.results.len() >= 3);
     ///
     /// let updated_movies = [
     ///  Movie {
@@ -1064,10 +1100,10 @@ impl Index {
     ///
     /// client.wait_for_task(tasks.last().unwrap(), None, None).await.unwrap();
     ///
-    /// let movies_updated = movie_index.get_documents::<Movie>(None, None, None).await.unwrap();
-    /// assert!(movies_updated.len() >= 3);
+    /// let movies_updated = movie_index.get_documents::<Movie>().await.unwrap();
+    /// assert!(movies_updated.results.len() >= 3);
     ///
-    /// assert!(&movies_updated[..] == &updated_movies[..]);
+    /// assert!(&movies_updated.results[..] == &updated_movies[..]);
     ///
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None,
     /// None).await.unwrap();
@@ -1479,6 +1515,40 @@ mod tests {
         assert!(index.updated_at.is_some());
         assert!(index.created_at.is_some());
         assert!(index.primary_key.is_none());
+    }
+
+    #[meilisearch_test]
+    async fn test_get_documents(index: Index) {
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        struct Object {
+            id: usize,
+            value: String,
+            kind: String,
+        }
+        let res = index.get_documents::<Object>().await.unwrap();
+
+        assert_eq!(res.limit, 20)
+    }
+
+    #[meilisearch_test]
+    async fn test_get_documents_with(index: Index) {
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        struct Object {
+            id: usize,
+            value: String,
+            kind: String,
+        }
+
+        let mut documents_query = DocumentsQuery::new(&index);
+        documents_query.with_limit(1).with_offset(2);
+
+        let res = index
+            .get_documents_with::<Object>(&documents_query)
+            .await
+            .unwrap();
+
+        assert_eq!(res.limit, 1);
+        assert_eq!(res.offset, 2);
     }
 
     #[meilisearch_test]

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -407,6 +407,7 @@ impl Index {
     pub async fn get_documents_with<T: DeserializeOwned + 'static>(
         &self,
         documents_query: &DocumentsQuery<'_>,
+    ) -> Result<DocumentsResults<T>, Error> {
         let url = format!("{}/indexes/{}/documents", self.client.host, self.uid);
         request::<&DocumentsQuery, DocumentsResults<T>>(
             &url,
@@ -467,7 +468,7 @@ impl Index {
     /// client.wait_for_task(task, None, None).await.unwrap();
     ///
     /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
-    /// assert!(movies.len() >= 3);
+    /// assert!(movies.results.len() >= 3);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
@@ -545,7 +546,7 @@ impl Index {
     /// client.wait_for_task(task, None, None).await.unwrap();
     ///
     /// let movies = movie_index.get_documents::<Movie>().await.unwrap();
-    /// assert!(movies.len() >= 3);
+    /// assert!(movies.results.len() >= 3);
     /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```

--- a/src/key.rs
+++ b/src/key.rs
@@ -6,20 +6,23 @@ use crate::{client::Client, errors::Error};
 /// Represent a [meilisearch key](https://docs.meilisearch.com/reference/api/keys.html#returned-fields)
 /// You can get a [Key] from the [Client::get_key] method.
 /// Or you can create a [Key] with the [KeyBuilder::create] or [Client::create_key] methods.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Key {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub actions: Vec<Action>,
     #[serde(skip_serializing, with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    pub description: String,
+    pub description: Option<String>,
+    pub name: Option<String>,
     #[serde(with = "time::serde::rfc3339::option")]
     pub expires_at: Option<OffsetDateTime>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub indexes: Vec<String>,
     #[serde(skip_serializing)]
     pub key: String,
+    #[serde(skip_serializing)]
+    pub uid: String,
     #[serde(skip_serializing, with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
 }
@@ -37,23 +40,23 @@ impl Key {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
+    /// let description = "My not so little lovely test key".to_string();
+    /// let mut key = KeyBuilder::new()
     ///   .with_action(Action::DocumentsAdd)
     ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
+    ///   .with_description(&description)
+    ///   .execute(&client).await.unwrap();
     ///
-    /// key.with_description("My not so little lovely test key");
-    /// # assert_eq!(key.description, "My not so little lovely test key".to_string());
+    /// # assert_eq!(key.description, Some(description));
     /// # client.delete_key(key).await.unwrap();
     /// # });
     /// ```
     pub fn with_description(&mut self, desc: impl AsRef<str>) -> &mut Self {
-        self.description = desc.as_ref().to_string();
+        self.description = Some(desc.as_ref().to_string());
         self
     }
 
-    /// Add a set of actions the [Key] will be able to execute.
+    /// Update the name of the key.
     ///
     /// # Example
     ///
@@ -65,134 +68,19 @@ impl Key {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
+    ///  let name = "lovely key".to_string();
+    ///  let mut key = KeyBuilder::new()
     ///   .with_action(Action::DocumentsAdd)
     ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
+    ///   .execute(&client).await.unwrap();
     ///
-    /// key.with_actions([Action::DocumentsGet, Action::DocumentsDelete]);
+    ///  key.with_name(&name);
+    /// # assert_eq!(key.name, Some(name));
     /// # client.delete_key(key).await.unwrap();
     /// # });
     /// ```
-    pub fn with_actions(&mut self, actions: impl IntoIterator<Item = Action>) -> &mut Self {
-        self.actions.extend(actions);
-        self
-    }
-
-    /// Add one action the [Key] will be able to execute.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
-    /// #
-    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// #
-    /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .with_action(Action::DocumentsAdd)
-    ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// key.with_action(Action::DocumentsGet);
-    /// # client.delete_key(key).await.unwrap();
-    /// # });
-    /// ```
-    pub fn with_action(&mut self, action: Action) -> &mut Self {
-        self.actions.push(action);
-        self
-    }
-
-    /// Update the expiration date of the [Key].
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
-    /// use time::{OffsetDateTime, Duration};
-    /// #
-    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// #
-    /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .with_action(Action::DocumentsAdd)
-    ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// // update the epiry date of the key to two weeks from now
-    /// key.with_expires_at(OffsetDateTime::now_utc() + Duration::WEEK * 2);
-    /// # client.delete_key(key).await.unwrap();
-    /// # });
-    /// ```
-    pub fn with_expires_at(&mut self, expires_at: OffsetDateTime) -> &mut Self {
-        self.expires_at = Some(expires_at);
-        self
-    }
-
-    /// Update the indexes the [Key] can manage.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
-    /// #
-    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// #
-    /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .with_action(Action::DocumentsAdd)
-    ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// key.with_indexes(vec!["test", "movies"]);
-    /// # client.delete_key(key).await.unwrap();
-    /// # });
-    /// ```
-    pub fn with_indexes(
-        &mut self,
-        indexes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> &mut Self {
-        self.indexes = indexes
-            .into_iter()
-            .map(|index| index.as_ref().to_string())
-            .collect();
-        self
-    }
-
-    /// Add one index the [Key] can manage.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
-    /// #
-    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// #
-    /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    ///
-    ///  let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .with_action(Action::DocumentsAdd)
-    ///   .with_index("*")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// key.with_index("test");
-    /// # client.delete_key(key).await.unwrap();
-    /// # });
-    /// ```
-    pub fn with_index(&mut self, index: impl AsRef<str>) -> &mut Self {
-        self.indexes.push(index.as_ref().to_string());
+    pub fn with_name(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.name = Some(desc.as_ref().to_string());
         self
     }
 
@@ -208,21 +96,50 @@ impl Key {
     /// #
     /// # futures::executor::block_on(async move {
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    /// let mut key = KeyBuilder::new("My little lovely test key")
-    ///   .create(&client).await.unwrap();
-    ///
-    /// # assert_eq!(key.description, "My little lovely test key");
-    ///
-    /// key.with_description("My not so little lovely test key");
+    /// let mut key = KeyBuilder::new()
+    ///   .execute(&client).await.unwrap();
+    /// let description = "My not so little lovely test key".to_string();
+    /// key.with_description(&description);
     /// let key = key.update(&client).await.unwrap();
     ///
-    /// # assert_eq!(key.description, "My not so little lovely test key".to_string());
-    ///
+    /// # assert_eq!(key.description, Some(description));
     /// # client.delete_key(key).await.unwrap();
     /// # });
     /// ```
     pub async fn update(&self, client: &Client) -> Result<Key, Error> {
-        client.update_key(self).await
+        // only send description and name
+        let mut key_update = KeyUpdater::new(self);
+
+        if let Some(ref description) = self.description {
+            key_update.with_description(description);
+        }
+        if let Some(ref name) = self.name {
+            key_update.with_name(name);
+        }
+
+        key_update.execute(client).await
+    }
+
+    /// Delete the [Key].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let mut key = KeyBuilder::new()
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn delete(&self, client: &Client) -> Result<(), Error> {
+        client.delete_key(self).await
     }
 }
 
@@ -235,6 +152,236 @@ impl AsRef<str> for Key {
 impl AsRef<Key> for Key {
     fn as_ref(&self) -> &Key {
         self
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyUpdater {
+    pub description: Option<String>,
+    pub name: Option<String>,
+    #[serde(skip_serializing)]
+    pub key: String,
+}
+
+impl KeyUpdater {
+    pub fn new(key_or_uid: impl AsRef<str>) -> KeyUpdater {
+        KeyUpdater {
+            description: None,
+            name: None,
+            key: key_or_uid.as_ref().to_string(),
+        }
+    }
+
+    /// Update the description of the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client, key::KeyUpdater};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut new_key = KeyBuilder::new()
+    ///     .execute(&client)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let description = "My not so little lovely test key".to_string();
+    /// let mut key_update = KeyUpdater::new(new_key)
+    ///     .with_description(&description)
+    ///     .execute(&client)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// # assert_eq!(key_update.description, Some(description));
+    /// # client.delete_key(key_update).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_description(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.description = Some(desc.as_ref().to_string());
+        self
+    }
+
+    /// Update the name of the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client, key::KeyUpdater};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut new_key = KeyBuilder::new()
+    ///     .execute(&client)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let name = "lovely key".to_string();
+    ///
+    /// let mut key_update = KeyUpdater::new(new_key)
+    ///     .with_name(&name)
+    ///     .execute(&client)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// # assert_eq!(key_update.name, Some(name));
+    /// # client.delete_key(key_update).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_name(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.name = Some(desc.as_ref().to_string());
+        self
+    }
+
+    /// Update a [Key] using the [KeyUpdater].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::KeyUpdater, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let description = "My little lovely test key".to_string();
+    /// let key = KeyBuilder::new()
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// let mut key_update = KeyUpdater::new(&key.key);
+    /// key_update.with_description(&description).execute(&client).await;
+    ///
+    /// assert_eq!(key_update.description, Some(description));
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn execute(&self, client: &Client) -> Result<Key, Error> {
+        client.update_key(self).await
+    }
+}
+
+impl AsRef<str> for KeyUpdater {
+    fn as_ref(&self) -> &str {
+        &self.key
+    }
+}
+
+impl AsRef<KeyUpdater> for KeyUpdater {
+    fn as_ref(&self) -> &KeyUpdater {
+        self
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct KeysQuery {
+    /// The number of documents to skip.
+    /// If the value of the parameter `offset` is `n`, the `n` first documents (ordered by relevance) will not be returned.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you want to skip the first document, set offset to `1`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+    /// The maximum number of documents returned.
+    /// If the value of the parameter `limit` is `n`, there will never be more than `n` documents in the response.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you don't want to get more than two documents, set limit to `2`.
+    /// Default: `20`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
+impl KeysQuery {
+    /// Create a [KeysQuery] with only a description.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeysQuery};
+    /// let builder = KeysQuery::new();
+    /// ```
+    pub fn new() -> KeysQuery {
+        Self::default()
+    }
+
+    /// Specify the offset.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeysQuery, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut keys = KeysQuery::new()
+    ///   .with_offset(1)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(keys.results.len(), 1);
+    /// # });
+    /// ```
+    pub fn with_offset(&mut self, offset: usize) -> &mut KeysQuery {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Specify the maximum number of keys to return.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeysQuery, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut keys = KeysQuery::new()
+    ///   .with_limit(1)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(keys.results.len(), 1);
+    /// # });
+    /// ```
+    pub fn with_limit(&mut self, limit: usize) -> &mut KeysQuery {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Get [Key]'s.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeysQuery, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let mut keys = KeysQuery::new()
+    ///   .with_limit(1)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(keys.results.len(), 1);
+    /// # });
+    /// ```
+    pub async fn execute(&self, client: &Client) -> Result<KeysResults, Error> {
+        client.get_keys_with(self).await
     }
 }
 
@@ -251,42 +398,41 @@ impl AsRef<Key> for Key {
 /// #
 /// # futures::executor::block_on(async move {
 /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+/// let description = "My little lovely test key".to_string();
+/// let key = KeyBuilder::new()
+///   .with_description(&description)
+///   .execute(&client).await.unwrap();
 ///
-/// let key = KeyBuilder::new("My little lovely test key")
-///   .with_action(Action::DocumentsAdd)
-///   .with_index("*")
-///   .create(&client).await.unwrap();
-///
-/// assert_eq!(key.description, "My little lovely test key");
+/// # assert_eq!(key.description, Some(description));
 /// # client.delete_key(key).await.unwrap();
 /// # });
 /// ```
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyBuilder {
     pub actions: Vec<Action>,
-    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     #[serde(with = "time::serde::rfc3339::option")]
     pub expires_at: Option<OffsetDateTime>,
     pub indexes: Vec<String>,
 }
 
 impl KeyBuilder {
-    /// Create a [KeyBuilder] with only a description.
+    /// Create a [KeyBuilder].
     ///
     /// # Example
     ///
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder};
-    /// let builder = KeyBuilder::new("My little lovely test key");
+    /// let builder = KeyBuilder::new();
     /// ```
-    pub fn new(description: impl AsRef<str>) -> KeyBuilder {
-        Self {
-            actions: Vec::new(),
-            description: description.as_ref().to_string(),
-            expires_at: None,
-            indexes: Vec::new(),
-        }
+    pub fn new() -> KeyBuilder {
+        Self::default()
     }
 
     /// Declare a set of actions the [Key] will be able to execute.
@@ -295,7 +441,7 @@ impl KeyBuilder {
     ///
     /// ```
     /// # use meilisearch_sdk::key::{KeyBuilder, Action};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
+    /// let mut builder = KeyBuilder::new();
     /// builder.with_actions(vec![Action::Search, Action::DocumentsAdd]);
     /// ```
     pub fn with_actions(&mut self, actions: impl IntoIterator<Item = Action>) -> &mut Self {
@@ -309,7 +455,7 @@ impl KeyBuilder {
     ///
     /// ```
     /// # use meilisearch_sdk::key::{KeyBuilder, Action};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
+    /// let mut builder = KeyBuilder::new();
     /// builder.with_action(Action::DocumentsAdd);
     /// ```
     pub fn with_action(&mut self, action: Action) -> &mut Self {
@@ -324,7 +470,7 @@ impl KeyBuilder {
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder};
     /// use time::{OffsetDateTime, Duration};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
+    /// let mut builder = KeyBuilder::new();
     /// // create a key that expires in two weeks from now
     /// builder.with_expires_at(OffsetDateTime::now_utc() + Duration::WEEK * 2);
     /// ```
@@ -338,9 +484,22 @@ impl KeyBuilder {
     /// # Example
     ///
     /// ```
-    /// # use meilisearch_sdk::{key::KeyBuilder};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
-    /// builder.with_indexes(vec!["test", "movies"]);
+    /// # use meilisearch_sdk::{key::KeyBuilder, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    /// let mut key = KeyBuilder::new()
+    ///   .with_indexes(vec!["test", "movies"])
+    ///   .execute(&client)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// assert_eq!(vec!["test", "movies"], key.indexes);
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
     /// ```
     pub fn with_indexes(
         &mut self,
@@ -359,11 +518,93 @@ impl KeyBuilder {
     ///
     /// ```
     /// # use meilisearch_sdk::{key::KeyBuilder};
-    /// let mut builder = KeyBuilder::new("My little lovely test key");
+    /// let mut builder = KeyBuilder::new();
     /// builder.with_index("test");
     /// ```
     pub fn with_index(&mut self, index: impl AsRef<str>) -> &mut Self {
         self.indexes.push(index.as_ref().to_string());
+        self
+    }
+
+    /// Add a description to the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let description = "My not so little lovely test key".to_string();
+    ///
+    ///  let mut key = KeyBuilder::new()
+    ///   .with_description(&description)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(key.description, Some(description));
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_description(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.description = Some(desc.as_ref().to_string());
+        self
+    }
+
+    /// Add a name to the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let name = "lovely key".to_string();
+    ///
+    ///  let mut key = KeyBuilder::new()
+    ///   .with_name(&name)
+    ///   .execute(&client).await.unwrap();
+    ///
+    /// # assert_eq!(key.name, Some(name));
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_name(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.name = Some(desc.as_ref().to_string());
+        self
+    }
+
+    /// Add an uid to the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{key::KeyBuilder, key::Action, client::Client};
+    /// #
+    /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
+    ///  let uid = "93bcd7fb-2196-4fd9-acb7-3fca8a96e78f".to_string();
+    ///
+    ///  let mut key = KeyBuilder::new()
+    ///   .with_uid(&uid)
+    ///   .execute(&client).await.unwrap();
+    ///  
+    ///
+    /// # assert_eq!(key.uid, uid);
+    /// # client.delete_key(key).await.unwrap();
+    /// # });
+    /// ```
+    pub fn with_uid(&mut self, desc: impl AsRef<str>) -> &mut Self {
+        self.uid = Some(desc.as_ref().to_string());
         self
     }
 
@@ -379,14 +620,16 @@ impl KeyBuilder {
     /// #
     /// # futures::executor::block_on(async move {
     /// let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    /// let key = KeyBuilder::new("My little lovely test key")
-    ///   .create(&client).await.unwrap();
+    /// let description = "My little lovely test key".to_string();
+    /// let key = KeyBuilder::new()
+    ///    .with_description(&description)
+    ///   .execute(&client).await.unwrap();
     ///
-    /// assert_eq!(key.description, "My little lovely test key");
+    /// # assert_eq!(key.description, Some(description));
     /// # client.delete_key(key).await.unwrap();
     /// # });
     /// ```
-    pub async fn create(&self, client: &Client) -> Result<Key, Error> {
+    pub async fn execute(&self, client: &Client) -> Result<Key, Error> {
         client.create_key(self).await
     }
 }
@@ -447,4 +690,23 @@ pub enum Action {
     /// Provides access to the [get Meilisearch version](https://docs.meilisearch.com/reference/api/version.md#get-version-of-meilisearch) endpoint.
     #[serde(rename = "version")]
     Version,
+    /// Provides access to the [get Key](https://docs.meilisearch.com/reference/api/keys.html#get-one-key) and [get Keys](https://docs.meilisearch.com/reference/api/keys.html#get-all-keys) endpoints.
+    #[serde(rename = "keys.get")]
+    KeyGet,
+    /// Provides access to the [create key](https://docs.meilisearch.com/reference/api/keys.html#create-a-key) endpoint.
+    #[serde(rename = "keys.create")]
+    KeyCreate,
+    /// Provides access to the [update key](https://docs.meilisearch.com/reference/api/keys.html#update-a-key) endpoint.
+    #[serde(rename = "keys.update")]
+    KeyUpdate,
+    /// Provides access to the [delete key](https://docs.meilisearch.com/reference/api/keys.html#delete-a-key) endpoint.
+    #[serde(rename = "keys.delete")]
+    KeyDelete,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KeysResults {
+    pub results: Vec<Key>,
+    pub limit: u32,
+    pub offset: u32,
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -329,7 +329,7 @@ impl KeysQuery {
     ///   .with_offset(1)
     ///   .execute(&client).await.unwrap();
     ///
-    /// # assert_eq!(keys.results.len(), 1);
+    /// # assert_eq!(keys.offset, 1);
     /// # });
     /// ```
     pub fn with_offset(&mut self, offset: usize) -> &mut KeysQuery {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@
 //!   ],
 //!   "offset": 0,
 //!   "limit": 20,
-//!   "nbHits": 1,
+//!   "estimatedTotalHits": 1,
 //!   "processingTimeMs": 0,
 //!   "query": "wonder"
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,8 @@
 
 /// Module containing the [client::Client] struct.
 pub mod client;
+/// Module representing the [documents] structures.
+pub mod documents;
 /// Module containing the [document::Document] trait.
 pub mod dumps;
 /// Module containing the [errors::Error] struct.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,11 @@ mod request;
 pub mod search;
 /// Module containing [settings::Settings].
 pub mod settings;
+/// Module representing the [task_info::TaskInfo]s.
+pub mod task_info;
 /// Module representing the [tasks::Task]s.
 pub mod tasks;
 /// Module that generates tenant tokens.
 mod tenant_tokens;
+/// Module containing utilies functions.
+mod utils;

--- a/src/search.rs
+++ b/src/search.rs
@@ -666,7 +666,6 @@ mod tests {
         query.with_highlight_post_tag(" ⊂(´• ω •`⊂)");
 
         let results: SearchResults<Document> = index.execute_query(&query).await?;
-        dbg!(&results);
         assert_eq!(
             &Document {
                 id: 2,
@@ -784,9 +783,10 @@ mod tests {
 
         for rules in search_rules {
             let token = allowed_client
-                .generate_tenant_token(rules, None, None)
+                .generate_tenant_token(key.uid.clone(), rules, None, None)
                 .expect("Cannot generate tenant token.");
-            let new_client = Client::new(meilisearch_host, token);
+
+            let new_client = Client::new(meilisearch_host, token.clone());
 
             let result: SearchResults<Document> = new_client
                 .index(index.uid.to_string())

--- a/src/search.rs
+++ b/src/search.rs
@@ -641,7 +641,7 @@ mod tests {
         assert_eq!(
             &Document {
                 id: 0,
-                value: "(ꈍᴗꈍ)consectetur adipiscing elit, sed do eiusmod(ꈍᴗꈍ)".to_string(),
+                value: "(ꈍᴗꈍ) sed do eiusmod tempor incididunt ut(ꈍᴗꈍ)".to_string(),
                 kind: "text".to_string(),
                 nested: Nested {
                     child: "first".to_string()

--- a/src/search.rs
+++ b/src/search.rs
@@ -734,10 +734,10 @@ mod tests {
         setup_test_index(&client, &index).await?;
 
         let meilisearch_host = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
-        let key = KeyBuilder::new("key for generate_tenant_token test")
+        let key = KeyBuilder::new()
             .with_action(Action::All)
             .with_index("*")
-            .create(&client)
+            .execute(&client)
             .await
             .unwrap();
         let allowed_client = Client::new(meilisearch_host, key.key);

--- a/src/search.rs
+++ b/src/search.rs
@@ -20,8 +20,8 @@ pub struct SearchResult<T> {
     #[serde(rename = "_formatted")]
     pub formatted_result: Option<Map<String, Value>>,
     /// The object that contains information about the matches.
-    #[serde(rename = "_matchesInfo")]
-    pub matches_info: Option<HashMap<String, Vec<MatchRange>>>,
+    #[serde(rename = "_matchesPosition")]
+    pub matches_position: Option<HashMap<String, Vec<MatchRange>>>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -35,13 +35,9 @@ pub struct SearchResults<T> {
     /// Number of results returned
     pub limit: usize,
     /// Total number of matches
-    pub nb_hits: usize,
-    /// Whether nb_hits is exhaustive
-    pub exhaustive_nb_hits: bool,
+    pub estimated_total_hits: usize,
     /// Distribution of the given facets
-    pub facets_distribution: Option<HashMap<String, HashMap<String, usize>>>,
-    /// Whether facet_distribution is exhaustive
-    pub exhaustive_facets_count: Option<bool>,
+    pub facet_distribution: Option<HashMap<String, HashMap<String, usize>>>,
     /// Processing time of the query
     pub processing_time_ms: usize,
     /// Query originating the response
@@ -101,19 +97,40 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 /// # Examples
 ///
 /// ```
+/// use serde::{Serialize, Deserialize};
 /// # use meilisearch_sdk::{client::Client, search::Query, indexes::Index};
 /// #
 /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
+/// #[derive(Serialize, Deserialize, Debug)]
+/// struct Movie {
+///     name: String,
+///     description: String,
+/// }
+///
+/// # futures::executor::block_on(async move {
 /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-/// # let index = client.index("does not matter");
-/// let query = Query::new(&index)
+/// # let index = client
+/// #  .create_index("search_query_builder", None)
+/// #  .await
+/// #  .unwrap()
+/// #  .wait_for_completion(&client, None, None)
+/// #  .await.unwrap()
+/// #  .try_make_index(&client)
+/// #  .unwrap();
+///
+/// let mut res = Query::new(&index)
 ///     .with_query("space")
 ///     .with_offset(42)
 ///     .with_limit(21)
+///     .execute::<Movie>()
+///     .await
+///     .unwrap();
 ///
-/// let res = query.execute().await?.unwrap();
+/// assert_eq!(res.limit, 21);
+/// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+/// # });
 /// ```
 ///
 /// ```
@@ -123,7 +140,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
 /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-/// # let index = client.index("does not matter");
+/// # let index = client.index("search_query_builder_build");
 /// let query = index.search()
 ///     .with_query("space")
 ///     .with_offset(42)
@@ -164,7 +181,7 @@ pub struct Query<'a> {
     /// Default: all attributes found in the documents.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(serialize_with = "serialize_with_wildcard")]
-    pub facets_distribution: Option<Selectors<&'a [&'a str]>>,
+    pub facets: Option<Selectors<&'a [&'a str]>>,
     /// Attributes to sort.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<&'a [&'a str]>,
@@ -216,7 +233,7 @@ pub struct Query<'a> {
     ///
     /// Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub matches: Option<bool>,
+    pub show_matches_position: Option<bool>,
 }
 
 #[allow(missing_docs)]
@@ -229,7 +246,7 @@ impl<'a> Query<'a> {
             limit: None,
             filter: None,
             sort: None,
-            facets_distribution: None,
+            facets: None,
             attributes_to_retrieve: None,
             attributes_to_crop: None,
             crop_length: None,
@@ -237,13 +254,14 @@ impl<'a> Query<'a> {
             attributes_to_highlight: None,
             highlight_pre_tag: None,
             highlight_post_tag: None,
-            matches: None,
+            show_matches_position: None,
         }
     }
     pub fn with_query<'b>(&'b mut self, query: &'a str) -> &'b mut Query<'a> {
         self.query = Some(query);
         self
     }
+
     pub fn with_offset<'b>(&'b mut self, offset: usize) -> &'b mut Query<'a> {
         self.offset = Some(offset);
         self
@@ -256,11 +274,8 @@ impl<'a> Query<'a> {
         self.filter = Some(filter);
         self
     }
-    pub fn with_facets_distribution<'b>(
-        &'b mut self,
-        facets_distribution: Selectors<&'a [&'a str]>,
-    ) -> &'b mut Query<'a> {
-        self.facets_distribution = Some(facets_distribution);
+    pub fn with_facets<'b>(&'b mut self, facets: Selectors<&'a [&'a str]>) -> &'b mut Query<'a> {
+        self.facets = Some(facets);
         self
     }
     pub fn with_sort<'b>(&'b mut self, sort: &'a [&'a str]) -> &'b mut Query<'a> {
@@ -310,8 +325,11 @@ impl<'a> Query<'a> {
         self.highlight_post_tag = Some(highlight_post_tag);
         self
     }
-    pub fn with_matches<'b>(&'b mut self, matches: bool) -> &'b mut Query<'a> {
-        self.matches = Some(matches);
+    pub fn with_show_matches_position<'b>(
+        &'b mut self,
+        show_matches_position: bool,
+    ) -> &'b mut Query<'a> {
+        self.show_matches_position = Some(show_matches_position);
         self
     }
     pub fn build(&mut self) -> Query<'a> {
@@ -374,6 +392,19 @@ mod tests {
         t1.wait_for_completion(client, None, None).await?;
         t0.wait_for_completion(client, None, None).await?;
 
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_query_builder(_client: Client, index: Index) -> Result<(), Error> {
+        let mut query = Query::new(&index);
+        query.with_query("space").with_offset(42).with_limit(21);
+
+        let res = query.execute::<Document>().await.unwrap();
+
+        assert_eq!(res.query, "space".to_string());
+        assert_eq!(res.limit, 21);
+        assert_eq!(res.offset, 42);
         Ok(())
     }
 
@@ -451,11 +482,11 @@ mod tests {
         setup_test_index(&client, &index).await?;
 
         let mut query = Query::new(&index);
-        query.with_facets_distribution(Selectors::All);
+        query.with_facets(Selectors::All);
         let results: SearchResults<Document> = index.execute_query(&query).await?;
         assert_eq!(
             results
-                .facets_distribution
+                .facet_distribution
                 .unwrap()
                 .get("kind")
                 .unwrap()
@@ -465,11 +496,11 @@ mod tests {
         );
 
         let mut query = Query::new(&index);
-        query.with_facets_distribution(Selectors::Some(&["kind"]));
+        query.with_facets(Selectors::Some(&["kind"]));
         let results: SearchResults<Document> = index.execute_query(&query).await?;
         assert_eq!(
             results
-                .facets_distribution
+                .facet_distribution
                 .clone()
                 .unwrap()
                 .get("kind")
@@ -480,7 +511,7 @@ mod tests {
         );
         assert_eq!(
             results
-                .facets_distribution
+                .facet_distribution
                 .unwrap()
                 .get("kind")
                 .unwrap()
@@ -690,17 +721,17 @@ mod tests {
     }
 
     #[meilisearch_test]
-    async fn test_query_matches(client: Client, index: Index) -> Result<(), Error> {
+    async fn test_query_show_matches_position(client: Client, index: Index) -> Result<(), Error> {
         setup_test_index(&client, &index).await?;
 
         let mut query = Query::new(&index);
         query.with_query("dolor text");
-        query.with_matches(true);
+        query.with_show_matches_position(true);
         let results: SearchResults<Document> = index.execute_query(&query).await?;
-        assert_eq!(results.hits[0].matches_info.as_ref().unwrap().len(), 2);
+        assert_eq!(results.hits[0].matches_position.as_ref().unwrap().len(), 2);
         assert_eq!(
             results.hits[0]
-                .matches_info
+                .matches_position
                 .as_ref()
                 .unwrap()
                 .get("value")
@@ -720,6 +751,7 @@ mod tests {
         let mut query = Query::new(&index);
         query.with_query("harry \"of Fire\"");
         let results: SearchResults<Document> = index.execute_query(&query).await?;
+
         assert_eq!(results.hits.len(), 1);
         Ok(())
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize, Serializer};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct MatchRange {
     pub start: usize,
     pub length: usize,

--- a/src/search.rs
+++ b/src/search.rs
@@ -112,7 +112,8 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///     .with_query("space")
 ///     .with_offset(42)
 ///     .with_limit(21)
-///     .build(); // you can also execute() instead of build()
+///
+/// let res = query.execute().await?.unwrap();
 /// ```
 ///
 /// ```

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -482,7 +482,7 @@ impl Index {
         request::<&Settings, TaskInfo>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
-            Method::Post(settings),
+            Method::Patch(settings),
             202,
         )
         .await
@@ -522,7 +522,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(synonyms),
+            Method::Put(synonyms),
             202,
         )
         .await
@@ -558,7 +558,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Put(
                 stop_words
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -608,7 +608,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Put(
                 ranking_rules
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -649,7 +649,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Put(
                 filterable_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -690,7 +690,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Put(
                 sortable_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -730,7 +730,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(distinct_attribute.as_ref().to_string()),
+            Method::Put(distinct_attribute.as_ref().to_string()),
             202,
         )
         .await
@@ -765,7 +765,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Put(
                 searchable_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())
@@ -805,7 +805,7 @@ impl Index {
                 self.client.host, self.uid
             ),
             &self.client.api_key,
-            Method::Post(
+            Method::Put(
                 displayed_attributes
                     .into_iter()
                     .map(|v| v.as_ref().to_string())

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::Error,
     indexes::Index,
     request::{request, Method},
-    tasks::Task,
+    task_info::TaskInfo,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -478,8 +478,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn set_settings(&self, settings: &Settings) -> Result<Task, Error> {
-        request::<&Settings, Task>(
+    pub async fn set_settings(&self, settings: &Settings) -> Result<TaskInfo, Error> {
+        request::<&Settings, TaskInfo>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
             Method::Post(settings),
@@ -515,8 +515,8 @@ impl Index {
     pub async fn set_synonyms(
         &self,
         synonyms: &HashMap<String, Vec<String>>,
-    ) -> Result<Task, Error> {
-        request::<&HashMap<String, Vec<String>>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<&HashMap<String, Vec<String>>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
@@ -551,8 +551,8 @@ impl Index {
     pub async fn set_stop_words(
         &self,
         stop_words: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
@@ -601,8 +601,8 @@ impl Index {
     pub async fn set_ranking_rules(
         &self,
         ranking_rules: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
@@ -642,8 +642,8 @@ impl Index {
     pub async fn set_filterable_attributes(
         &self,
         filterable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
@@ -683,8 +683,8 @@ impl Index {
     pub async fn set_sortable_attributes(
         &self,
         sortable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
@@ -723,8 +723,8 @@ impl Index {
     pub async fn set_distinct_attribute(
         &self,
         distinct_attribute: impl AsRef<str>,
-    ) -> Result<Task, Error> {
-        request::<String, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<String, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
@@ -758,8 +758,8 @@ impl Index {
     pub async fn set_searchable_attributes(
         &self,
         searchable_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
@@ -798,8 +798,8 @@ impl Index {
     pub async fn set_displayed_attributes(
         &self,
         displayed_attributes: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<Task, Error> {
-        request::<Vec<String>, Task>(
+    ) -> Result<TaskInfo, Error> {
+        request::<Vec<String>, TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
@@ -836,8 +836,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_settings(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_settings(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
             &self.client.api_key,
             Method::Delete,
@@ -865,8 +865,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_synonyms(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_synonyms(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
@@ -897,8 +897,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_stop_words(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_stop_words(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
@@ -930,8 +930,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_ranking_rules(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_ranking_rules(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
@@ -962,8 +962,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_filterable_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_filterable_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
@@ -994,8 +994,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_sortable_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_sortable_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
@@ -1026,8 +1026,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_distinct_attribute(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_distinct_attribute(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
@@ -1058,8 +1058,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_searchable_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_searchable_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
@@ -1090,8 +1090,8 @@ impl Index {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
-    pub async fn reset_displayed_attributes(&self) -> Result<Task, Error> {
-        request::<(), Task>(
+    pub async fn reset_displayed_attributes(&self) -> Result<TaskInfo, Error> {
+        request::<(), TaskInfo>(
             &format!(
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -164,7 +164,6 @@ mod test {
     }
 
     #[meilisearch_test]
-    // TODO: failing because settings routes now uses PUT instead of POST as http method
     async fn test_failing_task(client: Client, movies: Index) -> Result<(), Error> {
         let task_info = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
         let task = client.wait_for_task(task_info, None, None).await?;

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -1,0 +1,177 @@
+use serde::Deserialize;
+use std::time::Duration;
+use time::OffsetDateTime;
+
+use crate::{client::Client, errors::Error, tasks::*};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskInfo {
+    #[serde(with = "time::serde::rfc3339")]
+    pub enqueued_at: OffsetDateTime,
+    pub index_uid: Option<String>,
+    pub status: String,
+    #[serde(flatten)]
+    pub update_type: TaskType,
+    pub task_uid: u32,
+}
+
+impl AsRef<u32> for TaskInfo {
+    fn as_ref(&self) -> &u32 {
+        &self.task_uid
+    }
+}
+
+impl TaskInfo {
+    pub fn get_task_uid(&self) -> u32 {
+        self.task_uid
+    }
+
+    /// Wait until Meilisearch processes a task provided by [TaskInfo], and get its status.
+    ///
+    /// `interval` = The frequency at which the server should be polled. Default = 50ms
+    /// `timeout` = The maximum time to wait for processing to complete. Default = 5000ms
+    ///
+    /// If the waited time exceeds `timeout` then an [Error::Timeout] will be returned.
+    ///
+    /// See also [Client::wait_for_task, Index::wait_for_task].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, tasks::Task, task_info::TaskInfo};
+    /// # use serde::{Serialize, Deserialize};
+    /// #
+    /// # #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// # struct Document {
+    /// #    id: usize,
+    /// #    value: String,
+    /// #    kind: String,
+    /// # }
+    /// #
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let movies = client.index("movies_wait_for_completion");
+    ///
+    /// let status = movies.add_documents(&[
+    ///     Document { id: 0, kind: "title".into(), value: "The Social Network".to_string() },
+    ///     Document { id: 1, kind: "title".into(), value: "Harry Potter and the Sorcerer's Stone".to_string() },
+    /// ], None)
+    ///   .await
+    ///   .unwrap()
+    ///   .wait_for_completion(&client, None, None)
+    ///   .await
+    ///   .unwrap();
+    ///
+    /// assert!(matches!(status, Task::Succeeded { .. }));
+    /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn wait_for_completion(
+        self,
+        client: &Client,
+        interval: Option<Duration>,
+        timeout: Option<Duration>,
+    ) -> Result<Task, Error> {
+        client.wait_for_task(self, interval, timeout).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        client::*,
+        errors::{ErrorCode, ErrorType},
+        indexes::Index,
+    };
+    use meilisearch_test_macro::meilisearch_test;
+    use serde::{Deserialize, Serialize};
+    use std::time::Duration;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Document {
+        id: usize,
+        value: String,
+        kind: String,
+    }
+
+    #[test]
+    fn test_deserialize_task_info() {
+        let datetime = OffsetDateTime::parse(
+            "2022-02-03T13:02:38.369634Z",
+            &::time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+
+        let task_info: TaskInfo = serde_json::from_str(
+            r#"
+{
+  "enqueuedAt": "2022-02-03T13:02:38.369634Z",
+  "indexUid": "mieli",
+  "status": "enqueued",
+  "type": "documentAdditionOrUpdate",
+  "taskUid": 12
+}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            task_info,
+            TaskInfo {
+                enqueued_at,
+                index_uid: Some(index_uid),
+                task_uid: 12,
+                update_type: TaskType::DocumentAdditionOrUpdate { details: None },
+                status,
+            }
+        if enqueued_at == datetime && index_uid == "mieli" && status == "enqueued"));
+    }
+
+    #[meilisearch_test]
+    async fn test_wait_for_task_with_args(client: Client, movies: Index) -> Result<(), Error> {
+        let task_info = movies
+            .add_documents(
+                &[
+                    Document {
+                        id: 0,
+                        kind: "title".into(),
+                        value: "The Social Network".to_string(),
+                    },
+                    Document {
+                        id: 1,
+                        kind: "title".into(),
+                        value: "Harry Potter and the Sorcerer's Stone".to_string(),
+                    },
+                ],
+                None,
+            )
+            .await?;
+
+        let task = client
+            .get_task(task_info)
+            .await?
+            .wait_for_completion(
+                &client,
+                Some(Duration::from_millis(1)),
+                Some(Duration::from_millis(6000)),
+            )
+            .await?;
+
+        assert!(matches!(task, Task::Succeeded { .. }));
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    // TODO: failing because settings routes now uses PUT instead of POST as http method
+    async fn test_failing_task(client: Client, movies: Index) -> Result<(), Error> {
+        let task_info = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
+        let task = client.wait_for_task(task_info, None, None).await?;
+
+        let error = task.unwrap_failure();
+        assert_eq!(error.error_code, ErrorCode::InvalidRankingRule);
+        assert_eq!(error.error_type, ErrorType::InvalidRequest);
+        Ok(())
+    }
+}

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -28,6 +28,9 @@ pub enum TaskType {
     SettingsUpdate {
         details: Option<Settings>,
     },
+    DumpCreation {
+        details: Option<DumpCreation>,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -67,6 +70,12 @@ pub struct IndexUpdate {
 #[serde(rename_all = "camelCase")]
 pub struct IndexDeletion {
     pub deleted_documents: Option<usize>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DumpCreation {
+    pub dump_uid: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -694,7 +694,6 @@ mod test {
     }
 
     #[meilisearch_test]
-    // TODO: failing because settings routes now uses PUT instead of POST as http method
     async fn test_failing_task(client: Client, movies: Index) -> Result<(), Error> {
         let task_info = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -279,7 +279,6 @@ impl Task {
     /// # let task = client.create_index("unwrap_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
-    /// // TODO: fails until http method are implemented
     /// let task = index.set_ranking_rules(["wrong_ranking_rule"])
     ///   .await
     ///   .unwrap()

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::time::Duration;
 use time::OffsetDateTime;
 
@@ -9,20 +9,38 @@ use crate::{
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum TaskType {
-    ClearAll,
     Customs,
-    DocumentAddition { details: Option<DocumentAddition> },
-    DocumentPartial { details: Option<DocumentAddition> },
-    DocumentDeletion { details: Option<DocumentDeletion> },
-    IndexCreation { details: Option<IndexCreation> },
-    IndexUpdate { details: Option<IndexUpdate> },
-    IndexDeletion { details: Option<IndexDeletion> },
-    SettingsUpdate { details: Option<Settings> },
+    DocumentAdditionOrUpdate {
+        details: Option<DocumentAdditionOrUpdate>,
+    },
+    DocumentDeletion {
+        details: Option<DocumentDeletion>,
+    },
+    IndexCreation {
+        details: Option<IndexCreation>,
+    },
+    IndexUpdate {
+        details: Option<IndexUpdate>,
+    },
+    IndexDeletion {
+        details: Option<IndexDeletion>,
+    },
+    SettingsUpdate {
+        details: Option<Settings>,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TasksResults {
+    pub results: Vec<Task>,
+    pub limit: u32,
+    pub from: Option<u32>,
+    pub next: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DocumentAddition {
+pub struct DocumentAdditionOrUpdate {
     pub indexed_documents: Option<usize>,
     pub received_documents: usize,
 }
@@ -56,11 +74,11 @@ pub struct IndexDeletion {
 pub struct FailedTask {
     pub error: MeilisearchError,
     #[serde(flatten)]
-    pub task: ProcessedTask,
+    pub task: SucceededTask,
 }
 
-impl AsRef<u64> for FailedTask {
-    fn as_ref(&self) -> &u64 {
+impl AsRef<u32> for FailedTask {
+    fn as_ref(&self) -> &u32 {
         &self.task.uid
     }
 }
@@ -76,7 +94,7 @@ where
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ProcessedTask {
+pub struct SucceededTask {
     #[serde(deserialize_with = "deserialize_duration")]
     pub duration: Duration,
     #[serde(with = "time::serde::rfc3339")]
@@ -85,14 +103,14 @@ pub struct ProcessedTask {
     pub started_at: OffsetDateTime,
     #[serde(with = "time::serde::rfc3339")]
     pub finished_at: OffsetDateTime,
-    pub index_uid: String,
+    pub index_uid: Option<String>,
     #[serde(flatten)]
     pub update_type: TaskType,
-    pub uid: u64,
+    pub uid: u32,
 }
 
-impl AsRef<u64> for ProcessedTask {
-    fn as_ref(&self) -> &u64 {
+impl AsRef<u32> for SucceededTask {
+    fn as_ref(&self) -> &u32 {
         &self.uid
     }
 }
@@ -102,14 +120,14 @@ impl AsRef<u64> for ProcessedTask {
 pub struct EnqueuedTask {
     #[serde(with = "time::serde::rfc3339")]
     pub enqueued_at: OffsetDateTime,
-    pub index_uid: String,
+    pub index_uid: Option<String>,
     #[serde(flatten)]
     pub update_type: TaskType,
-    pub uid: u64,
+    pub uid: u32,
 }
 
-impl AsRef<u64> for EnqueuedTask {
-    fn as_ref(&self) -> &u64 {
+impl AsRef<u32> for EnqueuedTask {
+    fn as_ref(&self) -> &u32 {
         &self.uid
     }
 }
@@ -131,12 +149,12 @@ pub enum Task {
     },
     Succeeded {
         #[serde(flatten)]
-        content: ProcessedTask,
+        content: SucceededTask,
     },
 }
 
 impl Task {
-    pub fn get_uid(&self) -> u64 {
+    pub fn get_uid(&self) -> u32 {
         match self {
             Self::Enqueued { content } | Self::Processing { content } => *content.as_ref(),
             Self::Failed { content } => *content.as_ref(),
@@ -225,12 +243,12 @@ impl Task {
         match self {
             Self::Succeeded {
                 content:
-                    ProcessedTask {
+                    SucceededTask {
                         index_uid,
                         update_type: TaskType::IndexCreation { .. },
                         ..
                     },
-            } => Ok(client.index(index_uid)),
+            } => Ok(client.index(index_uid.unwrap())),
             _ => Err(self),
         }
     }
@@ -252,7 +270,7 @@ impl Task {
     /// # let task = client.create_index("unwrap_failure", None).await.unwrap();
     /// # let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
-    ///
+    /// // TODO: fails until http method are implemented
     /// let task = index.set_ranking_rules(["wrong_ranking_rule"])
     ///   .await
     ///   .unwrap()
@@ -303,6 +321,7 @@ impl Task {
     /// assert!(task.is_failure());
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
+    /// ```
     pub fn is_failure(&self) -> bool {
         matches!(self, Self::Failed { .. })
     }
@@ -330,6 +349,7 @@ impl Task {
     /// assert!(task.is_success());
     /// # task.try_make_index(&client).unwrap().delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
+    /// ```
     pub fn is_success(&self) -> bool {
         matches!(self, Self::Succeeded { .. })
     }
@@ -337,8 +357,9 @@ impl Task {
     /// Returns `true` if the [Task] is pending ([Self::Enqueued] or [Self::Processing]).
     ///
     /// # Example
-    ///
-    /// ```
+    /// ```no_run
+    /// # // The test is not run because it checks for an enqueued or processed status
+    /// # // and the task might already be processed when checking the status after the get_task call
     /// # use meilisearch_sdk::{client::*, indexes::*, errors::ErrorCode};
     /// #
     /// # let MEILISEARCH_HOST = option_env!("MEILISEARCH_HOST").unwrap_or("http://localhost:7700");
@@ -346,21 +367,22 @@ impl Task {
     /// #
     /// # futures::executor::block_on(async move {
     /// # let client = Client::new(MEILISEARCH_HOST, MEILISEARCH_API_KEY);
-    /// let task = client
+    /// let task_info = client
     ///   .create_index("is_pending", None)
     ///   .await
     ///   .unwrap();
-    ///
+    /// let task = client.get_task(task_info).await.unwrap();
     /// assert!(task.is_pending());
     /// # task.wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap().delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
+    /// ```
     pub fn is_pending(&self) -> bool {
         matches!(self, Self::Enqueued { .. } | Self::Processing { .. })
     }
 }
 
-impl AsRef<u64> for Task {
-    fn as_ref(&self) -> &u64 {
+impl AsRef<u32> for Task {
+    fn as_ref(&self) -> &u32 {
         match self {
             Self::Enqueued { content } | Self::Processing { content } => content.as_ref(),
             Self::Succeeded { content } => content.as_ref(),
@@ -369,32 +391,73 @@ impl AsRef<u64> for Task {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) async fn async_sleep(interval: Duration) {
-    let (sender, receiver) = futures::channel::oneshot::channel::<()>();
-    std::thread::spawn(move || {
-        std::thread::sleep(interval);
-        let _ = sender.send(());
-    });
-    let _ = receiver.await;
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TasksQuery<'a> {
+    #[serde(skip_serializing)]
+    pub client: &'a Client,
+    // Index uids array to only retrieve the tasks of the indexes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_uid: Option<Vec<&'a str>>,
+    // Statuses array to only retrieve the tasks with these statuses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<Vec<&'a str>>,
+    // Types array to only retrieve the tasks with these [TaskType].
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    pub task_type: Option<Vec<&'a str>>,
+    // Maximum number of tasks to return
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    // The first task uid that should be returned
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<u32>,
 }
 
-#[cfg(target_arch = "wasm32")]
-pub(crate) async fn async_sleep(interval: Duration) {
-    use std::convert::TryInto;
-    use wasm_bindgen_futures::JsFuture;
+#[allow(missing_docs)]
+impl<'a> TasksQuery<'a> {
+    pub fn new(client: &'a Client) -> TasksQuery<'a> {
+        TasksQuery {
+            client,
+            index_uid: None,
+            status: None,
+            task_type: None,
+            limit: None,
+            from: None,
+        }
+    }
+    pub fn with_index_uid<'b>(
+        &'b mut self,
+        index_uid: impl IntoIterator<Item = &'a str>,
+    ) -> &'b mut TasksQuery<'a> {
+        self.index_uid = Some(index_uid.into_iter().collect());
+        self
+    }
+    pub fn with_status<'b>(
+        &'b mut self,
+        status: impl IntoIterator<Item = &'a str>,
+    ) -> &'b mut TasksQuery<'a> {
+        self.status = Some(status.into_iter().collect());
+        self
+    }
+    pub fn with_type<'b>(
+        &'b mut self,
+        task_type: impl IntoIterator<Item = &'a str>,
+    ) -> &'b mut TasksQuery<'a> {
+        self.task_type = Some(task_type.into_iter().collect());
+        self
+    }
+    pub fn with_limit<'b>(&'b mut self, limit: u32) -> &'b mut TasksQuery<'a> {
+        self.limit = Some(limit);
+        self
+    }
+    pub fn with_from<'b>(&'b mut self, from: u32) -> &'b mut TasksQuery<'a> {
+        self.from = Some(from);
+        self
+    }
 
-    JsFuture::from(js_sys::Promise::new(&mut |yes, _| {
-        web_sys::window()
-            .unwrap()
-            .set_timeout_with_callback_and_timeout_and_arguments_0(
-                &yes,
-                interval.as_millis().try_into().unwrap(),
-            )
-            .unwrap();
-    }))
-    .await
-    .unwrap();
+    pub async fn execute(&'a self) -> Result<TasksResults, Error> {
+        self.client.get_tasks_with(self).await
+    }
 }
 
 #[cfg(test)]
@@ -405,8 +468,9 @@ mod test {
         errors::{ErrorCode, ErrorType},
     };
     use meilisearch_test_macro::meilisearch_test;
+    use mockito::mock;
     use serde::{Deserialize, Serialize};
-    use std::time::{self, Duration};
+    use std::time::Duration;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Document {
@@ -429,7 +493,7 @@ mod test {
   "enqueuedAt": "2022-02-03T13:02:38.369634Z",
   "indexUid": "mieli",
   "status": "enqueued",
-  "type": "documentAddition",
+  "type": "documentAdditionOrUpdate",
   "uid": 12
 }"#,
         )
@@ -440,8 +504,8 @@ mod test {
             Task::Enqueued {
                 content: EnqueuedTask {
                     enqueued_at,
-                    index_uid,
-                    update_type: TaskType::DocumentAddition { details: None },
+                    index_uid: Some(index_uid),
+                    update_type: TaskType::DocumentAdditionOrUpdate { details: None },
                     uid: 12,
                 }
             }
@@ -460,7 +524,7 @@ mod test {
   "indexUid": "mieli",
   "startedAt": "2022-02-03T15:17:02.812338Z",
   "status": "processing",
-  "type": "documentAddition",
+  "type": "documentAdditionOrUpdate",
   "uid": 14
 }"#,
         )
@@ -470,8 +534,8 @@ mod test {
             task,
             Task::Processing {
                 content: EnqueuedTask {
-                    update_type: TaskType::DocumentAddition {
-                        details: Some(DocumentAddition {
+                    update_type: TaskType::DocumentAdditionOrUpdate {
+                        details: Some(DocumentAdditionOrUpdate {
                             received_documents: 19547,
                             indexed_documents: None,
                         })
@@ -495,7 +559,7 @@ mod test {
   "indexUid": "mieli",
   "startedAt": "2022-02-03T15:17:02.812338Z",
   "status": "succeeded",
-  "type": "documentAddition",
+  "type": "documentAdditionOrUpdate",
   "uid": 14
 }"#,
         )
@@ -504,9 +568,9 @@ mod test {
         assert!(matches!(
             task,
             Task::Succeeded {
-                content: ProcessedTask {
-                    update_type: TaskType::DocumentAddition {
-                        details: Some(DocumentAddition {
+                content: SucceededTask {
+                    update_type: TaskType::DocumentAdditionOrUpdate {
+                        details: Some(DocumentAdditionOrUpdate {
                             received_documents: 19547,
                             indexed_documents: Some(19546),
                         })
@@ -521,11 +585,8 @@ mod test {
     }
 
     #[meilisearch_test]
-    async fn test_wait_for_pending_updates_with_args(
-        client: Client,
-        movies: Index,
-    ) -> Result<(), Error> {
-        let status = movies
+    async fn test_wait_for_task_with_args(client: Client, movies: Index) -> Result<(), Error> {
+        let task = movies
             .add_documents(
                 &[
                     Document {
@@ -549,62 +610,98 @@ mod test {
             )
             .await?;
 
-        assert!(matches!(status, Task::Succeeded { .. }));
+        assert!(matches!(task, Task::Succeeded { .. }));
         Ok(())
     }
 
     #[meilisearch_test]
-    async fn test_wait_for_pending_updates_time_out(
-        client: Client,
-        movies: Index,
-    ) -> Result<(), Error> {
-        let task = movies
-            .add_documents(
-                &[
-                    Document {
-                        id: 0,
-                        kind: "title".into(),
-                        value: "The Social Network".to_string(),
-                    },
-                    Document {
-                        id: 1,
-                        kind: "title".into(),
-                        value: "Harry Potter and the Sorcerer's Stone".to_string(),
-                    },
-                ],
-                None,
-            )
-            .await?;
+    async fn test_get_tasks_no_params() -> Result<(), Error> {
+        let mock_server_url = &mockito::server_url();
+        let client = Client::new(mock_server_url, "masterKey");
+        let path = "/tasks";
 
-        let error = client
-            .wait_for_task(
-                task,
-                Some(Duration::from_millis(1)),
-                Some(Duration::from_nanos(1)),
-            )
+        let mock_res = mock("GET", path).with_status(200).create();
+        let _ = client.get_tasks().await;
+        mock_res.assert();
+
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_get_tasks_with_params() -> Result<(), Error> {
+        let mock_server_url = &mockito::server_url();
+        let client = Client::new(mock_server_url, "masterKey");
+        let path =
+            "/tasks?indexUid=movies,test&status=equeued&type=documentDeletion&limit=0&from=1";
+
+        let mock_res = mock("GET", path).with_status(200).create();
+
+        let mut query = TasksQuery::new(&client);
+        query
+            .with_index_uid(["movies", "test"])
+            .with_status(["equeued"])
+            .with_type(["documentDeletion"])
+            .with_from(1)
+            .with_limit(0);
+
+        let _ = client.get_tasks_with(&query).await;
+
+        mock_res.assert();
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_get_tasks_on_struct_with_params() -> Result<(), Error> {
+        let mock_server_url = &mockito::server_url();
+        let client = Client::new(mock_server_url, "masterKey");
+        let path = "/tasks?indexUid=movies,test&status=equeued&type=documentDeletion";
+
+        let mock_res = mock("GET", path).with_status(200).create();
+
+        let mut query = TasksQuery::new(&client);
+        let _ = query
+            .with_index_uid(["movies", "test"])
+            .with_status(["equeued"])
+            .with_type(["documentDeletion"])
+            .execute()
+            .await;
+
+        // let _ = client.get_tasks(&query).await;
+        mock_res.assert();
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_get_tasks_with_none_existant_index_uid(client: Client) -> Result<(), Error> {
+        let mut query = TasksQuery::new(&client);
+        query.with_index_uid(["no_name"]);
+        let tasks = client.get_tasks_with(&query).await.unwrap();
+
+        assert_eq!(tasks.results.len(), 0);
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_get_tasks_with_execute(client: Client) -> Result<(), Error> {
+        let tasks = TasksQuery::new(&client)
+            .with_index_uid(["no_name"])
+            .execute()
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(matches!(error, Error::Timeout));
+        assert_eq!(tasks.results.len(), 0);
         Ok(())
     }
 
     #[meilisearch_test]
-    async fn test_async_sleep() {
-        let sleep_duration = time::Duration::from_millis(10);
-        let now = time::Instant::now();
+    // TODO: failing because settings routes now uses PUT instead of POST as http method
+    async fn test_failing_task(client: Client, movies: Index) -> Result<(), Error> {
+        let task_info = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
 
-        async_sleep(sleep_duration).await;
+        let task = client.get_task(task_info).await?;
+        let task = client.wait_for_task(task, None, None).await?;
 
-        assert!(now.elapsed() >= sleep_duration);
-    }
-
-    #[meilisearch_test]
-    async fn test_failing_update(client: Client, movies: Index) -> Result<(), Error> {
-        let task = movies.set_ranking_rules(["wrong_ranking_rule"]).await?;
-        let status = client.wait_for_task(task, None, None).await?;
-
-        let error = status.unwrap_failure();
+        let error = task.unwrap_failure();
         assert_eq!(error.error_code, ErrorCode::InvalidRankingRule);
         assert_eq!(error.error_type, ErrorType::InvalidRequest);
         Ok(())

--- a/src/tenant_tokens.rs
+++ b/src/tenant_tokens.rs
@@ -1,34 +1,41 @@
-use crate::{
-    errors::* 
-};
-use serde::{Serialize, Deserialize};
-use jsonwebtoken::{encode, Header, EncodingKey};
-use time::{OffsetDateTime};
+use crate::errors::*;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use time::OffsetDateTime;
+use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")] 
+#[serde(rename_all = "camelCase")]
 struct TenantTokenClaim {
-    api_key_prefix: String,
+    api_key_uid: String,
     search_rules: Value,
     #[serde(with = "time::serde::timestamp::option")]
     exp: Option<OffsetDateTime>,
 }
 
-pub fn generate_tenant_token(search_rules: Value, api_key: impl AsRef<str>, expires_at: Option<OffsetDateTime>) -> Result<String, Error> {
-    if api_key.as_ref().chars().count() < 8 {
-        return Err(Error::TenantTokensInvalidApiKey)
+pub fn generate_tenant_token(
+    api_key_uid: String,
+    search_rules: Value,
+    api_key: impl AsRef<str>,
+    expires_at: Option<OffsetDateTime>,
+) -> Result<String, Error> {
+    // Validate uuid format
+    let uid = Uuid::try_parse(&api_key_uid)?;
+
+    // Validate uuid version
+    if uid.get_version_num() != 4 {
+        return Err(Error::InvalidUuid4Version);
     }
 
     if expires_at.map_or(false, |expires_at| OffsetDateTime::now_utc() > expires_at) {
-        return Err(Error::TenantTokensExpiredSignature)
+        return Err(Error::TenantTokensExpiredSignature);
     }
 
-    let key_prefix = api_key.as_ref().chars().take(8).collect();
     let claims = TenantTokenClaim {
-        api_key_prefix: key_prefix,
+        api_key_uid,
         exp: expires_at,
-        search_rules
+        search_rules,
     };
 
     let token = encode(
@@ -42,9 +49,9 @@ pub fn generate_tenant_token(search_rules: Value, api_key: impl AsRef<str>, expi
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
     use crate::tenant_tokens::*;
-    use jsonwebtoken::{decode, DecodingKey, Validation, Algorithm};
+    use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+    use serde_json::json;
     use std::collections::HashSet;
 
     const SEARCH_RULES: [&str; 1] = ["*"];
@@ -60,13 +67,19 @@ mod tests {
 
     #[test]
     fn test_generate_token_with_given_key() {
-        let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, None).unwrap();
+        let api_key_uid = "76cf8b87-fd12-4688-ad34-260d930ca4f4".to_string();
+        let token =
+            generate_tenant_token(api_key_uid, json!(SEARCH_RULES), VALID_KEY, None).unwrap();
 
         let valid_key = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(VALID_KEY.as_ref()), &build_validation()
+            &token,
+            &DecodingKey::from_secret(VALID_KEY.as_ref()),
+            &build_validation(),
         );
         let invalid_key = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret("not-the-same-key".as_ref()), &build_validation()
+            &token,
+            &DecodingKey::from_secret("not-the-same-key".as_ref()),
+            &build_validation(),
         );
 
         assert!(valid_key.is_ok());
@@ -74,20 +87,25 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_token_without_key() {
+    fn test_generate_token_without_uid() {
+        let api_key_uid = "".to_string();
         let key = String::from("");
-        let token = generate_tenant_token(json!(SEARCH_RULES), &key, None);
+        let token = generate_tenant_token(api_key_uid, json!(SEARCH_RULES), &key, None);
 
         assert!(token.is_err());
     }
 
     #[test]
     fn test_generate_token_with_expiration() {
+        let api_key_uid = "76cf8b87-fd12-4688-ad34-260d930ca4f4".to_string();
         let exp = OffsetDateTime::now_utc() + time::Duration::HOUR;
-        let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, Some(exp)).unwrap();
+        let token =
+            generate_tenant_token(api_key_uid, json!(SEARCH_RULES), VALID_KEY, Some(exp)).unwrap();
 
         let decoded = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(VALID_KEY.as_ref()), &Validation::new(Algorithm::HS256)
+            &token,
+            &DecodingKey::from_secret(VALID_KEY.as_ref()),
+            &Validation::new(Algorithm::HS256),
         );
 
         assert!(decoded.is_ok());
@@ -95,33 +113,63 @@ mod tests {
 
     #[test]
     fn test_generate_token_with_expires_at_in_the_past() {
+        let api_key_uid = "76cf8b87-fd12-4688-ad34-260d930ca4f4".to_string();
         let exp = OffsetDateTime::now_utc() - time::Duration::HOUR;
-        let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, Some(exp));
+        let token = generate_tenant_token(api_key_uid, json!(SEARCH_RULES), VALID_KEY, Some(exp));
 
         assert!(token.is_err());
     }
 
     #[test]
     fn test_generate_token_contains_claims() {
-        let token = generate_tenant_token(json!(SEARCH_RULES), VALID_KEY, None).unwrap();
+        let api_key_uid = "76cf8b87-fd12-4688-ad34-260d930ca4f4".to_string();
+        let token =
+            generate_tenant_token(api_key_uid.clone(), json!(SEARCH_RULES), VALID_KEY, None)
+                .unwrap();
 
         let decoded = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(VALID_KEY.as_ref()), &build_validation()
-        ).expect("Cannot decode the token");
+            &token,
+            &DecodingKey::from_secret(VALID_KEY.as_ref()),
+            &build_validation(),
+        )
+        .expect("Cannot decode the token");
 
-        assert_eq!(decoded.claims.api_key_prefix, &VALID_KEY[..8]);
+        assert_eq!(decoded.claims.api_key_uid, api_key_uid);
         assert_eq!(decoded.claims.search_rules, json!(SEARCH_RULES));
     }
 
     #[test]
     fn test_generate_token_with_multi_byte_chars() {
+        let api_key_uid = "76cf8b87-fd12-4688-ad34-260d930ca4f4".to_string();
         let key = "Ëa1ทt9bVcL-vãUทtP3OpXW5qPc%bWH5ทvw09";
-        let token = generate_tenant_token(json!(SEARCH_RULES), key, None).unwrap();
+        let token =
+            generate_tenant_token(api_key_uid.clone(), json!(SEARCH_RULES), key, None).unwrap();
 
         let decoded = decode::<TenantTokenClaim>(
-            &token, &DecodingKey::from_secret(key.as_ref()), &build_validation()
-        ).expect("Cannot decode the token");
+            &token,
+            &DecodingKey::from_secret(key.as_ref()),
+            &build_validation(),
+        )
+        .expect("Cannot decode the token");
 
-        assert_eq!(decoded.claims.api_key_prefix, "Ëa1ทt9bV");
+        assert_eq!(decoded.claims.api_key_uid, api_key_uid);
+    }
+
+    #[test]
+    fn test_generate_token_with_wrongly_formated_uid() {
+        let api_key_uid = "xxx".to_string();
+        let key = "Ëa1ทt9bVcL-vãUทtP3OpXW5qPc%bWH5ทvw09";
+        let token = generate_tenant_token(api_key_uid.clone(), json!(SEARCH_RULES), key, None);
+
+        assert!(token.is_err());
+    }
+
+    #[test]
+    fn test_generate_token_with_wrong_uid_version() {
+        let api_key_uid = "6a11eb96-2485-11ed-861d-0242ac120002".to_string();
+        let key = "Ëa1ทt9bVcL-vãUทtP3OpXW5qPc%bWH5ทvw09";
+        let token = generate_tenant_token(api_key_uid.clone(), json!(SEARCH_RULES), key, None);
+
+        assert!(token.is_err());
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn async_sleep(interval: Duration) {
+    let (sender, receiver) = futures::channel::oneshot::channel::<()>();
+    std::thread::spawn(move || {
+        std::thread::sleep(interval);
+        let _ = sender.send(());
+    });
+    let _ = receiver.await;
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn async_sleep(interval: Duration) {
+    use std::convert::TryInto;
+    use wasm_bindgen_futures::JsFuture;
+
+    JsFuture::from(js_sys::Promise::new(&mut |yes, _| {
+        web_sys::window()
+            .unwrap()
+            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                &yes,
+                interval.as_millis().try_into().unwrap(),
+            )
+            .unwrap();
+    }))
+    .await
+    .unwrap();
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use meilisearch_test_macro::meilisearch_test;
+
+    #[meilisearch_test]
+    async fn test_async_sleep() {
+        let sleep_duration = std::time::Duration::from_millis(10);
+        let now = time::Instant::now();
+
+        async_sleep(sleep_duration).await;
+
+        assert!(now.elapsed() >= sleep_duration);
+    }
+}


### PR DESCRIPTION
For consistency between all routes that provide query parameters, this PR add a structure `DocumentQuery` in which you can set the `fields` parameters. 