### PR TITLE
Add licence and description field in index-settings crate

### DIFF
--- a/meilisearch-index-setting-macro/Cargo.toml
+++ b/meilisearch-index-setting-macro/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "meilisearch-index-setting-macro"
 version = "0.1.0"
+description = "Helper tool to generate settings of an Meilisearch index"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
In order for the `index-settings-macro` to be publishable on crates.io, it requires a `description` and `licence` field. 
Unfortunately, the `--dry-run` did not raise that, this lead to a failed publish previously.

```
Caused by:
  the remote server responded with an error: missing or empty metadata fields: description, license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata
```

