### PR TITLE
Rename setting detail original filters to original filter for v0.30.0

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -106,7 +106,7 @@ pub struct IndexSwap {
 pub struct TaskCancelation {
     pub matched_tasks: usize,
     pub canceled_tasks: usize,
-    pub original_filters: String,
+    pub original_filter: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -114,7 +114,7 @@ pub struct TaskCancelation {
 pub struct TaskDeletion {
     pub matched_tasks: usize,
     pub deleted_tasks: usize,
-    pub original_filters: String,
+    pub original_filter: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
As per [this issue](https://github.com/meilisearch/meilisearch/pull/3080)

# Changes

- `originalFilters` introduced in #377  is renamed to `originalFilter`
