### PR TITLE
Avoid the index settings macro from being published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,5 @@ jobs:
           cargo build --release
       - name: Login
         run: cargo login ${{ secrets.CRATES_TOKEN }}
-      - name: Publish meilisearch-index-setting-macro crate to crates.io
-        run: |-
-          cd meilisearch-index-setting-macro
-          cargo publish
       - name: Publish meilisearch crate to crates.io
         run: cargo publish


### PR DESCRIPTION
Since it's purpose is only to be used locally, we do not need to publish again.
It removed an additional useless step during the publishing of the meilisearch crate. 