### PR TITLE
Add missing_master_key error code for v0.30.0

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -139,6 +139,7 @@ pub enum ErrorCode {
     MissingAuthorizationHeader,
     TaskNotFound,
     DumpNotFound,
+    MssingMasterKey,
     NoSpaceLeftOnDevice,
     PayloadTooLarge,
     UnretrievableDocument,

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -248,6 +248,7 @@ impl Task {
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
+    #[allow(clippy::result_large_err)] // Since `self` has been consumed, this is not an issue
     pub fn try_make_index(self, client: &Client) -> Result<Index, Self> {
         match self {
             Self::Succeeded {


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2918

- [x] add `missing_master_key` error code

⚠️ Clippy failing due to unrelated rust update #386 
