### PR TITLE
Add `error` field in all types of task status for v0.30.0

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -113,6 +113,7 @@ pub struct SucceededTask {
     #[serde(with = "time::serde::rfc3339")]
     pub finished_at: OffsetDateTime,
     pub index_uid: Option<String>,
+    pub error: Option<MeilisearchError>,
     #[serde(flatten)]
     pub update_type: TaskType,
     pub uid: u32,


### PR DESCRIPTION
## Breaking change

- The error field is always present in any kind of Tasks (SuccededTask, etc..), but its value can be `Null`