### PR TITLE
Add facetstats for Meilisearch v1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ isahc-static-curl = ["isahc/static-curl"]
 env_logger = "0.10"
 futures-await-test = "0.3"
 futures = "0.3"
-mockito = "0.32.3"
+mockito = "1.0.0"
 meilisearch-test-macro = { path = "meilisearch-test-macro" }
 tokio = { version = "1", features = ["rt", "macros"] }
 

--- a/meilisearch-test-macro/src/lib.rs
+++ b/meilisearch-test-macro/src/lib.rs
@@ -169,9 +169,7 @@ pub fn meilisearch_test(params: TokenStream, input: TokenStream) -> TokenStream 
 
         outer_fn.sig.inputs.clear();
         outer_fn.sig.asyncness = inner_fn.sig.asyncness.clone();
-        outer_fn
-            .attrs
-            .push(parse_quote!(#[futures_await_test::async_test]));
+        outer_fn.attrs.push(parse_quote!(#[tokio::test]));
         outer_fn.block.stmts = outer_block;
     } else {
         panic!("#[meilisearch_test] can only be applied to async functions")

--- a/src/client.rs
+++ b/src/client.rs
@@ -1039,10 +1039,7 @@ pub struct Version {
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
-
     use big_s::S;
-    use mockito::mock;
     use time::OffsetDateTime;
 
     use meilisearch_test_macro::meilisearch_test;
@@ -1108,22 +1105,25 @@ mod tests {
 
     #[meilisearch_test]
     async fn test_methods_has_qualified_version_as_header() {
-        let mock_server_url = &mockito::server_url();
+        let mut s = mockito::Server::new_async().await;
+        let mock_server_url = s.url();
         let path = "/hello";
         let address = &format!("{}{}", mock_server_url, path);
         let user_agent = &*qualified_version();
 
         let assertions = vec![
             (
-                mock("GET", path)
+                s.mock("GET", path)
                     .match_header("User-Agent", user_agent)
-                    .create(),
+                    .create_async()
+                    .await,
                 request::<(), (), ()>(address, "", Method::Get { query: () }, 200),
             ),
             (
-                mock("POST", path)
+                s.mock("POST", path)
                     .match_header("User-Agent", user_agent)
-                    .create(),
+                    .create_async()
+                    .await,
                 request::<(), (), ()>(
                     address,
                     "",
@@ -1135,15 +1135,17 @@ mod tests {
                 ),
             ),
             (
-                mock("DELETE", path)
+                s.mock("DELETE", path)
                     .match_header("User-Agent", user_agent)
-                    .create(),
+                    .create_async()
+                    .await,
                 request::<(), (), ()>(address, "", Method::Delete { query: () }, 200),
             ),
             (
-                mock("PUT", path)
+                s.mock("PUT", path)
                     .match_header("User-Agent", user_agent)
-                    .create(),
+                    .create_async()
+                    .await,
                 request::<(), (), ()>(
                     address,
                     "",
@@ -1155,9 +1157,10 @@ mod tests {
                 ),
             ),
             (
-                mock("PATCH", path)
+                s.mock("PATCH", path)
                     .match_header("User-Agent", user_agent)
-                    .create(),
+                    .create_async()
+                    .await,
                 request::<(), (), ()>(
                     address,
                     "",
@@ -1173,8 +1176,7 @@ mod tests {
         for (m, req) in assertions {
             let _ = req.await;
 
-            m.assert();
-            mem::drop(m);
+            m.assert_async().await;
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -48,6 +48,12 @@ pub struct SearchResult<T> {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+pub struct FacetStats {
+    pub min: u32,
+    pub max: u32,
+}
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 /// A struct containing search results and other information about the search.
 pub struct SearchResults<T> {
     /// Results of the query
@@ -68,6 +74,8 @@ pub struct SearchResults<T> {
     pub total_pages: Option<usize>,
     /// Distribution of the given facets
     pub facet_distribution: Option<HashMap<String, HashMap<String, usize>>>,
+    /// facet stats of the numerical facets requested in the `facet` search parameter.
+    pub facet_stats: Option<HashMap<String, FacetStats>>,
     /// Processing time of the query
     pub processing_time_ms: usize,
     /// Query originating the response

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -698,7 +698,6 @@ mod test {
     };
     use big_s::S;
     use meilisearch_test_macro::meilisearch_test;
-    use mockito::mock;
     use serde::{Deserialize, Serialize};
     use std::time::Duration;
 
@@ -846,25 +845,27 @@ mod test {
 
     #[meilisearch_test]
     async fn test_get_tasks_no_params() -> Result<(), Error> {
-        let mock_server_url = &mockito::server_url();
+        let mut s = mockito::Server::new_async().await;
+        let mock_server_url = s.url();
         let client = Client::new(mock_server_url, "masterKey");
         let path = "/tasks";
 
-        let mock_res = mock("GET", path).with_status(200).create();
+        let mock_res = s.mock("GET", path).with_status(200).create_async().await;
         let _ = client.get_tasks().await;
-        mock_res.assert();
+        mock_res.assert_async().await;
 
         Ok(())
     }
 
     #[meilisearch_test]
     async fn test_get_tasks_with_params() -> Result<(), Error> {
-        let mock_server_url = &mockito::server_url();
+        let mut s = mockito::Server::new_async().await;
+        let mock_server_url = s.url();
         let client = Client::new(mock_server_url, "masterKey");
         let path =
             "/tasks?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1&limit=0&from=1";
 
-        let mock_res = mock("GET", path).with_status(200).create();
+        let mock_res = s.mock("GET", path).with_status(200).create_async().await;
 
         let mut query = TasksSearchQuery::new(&client);
         query
@@ -877,13 +878,15 @@ mod test {
 
         let _ = client.get_tasks_with(&query).await;
 
-        mock_res.assert();
+        mock_res.assert_async().await;
+
         Ok(())
     }
 
     #[meilisearch_test]
     async fn test_get_tasks_with_date_params() -> Result<(), Error> {
-        let mock_server_url = &mockito::server_url();
+        let mut s = mockito::Server::new_async().await;
+        let mock_server_url = s.url();
         let client = Client::new(mock_server_url, "masterKey");
         let path = "/tasks?\
             beforeEnqueuedAt=2022-02-03T13%3A02%3A38.369634Z\
@@ -893,7 +896,7 @@ mod test {
             &beforeFinishedAt=2026-02-03T13%3A02%3A38.369634Z\
             &afterFinishedAt=2027-02-03T13%3A02%3A38.369634Z";
 
-        let mock_res = mock("GET", path).with_status(200).create();
+        let mock_res = s.mock("GET", path).with_status(200).create_async().await;
 
         let before_enqueued_at = OffsetDateTime::parse(
             "2022-02-03T13:02:38.369634Z",
@@ -940,18 +943,20 @@ mod test {
 
         let _ = client.get_tasks_with(&query).await;
 
-        mock_res.assert();
+        mock_res.assert_async().await;
+
         Ok(())
     }
 
     #[meilisearch_test]
     async fn test_get_tasks_on_struct_with_params() -> Result<(), Error> {
-        let mock_server_url = &mockito::server_url();
+        let mut s = mockito::Server::new_async().await;
+        let mock_server_url = s.url();
         let client = Client::new(mock_server_url, "masterKey");
         let path =
             "/tasks?indexUids=movies,test&statuses=equeued&types=documentDeletion&canceledBy=9";
 
-        let mock_res = mock("GET", path).with_status(200).create();
+        let mock_res = s.mock("GET", path).with_status(200).create_async().await;
 
         let mut query = TasksSearchQuery::new(&client);
         let _ = query
@@ -962,7 +967,8 @@ mod test {
             .execute()
             .await;
 
-        mock_res.assert();
+        mock_res.assert_async().await;
+
         Ok(())
     }
 
@@ -1005,12 +1011,13 @@ mod test {
 
     #[meilisearch_test]
     async fn test_cancel_tasks_with_params() -> Result<(), Error> {
-        let mock_server_url = &mockito::server_url();
+        let mut s = mockito::Server::new_async().await;
+        let mock_server_url = s.url();
         let client = Client::new(mock_server_url, "masterKey");
         let path =
             "/tasks/cancel?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1";
 
-        let mock_res = mock("POST", path).with_status(200).create();
+        let mock_res = s.mock("POST", path).with_status(200).create_async().await;
 
         let mut query = TasksCancelQuery::new(&client);
         query
@@ -1021,18 +1028,20 @@ mod test {
 
         let _ = client.cancel_tasks_with(&query).await;
 
-        mock_res.assert();
+        mock_res.assert_async().await;
+
         Ok(())
     }
 
     #[meilisearch_test]
     async fn test_cancel_tasks_with_params_execute() -> Result<(), Error> {
-        let mock_server_url = &mockito::server_url();
+        let mut s = mockito::Server::new_async().await;
+        let mock_server_url = s.url();
         let client = Client::new(mock_server_url, "masterKey");
         let path =
             "/tasks/cancel?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1";
 
-        let mock_res = mock("POST", path).with_status(200).create();
+        let mock_res = s.mock("POST", path).with_status(200).create_async().await;
 
         let mut query = TasksCancelQuery::new(&client);
         let _ = query
@@ -1043,17 +1052,20 @@ mod test {
             .execute()
             .await;
 
-        mock_res.assert();
+        mock_res.assert_async().await;
+
         Ok(())
     }
 
     #[meilisearch_test]
     async fn test_delete_tasks_with_params() -> Result<(), Error> {
-        let mock_server_url = &mockito::server_url();
+        let mut s = mockito::Server::new_async().await;
+        //         let mut s = mockito::Server::new_async().await;
+        let mock_server_url = s.url();
         let client = Client::new(mock_server_url, "masterKey");
         let path = "/tasks?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1";
 
-        let mock_res = mock("DELETE", path).with_status(200).create();
+        let mock_res = s.mock("DELETE", path).with_status(200).create_async().await;
 
         let mut query = TasksDeleteQuery::new(&client);
         query
@@ -1064,17 +1076,19 @@ mod test {
 
         let _ = client.delete_tasks_with(&query).await;
 
-        mock_res.assert();
+        mock_res.assert_async().await;
+
         Ok(())
     }
 
     #[meilisearch_test]
     async fn test_delete_tasks_with_params_execute() -> Result<(), Error> {
-        let mock_server_url = &mockito::server_url();
+        let mut s = mockito::Server::new_async().await;
+        let mock_server_url = s.url();
         let client = Client::new(mock_server_url, "masterKey");
         let path = "/tasks?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1";
 
-        let mock_res = mock("DELETE", path).with_status(200).create();
+        let mock_res = s.mock("DELETE", path).with_status(200).create_async().await;
 
         let mut query = TasksDeleteQuery::new(&client);
         let _ = query
@@ -1085,7 +1099,8 @@ mod test {
             .execute()
             .await;
 
-        mock_res.assert();
+        mock_res.assert_async().await;
+
         Ok(())
     }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1060,7 +1060,6 @@ mod test {
     #[meilisearch_test]
     async fn test_delete_tasks_with_params() -> Result<(), Error> {
         let mut s = mockito::Server::new_async().await;
-        //         let mut s = mockito::Server::new_async().await;
         let mock_server_url = s.url();
         let client = Client::new(mock_server_url, "masterKey");
         let path = "/tasks?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1";


### PR DESCRIPTION
Add the `facetStats` type in the `SearchResults` structure. It introduces min max values for numeric facet that have been required through the search parameter facet 

As per [the specification](https://github.com/meilisearch/specifications/pull/224)

SDK requirements: https://github.com/meilisearch/integration-guides/issues/251