### PR TITLE
Update search params for v0.29.0

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -779,10 +779,12 @@ mod tests {
     async fn test_matching_strategy_all(client: Client, index: Index) -> Result<(), Error> {
         setup_test_index(&client, &index).await?;
 
-        let mut query = Query::new(&index);
-        query.with_query("harry Styles");
-        query.with_matching_strategy(MatchingStrategies::ALL);
-        let results: SearchResults<Document> = index.execute_query(&query).await?;
+        let results = Query::new(&index)
+            .with_query("Harry Styles")
+            .with_matching_strategy(MatchingStrategies::ALL)
+            .execute::<Document>()
+            .await
+            .unwrap();
 
         assert_eq!(results.hits.len(), 0);
         Ok(())
@@ -792,10 +794,12 @@ mod tests {
     async fn test_matching_strategy_left(client: Client, index: Index) -> Result<(), Error> {
         setup_test_index(&client, &index).await?;
 
-        let mut query = Query::new(&index);
-        query.with_query("Harry Styles");
-        query.with_matching_strategy(MatchingStrategies::LAST);
-        let results: SearchResults<Document> = index.execute_query(&query).await?;
+        let results = Query::new(&index)
+            .with_query("Harry Styles")
+            .with_matching_strategy(MatchingStrategies::LAST)
+            .execute::<Document>()
+            .await
+            .unwrap();
 
         assert_eq!(results.hits.len(), 7);
         Ok(())

--- a/src/search.rs
+++ b/src/search.rs
@@ -9,6 +9,14 @@ pub struct MatchRange {
     pub length: usize,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub enum MatchingStrategies {
+    #[serde(rename = "all")]
+    ALL,
+    #[serde(rename = "last")]
+    LAST,
+}
+
 /// A single result.
 /// Contains the complete object, optionally the formatted object, and optionally an object that contains information about the matches.
 #[derive(Deserialize, Debug)]
@@ -234,6 +242,10 @@ pub struct Query<'a> {
     /// Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_matches_position: Option<bool>,
+
+    /// Defines the strategy on how to handle queries containing multiple words.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matching_strategy: Option<MatchingStrategies>,
 }
 
 #[allow(missing_docs)]
@@ -255,6 +267,7 @@ impl<'a> Query<'a> {
             highlight_pre_tag: None,
             highlight_post_tag: None,
             show_matches_position: None,
+            matching_strategy: None,
         }
     }
     pub fn with_query<'b>(&'b mut self, query: &'a str) -> &'b mut Query<'a> {
@@ -330,6 +343,13 @@ impl<'a> Query<'a> {
         show_matches_position: bool,
     ) -> &'b mut Query<'a> {
         self.show_matches_position = Some(show_matches_position);
+        self
+    }
+    pub fn with_matching_strategy<'b>(
+        &'b mut self,
+        matching_strategy: MatchingStrategies,
+    ) -> &'b mut Query<'a> {
+        self.matching_strategy = Some(matching_strategy);
         self
     }
     pub fn build(&mut self) -> Query<'a> {
@@ -752,6 +772,32 @@ mod tests {
         let results: SearchResults<Document> = index.execute_query(&query).await?;
 
         assert_eq!(results.hits.len(), 1);
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_matching_strategy_all(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_index(&client, &index).await?;
+
+        let mut query = Query::new(&index);
+        query.with_query("harry Styles");
+        query.with_matching_strategy(MatchingStrategies::ALL);
+        let results: SearchResults<Document> = index.execute_query(&query).await?;
+
+        assert_eq!(results.hits.len(), 0);
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_matching_strategy_left(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_index(&client, &index).await?;
+
+        let mut query = Query::new(&index);
+        query.with_query("Harry Styles");
+        query.with_matching_strategy(MatchingStrategies::LAST);
+        let results: SearchResults<Document> = index.execute_query(&query).await?;
+
+        assert_eq!(results.hits.len(), 7);
         Ok(())
     }
 


### PR DESCRIPTION
## Improve matching query term policy

Related to:
- issue: https://github.com/meilisearch/meilisearch/issues/2578

This improvement motivation is about letting the user customize the behavior of Meilisearch when retrieving documents according to the query words.

  - Add a `matchingStrategy` parameter to search requests `search` and `searchRaw`. 
  - The value `last` is the default strategy if the field is not specified.
  - This field can receive only two valid options `last` or `all`.


Usage: 

```rust
    let results = Query::new(&index)
            .with_query("Harry Styles")
            .with_matching_strategy(MatchingStrategies::ALL)
            .execute::<Document>()
            .await
            .unwrap();
```

# Release body

## 🚀 Enhancements

- New search query parameter in `Query` struct. #333
- New method in `Query` struct: `matching_strategy` #333
