### PR TITLE
Update version for the next release (v0.22.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -957,7 +957,7 @@ primary_field_guide_add_document_primary_key: |-
 getting_started_add_documents_md: |-
   ```toml
     [dependencies]
-    meilisearch-sdk = "0.21"
+    meilisearch-sdk = "0.22"
     # futures: because we want to block on futures
     futures = "0.3"
     # serde: required if you are going to use documents

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-sdk"
-version = "0.21.2"
+version = "0.22.0"
 authors = ["Mubelotix <mubelotix@gmail.com>"]
 edition = "2018"
 description = "Rust wrapper for the Meilisearch API. Meilisearch is a powerful, fast, open-source, easy to use and deploy search engine."

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.21.2"
+meilisearch-sdk = "0.22.0"
 ```
 
 The following optional dependencies may also be useful:

--- a/README.tpl
+++ b/README.tpl
@@ -52,7 +52,7 @@ To use `meilisearch-sdk`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meilisearch-sdk = "0.21.2"
+meilisearch-sdk = "0.22.0"
 ```
 
 The following optional dependencies may also be useful:


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v1.0.0 :tada:
Check out the changelog of [Meilisearch v1.0.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0) for more information on the changes.

## ⚠️ Breaking change

- Some error codes were added and other were removed, see #414 
