### PR TITLE
Provide two methods to add documents from an async reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ meilisearch-index-setting-macro = { path = "meilisearch-index-setting-macro", ve
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures = "0.3"
+futures-io = "0.3.26"
 isahc = { version = "1.0", features = ["http2", "text-decoding"], default_features = false }
 uuid = { version = "1.1.2", features = ["v4"] }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -115,6 +115,100 @@ pub(crate) async fn request<
     parse_response(status, expected_status_code, body)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn stream_request<
+    'a,
+    Query: Serialize,
+    Body: futures_io::AsyncRead + Send + Sync + 'static,
+    Output: DeserializeOwned + 'static,
+>(
+    url: &str,
+    apikey: &str,
+    method: Method<Query, Body>,
+    content_type: &str,
+    expected_status_code: u16,
+) -> Result<Output, Error> {
+    use isahc::http::header;
+    use isahc::*;
+
+    let auth = format!("Bearer {}", apikey);
+    let user_agent = qualified_version();
+
+    let mut response = match method {
+        Method::Get { query } => {
+            let url = add_query_parameters(url, &query)?;
+
+            Request::get(url)
+                .header(header::AUTHORIZATION, auth)
+                .header(header::USER_AGENT, user_agent)
+                .body(())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+        }
+        Method::Delete { query } => {
+            let url = add_query_parameters(url, &query)?;
+
+            Request::delete(url)
+                .header(header::AUTHORIZATION, auth)
+                .header(header::USER_AGENT, user_agent)
+                .body(())
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+        }
+        Method::Post { query, body } => {
+            let url = add_query_parameters(url, &query)?;
+
+            Request::post(url)
+                .header(header::AUTHORIZATION, auth)
+                .header(header::USER_AGENT, user_agent)
+                .header(header::CONTENT_TYPE, content_type)
+                .body(AsyncBody::from_reader(body))
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+        }
+        Method::Patch { query, body } => {
+            let url = add_query_parameters(url, &query)?;
+
+            Request::patch(url)
+                .header(header::AUTHORIZATION, auth)
+                .header(header::USER_AGENT, user_agent)
+                .header(header::CONTENT_TYPE, content_type)
+                .body(AsyncBody::from_reader(body))
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+        }
+        Method::Put { query, body } => {
+            let url = add_query_parameters(url, &query)?;
+
+            Request::put(url)
+                .header(header::AUTHORIZATION, auth)
+                .header(header::USER_AGENT, user_agent)
+                .header(header::CONTENT_TYPE, content_type)
+                .body(AsyncBody::from_reader(body))
+                .map_err(|_| crate::errors::Error::InvalidRequest)?
+                .send_async()
+                .await?
+        }
+    };
+
+    let status = response.status().as_u16();
+
+    let mut body = response
+        .text()
+        .await
+        .map_err(|e| crate::errors::Error::HttpError(e.into()))?;
+
+    if body.is_empty() {
+        body = "null".to_string();
+    }
+
+    parse_response(status, expected_status_code, body)
+}
+
 #[cfg(target_arch = "wasm32")]
 pub fn add_query_parameters<Query: Serialize>(
     mut url: String,


### PR DESCRIPTION
# Pull Request

When using Meilisearch-rust to forward documents from another source it’s a pain to use.
These two simple methods let you send raw payload to meilisearch. But you **need** to specify your content-type.

----

## Note

I didn’t implements these method for the wasm version of the crate because `wasm-bindgen-futures` don’t provide an `AsyncReader` trait.