### PR TITLE
Add snapshot_creation task type for v0.30.0

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -31,6 +31,9 @@ pub enum TaskType {
     DumpCreation {
         details: Option<DumpCreation>,
     },
+    SnapshotCreation {
+        details: Option<SnapshotCreation>,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -71,6 +74,10 @@ pub struct IndexUpdate {
 pub struct IndexDeletion {
     pub deleted_documents: Option<usize>,
 }
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotCreation {}
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2953

- [x] Add `snapshot_creation` task type
