### PR TITLE
Add script to update the version of meilisearch-index-setting-macro

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -2,24 +2,39 @@
 
 # Checking if current tag matches the package version
 current_tag=$(echo $GITHUB_REF | cut -d '/' -f 3 | sed -r 's/^v//')
-major=$(echo $current_tag | cut -d '.' -f1 )
-minor=$(echo $current_tag | cut -d '.' -f2 )
+major=$(echo $current_tag | cut -d '.' -f1)
+minor=$(echo $current_tag | cut -d '.' -f2)
 cropped_current_tag="$major.$minor"
 file1='Cargo.toml'
 file2='README.tpl'
 file3='.code-samples.meilisearch.yaml'
 file4='README.md'
+file5='./meilisearch-index-setting-macro/Cargo.toml'
 
 file_tag1=$(grep '^version = ' $file1 | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')
+file_tag_1_1=$(grep '{ path = "meilisearch-index-setting-macro", version =' $file1 | grep -Eo '[0-9]+.[0-9]+.[0-9]+')
 file_tag2=$(grep 'meilisearch-sdk = ' $file2 | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')
 file_tag3=$(grep 'meilisearch-sdk = ' $file3 | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')
 file_tag4=$(grep 'meilisearch-sdk = ' $file4 | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')
-if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" ] || [ "$cropped_current_tag" != "$file_tag3" ] || [ "$current_tag" != "$file_tag4" ]; then
+file_tag5=$(grep '^version = ' $file5 | grep -Eo '[0-9]+.[0-9]+.[0-9]+')
+file_tag5_1=$(grep '{ path = \"..\", version =' $file5 | grep -Eo '[0-9]+.[0-9]+.[0-9]+')
+
+if [ "$current_tag" != "$file_tag1" ] ||
+  [ "$current_tag" != "$file_tag_1_1" ] ||
+  [ "$current_tag" != "$file_tag2" ] ||
+  [ "$cropped_current_tag" != "$file_tag3" ] ||
+  [ "$current_tag" != "$file_tag4" ] ||
+  [ "$current_tag" != "$file_tag5" ] ||
+  [ "$current_tag" != "$file_tag5_1" ] \
+  ; then
   echo "Error: the current tag does not match the version in package file(s)."
   echo "$file1: found $file_tag1 - expected $current_tag"
+  echo "$file1: found $file_tag_1_1 - expected $current_tag"
   echo "$file2: found $file_tag2 - expected $current_tag"
   echo "$file3: found $file_tag3 - expected $cropped_current_tag"
   echo "$file4: found $file_tag4 - expected $current_tag"
+  echo "$file5: found $file_tag5 - expected $current_tag"
+  echo "$file5: found $file_tag5_1 - expected $current_tag"
   exit 1
 fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,12 @@ Make a PR modifying the file [`Cargo.toml`](/Cargo.toml):
 version = "X.X.X"
 ```
 
+After the changes on `Cargo.toml`, run the following command: 
+
+```
+sh scripts/update_macro_versions.sh
+```
+
 and the [`README.tpl`](/README.tpl):
 
 ```rust
@@ -181,13 +187,13 @@ and the [`README.tpl`](/README.tpl):
 
 with the right version.
 
-You should run the following command after the changes applied to `lib.rs`:
+After the changes on `lib.rs`, run the following command:
 
 ```bash
 sh scripts/update-readme.sh
 ```
 
-Also, you might need to change the [code-samples file](/.code-samples.meilisearch.yaml) if the minor has been upgraded:
+You might need to change the [code-samples file](/.code-samples.meilisearch.yaml) if the minor has been upgraded:
 
 ```yml
   meilisearch-sdk = "X.X"

--- a/scripts/update_macro_versions.sh
+++ b/scripts/update_macro_versions.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+new_version=$(cat Cargo.toml | grep '^version = ')
+
+# Updates the versions in meilisearch-rust and meilisearch-index-setting-macro of the latter, with the latest meilisearch-rust version.
+
+old_index_macro_version=$(cat ./meilisearch-index-setting-macro/Cargo.toml | grep '^version = ')
+old_sdk_in_macro_version=$(cat ./meilisearch-index-setting-macro/Cargo.toml | grep 'meilisearch-sdk = { path = "..", version = ')
+old_macro_in_sdk_version=$(cat ./Cargo.toml | grep '{ path = "meilisearch-index-setting-macro", version =')
+
+sed -i '' -e "s/^$old_index_macro_version/$new_version/g" './meilisearch-index-setting-macro/Cargo.toml'
+sed -i '' -e "s/^$old_sdk_in_macro_version/meilisearch-sdk = { path = \"..\", $new_version }/g" './meilisearch-index-setting-macro/Cargo.toml'
+sed -i '' -e "s/$old_macro_in_sdk_version/meilisearch-index-setting-macro = { path = \"meilisearch-index-setting-macro\", $new_version }/g" './Cargo.toml'


### PR DESCRIPTION
When publishing the package, both meilisearch and meilisearch-index-setting-macro are published. 
If `meilisearch-index-setting-macro` has not seen its version updated, the publishing will fail as the current version on crates is the same as the one being published.

To tackle this issue without to much hassle, both the macro and `meilisearch-rust` are going to share the same version.

This PR creates a script to automatically update the versions and check if they are correct