### PR TITLE
Bump version to v0.18.0

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -495,7 +495,7 @@ primary_field_guide_add_document_primary_key: |-
 getting_started_add_documents_md: |-
   ```toml
     [dependencies]
-    meilisearch-sdk = "0.17"
+    meilisearch-sdk = "0.18"
     # futures: because we want to block on futures
     futures = "0.3"
     # serde: required if you are going to use documents

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-sdk"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Mubelotix <mubelotix@gmail.com>"]
 edition = "2018"
 description = "Rust wrapper for the Meilisearch API. Meilisearch is a powerful, fast, open-source, easy to use and deploy search engine."

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.17.0"
+meilisearch-sdk = "0.18.0"
 ```
 
 The following optional dependencies may also be useful:

--- a/README.tpl
+++ b/README.tpl
@@ -50,7 +50,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.17.0"
+meilisearch-sdk = "0.18.0"
 ```
 
 The following optional dependencies may also be useful:


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.28.0 :tada:
Check out the changelog of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0) for more information on the changes.

## 💥  Breaking Changes

- Actions that create a task in Meilisearch now return a `TaskInfo` and not a `Task` object anymore. (ex: add_documents). #299
- `get_tasks` now returns a `TasksResults` where the tasks are contained inside the `results` field. #299
- `task_id` in `Task` and`TaskInfo` is now a `u32` instead of a `u64` #299
- `index_uid` in `Task` and `TaskInfo` is now optional. #299
- Following taskTypes are renamed: #299
   - documentPartial -> documentAdditionOrUpdate
   - documentAddition -> documentAdditionOrUpdate
   - clearAll -> documentDeletion
- Possibility to filter the tasks when using `get_tasks` on `indexUid`, `status` and `type`. #299
- The returned keys when using `get_keys_with` `get_keys` or `get_key` now returns an additional `name and `uid` field. #313
- The response from `get_keys_with` and `get_keys` is now a `KeysResults` instead of `Vec<Key>`. #313
- `update_key` only accepts updates on the `description` and the `name` #313
- `client.get_indexes` now returns a `IndexesResults` instead of a `Vec<Index>` #315
- `client.get_indexes_raw` now returns a `Value` instead of a `Vec<Value>`#315
- `Index` structure:  #315
   - `uid` is now a `string` and not a `Arc<string>` and is public 
   - `client` is now public
   - `primary_key` is now public
   - `name` field is removed
- In `SearchResults` `nbHits` is now named `estimated_total_hits` #316
- In `SearchResults` `exhaustive_nb_hits` is removed. #316
- In `SearchResults` `exhaustive_facets_count` is removed. #316
- In `SearchQuery`  `matches` is now named `show_mathes_position` and the method `with_matches` is now named `with_show_matches_position` #316
- In `SearchResults`  `matches_info` is now named `matches_position` #316
- In `SearchQuery` `facets_distribution` is now named `facets` #316
- In `SearchResults` `facets_distribution`  is now named `facet_distribution`  #316
- `client.get_documents` and `client.get_documents_with` now returns a `DocumentsResults` instead of a `Vec<T>` #315
- `client.get_documents` has no filtering parameters anymore, use `get_documents_with` to filter.
- in `client.generate_tenant_token`, `apiKeyPrefix` is now named `apiKeyUid` and expects the uid of the signing API key as a value. The prototype of the function changed accordingly. #318 
    ```rust
      pub fn generate_tenant_token(
         api_key_uid: String,
         search_rules: Value,
         api_key: impl AsRef<str>,
         expires_at: Option<OffsetDateTime>,
      ) -> Result<String, Error>
   ```
- Method `get_dump_status` removed on Dumps struct  #319
- `create_dump` now returns a `TaskInfo` instead of a `DumpInfo` #319
- Remove the sync feature and use Arc everywhere by default (#251) @irevoire

## 🐛 Enhancements

- Creation of a method `client.get_tasks_with` and a struct `TasksQuery` based of [this](https://github.com/meilisearch/specifications/pull/115) that lets you filter tasks. #299
- Creation of `client.get_keys_with()` that lets you paginate on `limit` (default: 20), `offset` (default: 0). #313
- `create_key` accepts a custom `name` and a custom `uuid` to create deterministic API keys.  #313
- `client.get_indexes_with` takes as argument `IndexesQuery` giving you the possibility to set `limit` and `offset`. #315
- `client.get_indexes_raw_with` takes as argument `IndexesQuery` giving you the possibility to set `limit` and `offset`. #315
- `IndexUpdater` struct gives you the possibility to create an instance of all the fields you would like to change in an Index  and then execute the update: `IndexUpdater::new(&client).with_primary_key("my_id".to_string()).execute().await) #315
- `IndexesQuery` struct allows you to define the filtering applied during the `get_all_indexes_with` call. #315
- new method `client.get_documents_with` takes as argument `DocumentsQuery` giving the possibility to set `limit`m `offset` and the fields that you want to see in the returned documents (default: all fields). #315
- new method `index.get_document_with` takes as argument `DocumentQuery` giving the possibility to chose the fields you want to see in your returned documents. #326 


Thanks again to @bidoubiwa, @abhizer ! 🎉
