### PR TITLE
Fix skip-changelog tag in dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: "monthly"
   labels:
-    - 'skip changelog'
+    - 'skip-changelog'
     - 'dependencies'
   rebase-strategy: disabled
 


### PR DESCRIPTION
The tag was set as `skip changelog` and not `skip-changelog` whenever dependabot creates a dump