### PR TITLE
Add matched_documents as a detail when performing document deletion for v0.30.0

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -52,6 +52,7 @@ pub struct DocumentAdditionOrUpdate {
 #[serde(rename_all = "camelCase")]
 pub struct DocumentDeletion {
     pub deleted_documents: Option<usize>,
+    pub matched_documents: usize,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2799

- [x] Add `matched_documents` as a detail on `DocumentDeletion`

