### PR TITLE
Fix order of crate publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,9 @@ jobs:
           cargo build --release
       - name: Login
         run: cargo login ${{ secrets.CRATES_TOKEN }}
-      - name: Publish meilisearch crate to crates.io
-        run: cargo publish
       - name: Publish meilisearch-index-setting-macro crate to crates.io
         run: |-
           cd meilisearch-index-setting-macro
           cargo publish
+      - name: Publish meilisearch crate to crates.io
+        run: cargo publish


### PR DESCRIPTION
The macro crate should be published before the meilisearch-rust crate since `meilisearch-rust` needs the macro crate to work