### PR TITLE
Add cargo fmt in contributing and correctly in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,52 +20,52 @@ jobs:
     runs-on: ubuntu-latest
     name: integration-tests
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Meilisearch (latest version) setup with Docker
-      run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --no-analytics --master-key=masterKey
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --workspace --all-targets --all
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Meilisearch (latest version) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --no-analytics --master-key=masterKey
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --workspace --all-targets --all
 
   linter:
     name: clippy-check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install clippy
-      run: rustup component add clippy
-    - name: Run linter (clippy)
-      # Will fail when encountering warnings
-      run: cargo clippy -- -D warnings
+      - uses: actions/checkout@v2
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Run linter (clippy)
+        # Will fail when encountering warnings
+        run: cargo clippy -- -D warnings
 
   formatter:
     name: rust-format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run formatter
-      run: cargo fmt
+      - uses: actions/checkout@v2
+      - name: Run formatter
+        run: cargo fmt --all -- --check
 
   readme_check:
     name: readme-check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Check the README.md file is up-to-date
-      run: sh scripts/check-readme.sh
+      - uses: actions/checkout@v2
+      - name: Check the README.md file is up-to-date
+        run: sh scripts/check-readme.sh
 
   wasm_build:
     name: wasm-build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run:  |
-        rustup target add wasm32-unknown-unknown
-        cargo check -p web_app --target wasm32-unknown-unknown
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo check -p web_app --target wasm32-unknown-unknown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,21 @@ rustup component add clippy
 rustup update
 ```
 
+### Fmt
+
+Each PR should pass the format test to be accepted.
+
+Run the following to fix the formating errors:
+
+```
+cargo fmt
+```
+
+and the following to test if the formating is correct:
+```
+cargo fmt --all -- --check
+```
+
 ### Update the README <!-- omit in toc -->
 
 The README is generated. Please do not update manually the `README.md` file.


### PR DESCRIPTION
We were testing `cargo fmt` in the CI which does not test but fixes formating error.

The command has been updated to `cargo fmt --all -- --check` which throws error in case of formating errors.

Additionally, the step to try the formating are added in the CONTRIBUTING guide.