### PR TITLE
Fix the build issues introduced by latest serde patch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ To install dependencies:
 cargo build --release
 ```
 
+To ensure the same dependency versions in all environments, for example the CI, update the dependencies by running: `cargo update`.
+
 ### Tests <!-- omit in toc -->
 
 To run the tests, run:

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -16,7 +16,6 @@ pub struct PaginationSetting {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct FacetingSettings {
-    #[serde()]
     pub max_values_per_facet: usize,
 }
 


### PR DESCRIPTION
In the latest serde patch version a breaking change led to a build error. 
By installing the project for the first time, the latest patch versions are installed. This is not the case in an already existing project unless `cargo update` is ran.
