### PR TITLE
Fix invalid type error in getting_started_add_documents_md

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -971,7 +971,7 @@ getting_started_add_documents_md: |-
   ```rust
   #[derive(Serialize, Deserialize)]
   struct Movie {
-    id: String,
+    id: i64,
     title: String,
     poster: String,
     overview: String,

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -986,7 +986,7 @@ getting_started_add_documents_md: |-
   ```rust
   #[derive(Serialize, Deserialize)]
   struct Movie {
-    id: String,
+    id: i64,
     #[serde(flatten)]
     value: serde_json::Value,
   }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #434

## What does this PR do?
- Fix a panic caused by running sample code from the quickstart section ["Add documents"](https://docs.meilisearch.com/learn/getting_started/quick_start.html#add-documents)

## PR checklist
Please check if your PR fulfills the following requirements:
- [ x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ x] Have you read the contributing guidelines?
- [ x] Have you made sure that the title is accurate and descriptive of the changes?