### PR TITLE
Fix indentation of `authorization_header_1` code sample

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1280,9 +1280,9 @@ delete_a_key_1: |-
 authorization_header_1:
   let client = Client::new("http://localhost:7700", "masterKey");
   let keys = client
-  .get_keys()
-  .await
-  .unwrap();
+    .get_keys()
+    .await
+    .unwrap();
 security_guide_search_key_1: |-
   let client = Client::new("http://localhost:7700", "apiKey");
   let result = client.index("patient_medical_records")


### PR DESCRIPTION
Fix indentation of the get keys code sample:

<img width="794" alt="image" src="https://user-images.githubusercontent.com/4116980/195279105-00949ff4-b1b9-4ac7-9d7f-f91e4fd1201a.png">
