### PR TITLE
adds AWC as client option. Need test work for Document

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ yaup = "0.2.0"
 either = { version = "1.8.0", features = ["serde"] }
 thiserror = "1.0.37"
 meilisearch-index-setting-macro = { path = "meilisearch-index-setting-macro", version = "0.22.0" }
-
+awc = {version = "3.1.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures = "0.3"
@@ -36,9 +36,11 @@ web-sys = { version = "0.3", features = ["RequestInit", "Headers", "Window", "Re
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 
+
 [features]
 default = ["isahc-static-curl"]
 isahc-static-curl = ["isahc/static-curl"]
+awc = ["awc/rustls"]
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,7 @@
 use crate::errors::{Error, MeilisearchError};
 use log::{error, trace, warn};
 use serde::{de::DeserializeOwned, Serialize};
+#[cfg(not(feature = "awc"))]
 use serde_json::{from_str, to_string};
 
 #[derive(Debug)]
@@ -23,6 +24,7 @@ pub fn add_query_parameters<Query: Serialize>(url: &str, query: &Query) -> Resul
     }
 }
 
+#[cfg(feature = "isahc-static-curl")]
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) async fn request<
     Query: Serialize,
@@ -224,6 +226,187 @@ pub(crate) async fn request<
     }
 }
 
+#[cfg(feature = "awc")]
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn request<
+    Query: Serialize,
+    Body: Serialize,
+    Output: DeserializeOwned + 'static,
+>(
+    url: &str,
+    apikey: &str,
+    method: Method<Query, Body>,
+    expected_status_code: u16,
+) -> Result<Output, Error> {
+    use awc::{error::JsonPayloadError, Client};
+
+    let client = Client::builder()
+        .add_default_header(("User-Agent".to_string(), qualified_version()))
+        .bearer_auth(apikey)
+        .finish();
+
+    let mut response = match &method {
+        Method::Get { query } => {
+            let url = add_query_parameters(url, query)?;
+
+            client.get(url).send().await?
+        }
+        Method::Delete { query } => {
+            let url = add_query_parameters(url, query)?;
+
+            client.delete(url).send().await?
+        }
+        Method::Post { query, body } => {
+            let url = add_query_parameters(url, query)?;
+            client.post(url).send_json(body).await?
+        }
+        Method::Patch { query, body } => {
+            let url = add_query_parameters(url, query)?;
+            client.patch(url).send_json(body).await?
+        }
+        Method::Put { query, body } => {
+            let url = add_query_parameters(url, query)?;
+            client.put(url).send_json(body).await?
+        }
+    };
+
+    let status_code = response.status().as_u16();
+    if status_code == expected_status_code {
+       response.json::<Output>().await.map_err(|e| {
+            error!("Request succeeded but failed to parse response");
+
+            match e {
+                JsonPayloadError::Deserialize(err) => Error::ParseError(err),
+                other => Error::ResponseParseError(other),
+            }
+        })
+    } else {
+        // TODO: create issue where it is clear what the HTTP error is
+        // ParseError(Error("invalid type: null, expected struct MeilisearchError", line: 1, column: 4))
+
+        warn!(
+            "Expected response code {}, got {}",
+            expected_status_code, status_code
+        );
+        match response.json::<MeilisearchError>().await {
+            Ok(e) => Err(Error::from(e)),
+            Err(e) => match e {
+                JsonPayloadError::Deserialize(err) => Err(Error::ParseError(err)),
+                other => Err(Error::ResponseParseError(other)),
+            },
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn add_query_parameters<Query: Serialize>(
+    mut url: String,
+    query: &Query,
+) -> Result<String, Error> {
+    let query = yaup::to_string(query)?;
+
+    if !query.is_empty() {
+        url = format!("{}?{}", url, query);
+    };
+    return Ok(url);
+}
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn request<
+    Query: Serialize,
+    Body: Serialize,
+    Output: DeserializeOwned + 'static,
+>(
+    url: &str,
+    apikey: &str,
+    method: Method<Query, Body>,
+    expected_status_code: u16,
+) -> Result<Output, Error> {
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_futures::JsFuture;
+    use web_sys::{Headers, RequestInit, Response};
+
+    const CONTENT_TYPE: &str = "Content-Type";
+    const JSON: &str = "application/json";
+
+    // The 2 following unwraps should not be able to fail
+    let mut mut_url = url.clone().to_string();
+    let headers = Headers::new().unwrap();
+    headers
+        .append("Authorization", format!("Bearer {}", apikey).as_str())
+        .unwrap();
+    headers
+        .append("X-Meilisearch-Client", qualified_version().as_str())
+        .unwrap();
+
+    let mut request: RequestInit = RequestInit::new();
+    request.headers(&headers);
+
+    match &method {
+        Method::Get { query } => {
+            mut_url = add_query_parameters(mut_url, &query)?;
+
+            request.method("GET");
+        }
+        Method::Delete { query } => {
+            mut_url = add_query_parameters(mut_url, &query)?;
+            request.method("DELETE");
+        }
+        Method::Patch { query, body } => {
+            mut_url = add_query_parameters(mut_url, &query)?;
+            request.method("PATCH");
+            headers.append(CONTENT_TYPE, JSON).unwrap();
+            request.body(Some(&JsValue::from_str(&to_string(body).unwrap())));
+        }
+        Method::Post { query, body } => {
+            mut_url = add_query_parameters(mut_url, &query)?;
+            request.method("POST");
+            headers.append(CONTENT_TYPE, JSON).unwrap();
+            request.body(Some(&JsValue::from_str(&to_string(body).unwrap())));
+        }
+        Method::Put { query, body } => {
+            mut_url = add_query_parameters(mut_url, &query)?;
+            request.method("PUT");
+            headers.append(CONTENT_TYPE, JSON).unwrap();
+            request.body(Some(&JsValue::from_str(&to_string(body).unwrap())));
+        }
+    }
+
+    let window = web_sys::window().unwrap(); // TODO remove this unwrap
+    let response =
+        match JsFuture::from(window.fetch_with_str_and_init(mut_url.as_str(), &request)).await {
+            Ok(response) => Response::from(response),
+            Err(e) => {
+                error!("Network error: {:?}", e);
+                return Err(Error::UnreachableServer);
+            }
+        };
+    let status = response.status() as u16;
+    let text = match response.text() {
+        Ok(text) => match JsFuture::from(text).await {
+            Ok(text) => text,
+            Err(e) => {
+                error!("Invalid response: {:?}", e);
+                return Err(Error::HttpError("Invalid response".to_string()));
+            }
+        },
+        Err(e) => {
+            error!("Invalid response: {:?}", e);
+            return Err(Error::HttpError("Invalid response".to_string()));
+        }
+    };
+
+    if let Some(t) = text.as_string() {
+        if t.is_empty() {
+            parse_response(status, expected_status_code, String::from("null"))
+        } else {
+            parse_response(status, expected_status_code, t)
+        }
+    } else {
+        error!("Invalid response");
+        Err(Error::HttpError("Invalid utf8".to_string()))
+    }
+}
+#[cfg(not(feature = "awc"))]
 fn parse_response<Output: DeserializeOwned>(
     status_code: u16,
     expected_status_code: u16,


### PR DESCRIPTION
# Pull Request

## Related issue
- None: Small change, so opening pr for visibility. The tests in `documents` will need to be rewritten to work with other clients before mainlining. Can also add a feature for reqwest if interest ( and work on tests is done ). 
- This pr allows users to drop isahc as a dependency when using actix_web and run in environments where the current isahc configuration does not support tls.    

## What does this PR do?
- Adds feature for using Actix Web Client as the request client.
- Will need cleanup before mainlining.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
