### PR TITLE
Add provided_ids detail setting for v0.30.0

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -64,6 +64,7 @@ pub struct DocumentAdditionOrUpdate {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentDeletion {
+    pub provided_ids: Option<usize>,
     pub deleted_documents: Option<usize>,
 }
 


### PR DESCRIPTION
As per [this issue](https://github.com/meilisearch/meilisearch/pull/3081)

# Changes:

- Add `provided_ids` as detail setting when performing a document deletion