### PR TITLE
Fix primary key test using the wrong index name

### DIFF
--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -813,10 +813,11 @@ impl Index {
     /// # futures::executor::block_on(async move {
     /// // create the client
     /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
-    /// # let index = client.create_index("get_primary_key", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
+    /// # let mut index = client.create_index("get_primary_key", Some("id")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
-    /// // get the primary key of the index named "movies"
-    /// let movies = client.index("movies").get_primary_key().await;
+    /// let primary_key = index.get_primary_key().await.unwrap();
+    ///
+    /// assert_eq!(primary_key, Some("id"));
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```


### PR DESCRIPTION
The documentation test on `get_primary_key` was using `movies` as an index. Which creates conflict with the lib test also using `movies` as an index name.

As per the convention on other documentation tests, we are using the name as the function as index name. This ensures that we do not have two times the same index name. This PR fixes this.