### PR TITLE
Add tasks filters for v0.30.0

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -117,7 +117,7 @@ get_all_tasks_filtering_1: |-
 get_all_tasks_filtering_2: |-
   let mut query = TasksQuery::new(&client)
       .with_status(["succeeded", "failed"])
-      .with_type(["documentAdditionOrUpdate"])
+      .with_types(["documentAdditionOrUpdate"])
       .execute()
       .await
       .unwrap();

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -110,13 +110,13 @@ get_all_tasks_1: |-
     .unwrap();
 get_all_tasks_filtering_1: |-
   let mut query = TasksQuery::new(&client)
-      .with_index_uid(["movies"])
+      .with_index_uids(["movies"])
       .execute()
       .await
       .unwrap();
 get_all_tasks_filtering_2: |-
   let mut query = TasksQuery::new(&client)
-      .with_status(["succeeded", "failed"])
+      .with_statuses(["succeeded", "failed"])
       .with_types(["documentAdditionOrUpdate"])
       .execute()
       .await

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ WARNING: `meilisearch-sdk` will panic if no Window is available (ex: Web extensi
 
 ## 🤖 Compatibility with Meilisearch
 
-This package only guarantees the compatibility with the [version v0.29.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0).
+This package only guarantees the compatibility with the [version v0.30.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0).
 
 ## ⚙️ Contributing
 

--- a/README.tpl
+++ b/README.tpl
@@ -108,7 +108,7 @@ WARNING: `meilisearch-sdk` will panic if no Window is available (ex: Web extensi
 
 ## 🤖 Compatibility with Meilisearch
 
-This package only guarantees the compatibility with the [version v0.29.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0).
+This package only guarantees the compatibility with the [version v0.30.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0).
 
 ## ⚙️ Contributing
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -744,7 +744,7 @@ impl Client {
     /// # let client = client::Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
     ///
     /// let mut query = tasks::TasksQuery::new(&client);
-    /// query.with_index_uid(["get_tasks_with"]);
+    /// query.with_index_uids(["get_tasks_with"]);
     /// let tasks = client.get_tasks_with(&query).await.unwrap();
     /// # });
     /// ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -930,7 +930,7 @@ mod tests {
     #[meilisearch_test]
     async fn test_get_tasks(client: Client) {
         let tasks = client.get_tasks().await.unwrap();
-        assert!(tasks.results.len() >= 2);
+        assert!(tasks.limit == 20);
     }
 
     #[meilisearch_test]
@@ -938,7 +938,7 @@ mod tests {
         let query = TasksQuery::new(&client);
         let tasks = client.get_tasks_with(&query).await.unwrap();
 
-        assert!(tasks.results.len() >= 2);
+        assert!(tasks.limit == 20);
     }
 
     #[meilisearch_test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -156,6 +156,9 @@ pub enum ErrorCode {
     InvalidApiKeyIndexes,
     InvalidApiKeyExpiresAt,
     ApiKeyNotFound,
+    InvalidTaskUid,
+    InvalidTaskDate,
+    MissingTaskFilter,
 
     /// That's unexpected. Please open a GitHub issue after ensuring you are
     /// using the supported version of the Meilisearch server.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -156,8 +156,11 @@ pub enum ErrorCode {
     InvalidApiKeyIndexes,
     InvalidApiKeyExpiresAt,
     ApiKeyNotFound,
-    InvalidTaskUid,
-    InvalidTaskDate,
+    InvalidTaskTypesFilter,
+    InvalidTaskStatusesFilter,
+    InvalidTaskCanceledByFilter,
+    InvalidTaskUidsFilter,
+    InvalidTaskDateFilter,
     MissingTaskFilter,
 
     /// That's unexpected. Please open a GitHub issue after ensuring you are

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -161,7 +161,7 @@ pub enum ErrorCode {
     InvalidTaskCanceledByFilter,
     InvalidTaskUidsFilter,
     InvalidTaskDateFilter,
-    MissingTaskFilter,
+    MissingTaskFilters,
 
     /// That's unexpected. Please open a GitHub issue after ensuring you are
     /// using the supported version of the Meilisearch server.

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -903,7 +903,7 @@ impl Index {
     /// ```
     pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
         let mut query = TasksQuery::new(&self.client);
-        query.with_index_uid([self.uid.as_str()]);
+        query.with_index_uids([self.uid.as_str()]);
 
         self.client.get_tasks_with(&query).await
     }
@@ -924,7 +924,7 @@ impl Index {
     /// # let index = client.create_index("get_tasks_with", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let mut query = TasksQuery::new(&client);
-    /// query.with_index_uid(["none_existant"]);
+    /// query.with_index_uids(["none_existant"]);
     /// let tasks = index.get_tasks_with(&query).await.unwrap();
     ///
     /// assert!(tasks.results.len() > 0);
@@ -936,7 +936,7 @@ impl Index {
         tasks_query: &TasksQuery<'_>,
     ) -> Result<TasksResults, Error> {
         let mut query = tasks_query.clone();
-        query.with_index_uid([self.uid.as_str()]);
+        query.with_index_uids([self.uid.as_str()]);
 
         self.client.get_tasks_with(&query).await
     }

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -436,7 +436,8 @@ impl Index {
     ///
     /// # futures::executor::block_on(async move {
     /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
-    /// let movie_index = client.index("get_documents");
+    ///
+    /// let movie_index = client.index("get_documents_with");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -434,7 +434,7 @@ pub struct TasksQuery<'a> {
         serialize_with = "time::serde::rfc3339::option::serialize"
     )]
     pub before_started_at: Option<OffsetDateTime>,
-    // Date to retrieve all tasks that were started before it.
+    // Date to retrieve all tasks that were started after it.
     #[serde(
         skip_serializing_if = "Option::is_none",
         serialize_with = "time::serde::rfc3339::option::serialize"

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -511,42 +511,42 @@ impl<'a> TasksQuery<'a> {
         &'b mut self,
         before_enqueued_at: &'a OffsetDateTime,
     ) -> &'b mut TasksQuery<'a> {
-        self.before_enqueued_at = Some(before_enqueued_at.clone());
+        self.before_enqueued_at = Some(*before_enqueued_at);
         self
     }
     pub fn with_after_enqueued_at<'b>(
         &'b mut self,
         after_enqueued_at: &'a OffsetDateTime,
     ) -> &'b mut TasksQuery<'a> {
-        self.after_enqueued_at = Some(after_enqueued_at.clone());
+        self.after_enqueued_at = Some(*after_enqueued_at);
         self
     }
     pub fn with_before_started_at<'b>(
         &'b mut self,
         before_started_at: &'a OffsetDateTime,
     ) -> &'b mut TasksQuery<'a> {
-        self.before_started_at = Some(before_started_at.clone());
+        self.before_started_at = Some(*before_started_at);
         self
     }
     pub fn with_after_started_at<'b>(
         &'b mut self,
         after_started_at: &'a OffsetDateTime,
     ) -> &'b mut TasksQuery<'a> {
-        self.after_started_at = Some(after_started_at.clone());
+        self.after_started_at = Some(*after_started_at);
         self
     }
     pub fn with_before_finished_at<'b>(
         &'b mut self,
         before_finished_at: &'a OffsetDateTime,
     ) -> &'b mut TasksQuery<'a> {
-        self.before_finished_at = Some(before_finished_at.clone());
+        self.before_finished_at = Some(*before_finished_at);
         self
     }
     pub fn with_after_finished_at<'b>(
         &'b mut self,
         after_finished_at: &'a OffsetDateTime,
     ) -> &'b mut TasksQuery<'a> {
-        self.after_finished_at = Some(after_finished_at.clone());
+        self.after_finished_at = Some(*after_finished_at);
         self
     }
     pub fn with_limit<'b>(&'b mut self, limit: u32) -> &'b mut TasksQuery<'a> {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -413,6 +413,28 @@ pub struct TasksQuery<'a> {
     // Types array to only retrieve the tasks with these [TaskType].
     #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     pub task_type: Option<Vec<&'a str>>,
+    // Uids of the tasks to retrieve
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid: Option<Vec<&'a usize>>,
+    // Date to retrieve all tasks that were enqueued before it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beforeEnqueuedAt: Option<OffsetDateTime>,
+    // Date to retrieve all tasks that were enqueued after it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub afterEnqueuedAt: Option<OffsetDateTime>,
+    // Date to retrieve all tasks that were started before it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beforeStartedAt: Option<OffsetDateTime>,
+    // Date to retrieve all tasks that were started before it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub afterStatedAt: Option<OffsetDateTime>,
+    // Date to retrieve all tasks that were finished before it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beforeFinishedAt: Option<OffsetDateTime>,
+    // Date to retrieve all tasks that were finished after it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub afterFinishedAt: Option<OffsetDateTime>,
+
     // Maximum number of tasks to return
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,


### PR DESCRIPTION
Add new filters on the `get /tasks` route.

Present in this [spec](https://github.com/meilisearch/specifications/pull/195)

TODO: 
V0.30.0rc1
- TasksQuery: 
   - [x] `index_uid` renamed to `index_uids`
   - [x] `type` renamed to  `types`
   - [x] `status` renamed to `statuses`
   - [x] `uid` renamed to `uids`
- In TaskQuery impl constructor:    
    - [x] `with_index_uid` renamed to `with_index_uids`
    - [x] `with_type` renamed to `with_types`
    - [x] `with_status` renamed to `with_statuses`
    - [x] `with_uid` renamed to `with_uids`
- ErrorsCodes: 
  - [x] invalid_task_types_filter
  - [x] invalid_task_statuses_filter
  - [x] invalid_task_canceled_by_filter
  - [x] invalid_task_uids_filter
  - [x] invalid_task_date_filter 
  - [x] missing_task_filter

V0.30.0rc0
in TasksQuery struct:
  - [x] Add `uid`
  - [x] Add `before_enqueued_at`
  - [x] Add `after_enqueued_at`
  - [x] Add `before_started_at`
  - [x] Add `after_started_at`
  - [x] Add `before_finished_at`
  - [x] Add `after_finished_at`

In TaskQuery impl constructor: 
  - [x] Add `uids: None`
  - [x] Add `before_enqueued_at: None`
  - [x] Add `after_enqueued_at: None`
  - [x] Add `before_started_at: None`
  - [x] Add `after_started_at: None`
  - [x] Add `before_finished_at: None`
  - [x] Add `after_finished_at: None`

in TasksQuery implementation:  
- [x] Add `with_uids()`
- [x] Add `with_before_enqueued_at()`
- [x] Add `with_after_enqueued_at()`
- [x] Add `with_before_started_at()`
- [x] Add `with_after_started_at()`
- [x] Add `with_before_finished_at()`
- [x] Add `with_after_finished_at()`

Tests:
  - [x] Add test on filters

