### PR TITLE
Fix wasm panic when trying to change the user-agent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Also, the WASM example compilation should be checked:
 
 ```bash
 rustup target add wasm32-unknown-unknown
-cargo check --example web_app --target wasm32-unknown-unknown --features=sync
+cargo check -p web_app --target wasm32-unknown-unknown
 ```
 
 Each PR should pass the tests to be accepted.

--- a/examples/web_app/README.md
+++ b/examples/web_app/README.md
@@ -11,7 +11,7 @@ The Rust source files are compiled into WebAssembly and so can be readable by th
 If you only want to check if this example compiles, you can run:
 
 ```console
-cargo build --example web_app
+cargo build
 ```
 
 ## Building
@@ -23,7 +23,7 @@ curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 ```
 
 ```console
-wasm-pack build examples/web_app/ --target=web --no-typescript
+wasm-pack build . --target=web --no-typescript
 ```
 
 The compiled files will be stored in the `examples/web_app/pkg` folder.

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -15,10 +15,7 @@ mod document;
 use crate::document::{display, Crate};
 
 lazy_static! {
-    static ref CLIENT: Client = Client::new(
-        "https://finding-demos.meilisearch.com",
-        "2b902cce4f868214987a9f3c7af51a69fa660d74a785bed258178b96e3480bb3",
-    );
+    static ref CLIENT: Client = Client::new("http://localhost:7700", "masterKey",);
 }
 
 struct Model {

--- a/src/request.rs
+++ b/src/request.rs
@@ -113,7 +113,9 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
     // The 2 following unwraps should not be able to fail
     let mut mut_url = url.clone().to_string();
     let headers = Headers::new().unwrap();
-    headers.append("Authorization: Bearer", apikey).unwrap();
+    headers
+        .append("Authorization", format!("Bearer {}", apikey).as_str())
+        .unwrap();
     headers
         .append("X-Meilisearch-Client", qualified_version().as_str())
         .unwrap();

--- a/src/request.rs
+++ b/src/request.rs
@@ -114,6 +114,9 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
     let mut mut_url = url.clone().to_string();
     let headers = Headers::new().unwrap();
     headers.append("Authorization: Bearer", apikey).unwrap();
+    headers
+        .append("X-Meilisearch-Client", qualified_version().as_str())
+        .unwrap();
 
     let mut request: RequestInit = RequestInit::new();
     request.headers(&headers);
@@ -122,10 +125,8 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
         Method::Get(query) => {
             let query = yaup::to_string(query)?;
 
-            mut_url = if query.is_empty() {
-                mut_url.to_string()
-            } else {
-                format!("{}?{}", mut_url, query)
+            if !query.is_empty() {
+                mut_url = format!("{}?{}", mut_url, query);
             };
 
             request.method("GET");

--- a/src/request.rs
+++ b/src/request.rs
@@ -109,13 +109,11 @@ pub(crate) async fn request<Input: Serialize, Output: DeserializeOwned + 'static
 
     const CONTENT_TYPE: &str = "Content-Type";
     const JSON: &str = "application/json";
-    let user_agent = qualified_version();
 
     // The 2 following unwraps should not be able to fail
     let mut mut_url = url.clone().to_string();
     let headers = Headers::new().unwrap();
     headers.append("Authorization: Bearer", apikey).unwrap();
-    headers.append("User-Agent", &user_agent).unwrap();
 
     let mut request: RequestInit = RequestInit::new();
     request.headers(&headers);


### PR DESCRIPTION
Fixes: #308 

User-agent can not be changed in chromium. It is considered a security breach. Probably because of that wasm does not accept it either. 