### PR TITLE
Checks that all error messages are correctly parsed

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -188,6 +188,8 @@ impl From<isahc::Error> for Error {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use jsonwebtoken::errors::ErrorKind::InvalidToken;
     use uuid::Uuid;
 
     #[test]
@@ -287,6 +289,18 @@ mod test {
         assert_eq!(
             error.to_string(),
             "HTTP request failed: failed to resolve host name"
+        );
+
+        let error = Error::InvalidTenantToken(jsonwebtoken::errors::Error::from(InvalidToken));
+        assert_eq!(
+            error.to_string(),
+            "Impossible to generate the token, jsonwebtoken encountered an error: InvalidToken"
+        );
+
+        let error = Error::Yaup(yaup::error::Error::Custom("Test yaup error".to_string()));
+        assert_eq!(
+            error.to_string(),
+            "Internal Error: could not parse the query parameters: Test yaup error"
         );
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #162

## What does this PR do?
- Adds parsing checks for the remaining two errors,ie, `InvalidTenantToken` and `Yaup`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
