### PR TITLE
Fix clippy error on format

### DIFF
--- a/meilisearch-index-setting-macro/src/lib.rs
+++ b/meilisearch-index-setting-macro/src/lib.rs
@@ -176,10 +176,7 @@ fn extract_all_attr_values(
                                         return std::result::Result::Err(
                                             syn::Error::new(
                                                 ident.span(),
-                                                format!(
-                                                    "`{}` already exists for this field",
-                                                    ident
-                                                ),
+                                                format!("`{ident}` already exists for this field"),
                                             )
                                             .to_compile_error(),
                                         );
@@ -190,8 +187,7 @@ fn extract_all_attr_values(
                                                 syn::Error::new(
                                                     ident.span(),
                                                     format!(
-                                                        "Property `{}` does not exist for type `document`",
-                                                        ident
+                                                        "Property `{ident}` does not exist for type `document`"
                                                     ),
                                                 )
                                                     .to_compile_error(),
@@ -213,7 +209,6 @@ fn extract_all_attr_values(
                 }
             }
             std::result::Result::Err(e) => {
-                println!("{:#?}", attr);
                 for token_stream in attr.tokens.clone().into_iter() {
                     if let TokenTree::Group(group) = token_stream {
                         for token in group.stream() {

--- a/src/request.rs
+++ b/src/request.rs
@@ -19,7 +19,7 @@ pub fn add_query_parameters<Query: Serialize>(url: &str, query: &Query) -> Resul
     if query.is_empty() {
         Ok(url.to_string())
     } else {
-        Ok(format!("{}?{}", url, query))
+        Ok(format!("{url}?{query}"))
     }
 }
 
@@ -37,7 +37,7 @@ pub(crate) async fn request<
     use isahc::http::header;
     use isahc::*;
 
-    let auth = format!("Bearer {}", apikey);
+    let auth = format!("Bearer {apikey}");
     let user_agent = qualified_version();
 
     let mut response = match &method {


### PR DESCRIPTION
Clippy errors are introduced with the new clippy rule on `format!`