### PR TITLE
Update version for the next release (v0.21.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -828,7 +828,7 @@ primary_field_guide_add_document_primary_key: |-
 getting_started_add_documents_md: |-
   ```toml
     [dependencies]
-    meilisearch-sdk = "0.20"
+    meilisearch-sdk = "0.21"
     # futures: because we want to block on futures
     futures = "0.3"
     # serde: required if you are going to use documents

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-sdk"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["Mubelotix <mubelotix@gmail.com>"]
 edition = "2018"
 description = "Rust wrapper for the Meilisearch API. Meilisearch is a powerful, fast, open-source, easy to use and deploy search engine."

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.20.1"
+meilisearch-sdk = "0.21.0"
 ```
 
 The following optional dependencies may also be useful:

--- a/README.tpl
+++ b/README.tpl
@@ -52,7 +52,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.20.1"
+meilisearch-sdk = "0.21.0"
 ```
 
 The following optional dependencies may also be useful:


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.30.0 :tada:
Check out the changelog of [Meilisearch v0.30.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0) for more information on the changes.

## 🚀 Enhancements

- New `pagination` strategy with the search parameters`page` and `hitsPerPage` #374
- New bulder methods on `get_tasks`: `with_uids`, `with_before_enqueued_at`, ... see #375
- New `client.cancel_tasks` method that lets you cancel `enqueued` and `processing` tasks #377 
- New `client.delete_tasks` method that lets you delete tasks #381 
- New `client.swap_indexes` method that lets you swap two indexes #382

## ⚠️ Breaking change

- builder functions on `TasksQuery` name changes: #375
   - `with_status` -> `with_statuses`
   - `with_index_uid` -> `with_index_uids`
   - `with_type` -> `with_types`
- Task detail `receivedDocumentIds` renamed to `providedIds` #393
- Error field in `Task` is now always present and has a `None` value when there are no errors #390
- Add and rename some error codes: #384 