### PR TITLE
make the api key optional

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -779,7 +779,7 @@ add_movies_json_1: |-
   use futures::executor::block_on;
 
   fn main() { block_on(async move {
-    let client = Client::new("http://localhost:7700", "masterKey");
+    let client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // reading and parsing the file
     let mut file = File::open("movies.json")
@@ -903,7 +903,7 @@ getting_started_add_documents_md: |-
   use futures::executor::block_on;
 
   fn main() { block_on(async move {
-    let client = Client::new("http://localhost:7700", "masterKey");
+    let client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // reading and parsing the file
     let mut file = File::open("movies.json")
@@ -1022,7 +1022,7 @@ getting_started_update_displayed_attributes: |-
     .await
     .unwrap();
 getting_started_communicating_with_a_protected_instance: |-
-  let client = Client::new("http://localhost:7700", "apiKey");
+  let client = Client::new("http://localhost:7700", Some("apiKey"));
   client
     .index("movies")
     .search()
@@ -1385,20 +1385,20 @@ delete_a_key_1: |-
     .delete_key(&key)
     .await?;
 authorization_header_1:
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let keys = client
   .get_keys()
   .await
   .unwrap();
 security_guide_search_key_1: |-
-  let client = Client::new("http://localhost:7700", "apiKey");
+  let client = Client::new("http://localhost:7700", Some("apiKey"));
   let result = client.index("patient_medical_records")
     .search()
     .execute()
     .await
     .unwrap();
 security_guide_update_key_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let mut key = client
     .get_key("74c9c733-3368-4738-bbe5-1d18a5fecb37")
     .await
@@ -1407,7 +1407,7 @@ security_guide_update_key_1: |-
     .with_description("Default Search API key".to_string())
     .update(&client);
 security_guide_create_key_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let mut key_options = KeyBuilder::new("Search patient records key");
   key_options
     .with_action(Action::Search)
@@ -1418,13 +1418,13 @@ security_guide_create_key_1: |-
     .await
     .unwrap();
 security_guide_list_keys_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let keys = client
     .get_keys()
     .await
     .unwrap();
 security_guide_delete_key_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let key = client
     .get_key("ac5cd97d-5a4b-4226-a868-2d0eb6d197ab")
     .await
@@ -1433,7 +1433,7 @@ security_guide_delete_key_1: |-
     .delete_key(&key)
     .await?;
 landing_getting_started_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
 
   #[derive(Serialize, Deserialize)]
   struct Movie {
@@ -1462,7 +1462,7 @@ tenant_token_guide_generate_sdk_1: |-
     .generate_tenant_token(api_key_uid, search_rules, api_key, expires_at)
     .unwrap();
 tenant_token_guide_search_sdk_1: |-
-  let front_end_client = Client::new("http://localhost:7700", token);
+  let front_end_client = Client::new("http://localhost:7700", Some(token));
   let results: SearchResults<Patient> = front_end_client
     .index("patient_medical_records")
     .search()

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ struct Movie {
 
 fn main() { block_on(async move {
     // Create a client (without sending any request so that can't fail)
-    let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 
     // An index is where the documents are stored.
     let movies = client.index("movies");

--- a/examples/cli-app/src/main.rs
+++ b/examples/cli-app/src/main.rs
@@ -7,7 +7,7 @@ use std::io::stdin;
 
 // instantiate the client. load it once
 lazy_static! {
-    static ref CLIENT: Client = Client::new("http://localhost:7700", "masterKey");
+    static ref CLIENT: Client = Client::new("http://localhost:7700", Some("masterKey"));
 }
 
 fn main() {

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -5,7 +5,7 @@ use meilisearch_sdk::settings::Settings;
 // we need an async runtime
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let client: Client = Client::new("http://localhost:7700", "masterKey");
+    let client: Client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // We try to create an index called `movies` with a primary_key of `movie_id`.
     let my_index: Index = client

--- a/examples/web_app/src/lib.rs
+++ b/examples/web_app/src/lib.rs
@@ -16,7 +16,7 @@ mod document;
 use crate::document::{display, Crate};
 
 lazy_static! {
-    static ref CLIENT: Client = Client::new("http://localhost:7700", "masterKey",);
+    static ref CLIENT: Client = Client::new("http://localhost:7700", Some("masterKey"));
 }
 
 struct Model {

--- a/meilisearch-test-macro/src/lib.rs
+++ b/meilisearch-test-macro/src/lib.rs
@@ -89,7 +89,7 @@ pub fn meilisearch_test(params: TokenStream, input: TokenStream) -> TokenStream 
                 let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
             ));
             outer_block.push(parse_quote!(
-                let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+                let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
             ));
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Client {
     pub(crate) host: String,
-    pub(crate) api_key: String,
+    pub(crate) api_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,10 +40,10 @@ impl Client {
     /// // create the client
     /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
     /// ```
-    pub fn new(host: impl Into<String>, api_key: impl Into<String>) -> Client {
+    pub fn new(host: impl Into<String>, api_key: Option<impl Into<String>>) -> Client {
         Client {
             host: host.into(),
-            api_key: api_key.into(),
+            api_key: api_key.map(|key| key.into()),
         }
     }
 
@@ -91,8 +91,8 @@ impl Client {
     ///
     /// assert_eq!(client.get_api_key(), "doggo");
     /// ```
-    pub fn get_api_key(&self) -> &str {
-        &self.api_key
+    pub fn get_api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
     }
 
     /// List all [Index]es with query parameters and returns values as instances of [Index].
@@ -170,7 +170,7 @@ impl Client {
     pub async fn list_all_indexes_raw(&self) -> Result<Value, Error> {
         let json_indexes = request::<(), (), Value>(
             &format!("{}/indexes", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -206,7 +206,7 @@ impl Client {
     ) -> Result<Value, Error> {
         let json_indexes = request::<&IndexesQuery, (), Value>(
             &format!("{}/indexes", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get {
                 query: indexes_query,
             },
@@ -269,7 +269,7 @@ impl Client {
     pub async fn get_raw_index(&self, uid: impl AsRef<str>) -> Result<Value, Error> {
         request::<(), (), Value>(
             &format!("{}/indexes/{}", self.host, uid.as_ref()),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -316,7 +316,7 @@ impl Client {
     ) -> Result<TaskInfo, Error> {
         request::<(), Value, TaskInfo>(
             &format!("{}/indexes", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Post {
                 query: (),
                 body: json!({
@@ -334,7 +334,7 @@ impl Client {
     pub async fn delete_index(&self, uid: impl AsRef<str>) -> Result<TaskInfo, Error> {
         request::<(), (), TaskInfo>(
             &format!("{}/indexes/{}", self.host, uid.as_ref()),
-            &self.api_key,
+            self.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -407,7 +407,7 @@ impl Client {
     ) -> Result<TaskInfo, Error> {
         request::<(), Vec<&SwapIndexes>, TaskInfo>(
             &format!("{}/swap-indexes", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Post {
                 query: (),
                 body: indexes.into_iter().collect(),
@@ -435,7 +435,7 @@ impl Client {
     pub async fn get_stats(&self) -> Result<ClientStats, Error> {
         request::<(), (), ClientStats>(
             &format!("{}/stats", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -461,7 +461,7 @@ impl Client {
     pub async fn health(&self) -> Result<Health, Error> {
         request::<(), (), Health>(
             &format!("{}/health", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -517,7 +517,7 @@ impl Client {
     pub async fn get_keys_with(&self, keys_query: &KeysQuery) -> Result<KeysResults, Error> {
         let keys = request::<&KeysQuery, (), KeysResults>(
             &format!("{}/keys", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: keys_query },
             200,
         )
@@ -549,7 +549,7 @@ impl Client {
     pub async fn get_keys(&self) -> Result<KeysResults, Error> {
         let keys = request::<(), (), KeysResults>(
             &format!("{}/keys", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -585,7 +585,7 @@ impl Client {
     pub async fn get_key(&self, key: impl AsRef<str>) -> Result<Key, Error> {
         request::<(), (), Key>(
             &format!("{}/keys/{}", self.host, key.as_ref()),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -620,7 +620,7 @@ impl Client {
     pub async fn delete_key(&self, key: impl AsRef<str>) -> Result<(), Error> {
         request::<(), (), ()>(
             &format!("{}/keys/{}", self.host, key.as_ref()),
-            &self.api_key,
+            self.get_api_key(),
             Method::Delete { query: () },
             204,
         )
@@ -654,7 +654,7 @@ impl Client {
     pub async fn create_key(&self, key: impl AsRef<KeyBuilder>) -> Result<Key, Error> {
         request::<(), &KeyBuilder, Key>(
             &format!("{}/keys", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Post {
                 query: (),
                 body: key.as_ref(),
@@ -693,7 +693,7 @@ impl Client {
     pub async fn update_key(&self, key: impl AsRef<KeyUpdater>) -> Result<Key, Error> {
         request::<(), &KeyUpdater, Key>(
             &format!("{}/keys/{}", self.host, key.as_ref().key),
-            &self.api_key,
+            self.get_api_key(),
             Method::Patch {
                 body: key.as_ref(),
                 query: (),
@@ -721,7 +721,7 @@ impl Client {
     pub async fn get_version(&self) -> Result<Version, Error> {
         request::<(), (), Version>(
             &format!("{}/version", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -822,7 +822,7 @@ impl Client {
     pub async fn get_task(&self, task_id: impl AsRef<u32>) -> Result<Task, Error> {
         request::<(), (), Task>(
             &format!("{}/tasks/{}", self.host, task_id.as_ref()),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -853,7 +853,7 @@ impl Client {
     ) -> Result<TasksResults, Error> {
         let tasks = request::<&TasksSearchQuery, (), TasksResults>(
             &format!("{}/tasks", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: tasks_query },
             200,
         )
@@ -887,7 +887,7 @@ impl Client {
     ) -> Result<TaskInfo, Error> {
         let tasks = request::<&TasksCancelQuery, (), TaskInfo>(
             &format!("{}/tasks/cancel", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Post {
                 query: filters,
                 body: (),
@@ -924,7 +924,7 @@ impl Client {
     ) -> Result<TaskInfo, Error> {
         let tasks = request::<&TasksDeleteQuery, (), TaskInfo>(
             &format!("{}/tasks", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Delete { query: filters },
             200,
         )
@@ -953,7 +953,7 @@ impl Client {
     pub async fn get_tasks(&self) -> Result<TasksResults, Error> {
         let tasks = request::<(), (), TasksResults>(
             &format!("{}/tasks", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -987,7 +987,14 @@ impl Client {
         api_key: Option<&str>,
         expires_at: Option<OffsetDateTime>,
     ) -> Result<String, Error> {
-        let api_key = api_key.unwrap_or(&self.api_key);
+        let api_key = match self.get_api_key() {
+            Some(key) => api_key.unwrap_or(key),
+            None => {
+                return Err(Error::CantUseWithoutApiKey(
+                    "generate_tenant_token".to_string(),
+                ))
+            }
+        };
 
         crate::tenant_tokens::generate_tenant_token(api_key_uid, search_rules, api_key, expires_at)
     }
@@ -1117,7 +1124,7 @@ mod tests {
                     .match_header("User-Agent", user_agent)
                     .create_async()
                     .await,
-                request::<(), (), ()>(address, "", Method::Get { query: () }, 200),
+                request::<(), (), ()>(address, None, Method::Get { query: () }, 200),
             ),
             (
                 s.mock("POST", path)
@@ -1126,7 +1133,7 @@ mod tests {
                     .await,
                 request::<(), (), ()>(
                     address,
-                    "",
+                    None,
                     Method::Post {
                         query: (),
                         body: {},
@@ -1139,7 +1146,7 @@ mod tests {
                     .match_header("User-Agent", user_agent)
                     .create_async()
                     .await,
-                request::<(), (), ()>(address, "", Method::Delete { query: () }, 200),
+                request::<(), (), ()>(address, None, Method::Delete { query: () }, 200),
             ),
             (
                 s.mock("PUT", path)
@@ -1148,7 +1155,7 @@ mod tests {
                     .await,
                 request::<(), (), ()>(
                     address,
-                    "",
+                    None,
                     Method::Put {
                         query: (),
                         body: (),
@@ -1163,7 +1170,7 @@ mod tests {
                     .await,
                 request::<(), (), ()>(
                     address,
-                    "",
+                    None,
                     Method::Patch {
                         query: (),
                         body: (),
@@ -1237,7 +1244,7 @@ mod tests {
         let key = client.create_key(key).await.unwrap();
         let master_key = client.api_key.clone();
         // this key has no right
-        client.api_key = key.key.clone();
+        client.api_key = Some(key.key.clone());
         // with a wrong key
         let error = client.delete_key("invalid_key").await.unwrap_err();
         assert!(matches!(
@@ -1312,7 +1319,7 @@ mod tests {
 
         // backup the master key for cleanup at the end of the test
         let master_client = client.clone();
-        client.api_key = no_right_key.key.clone();
+        client.api_key = Some(no_right_key.key.clone());
 
         let mut key = KeyBuilder::new();
         key.with_name(format!("{name}_2"));
@@ -1328,7 +1335,10 @@ mod tests {
         ));
 
         // cleanup
-        master_client.delete_key(&*client.api_key).await.unwrap();
+        master_client
+            .delete_key(client.api_key.unwrap())
+            .await
+            .unwrap();
     }
 
     #[meilisearch_test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,7 +38,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// ```
     pub fn new(host: impl Into<String>, api_key: Option<impl Into<String>>) -> Client {
         Client {
@@ -71,7 +71,7 @@ impl Client {
     /// # use meilisearch_sdk::{client::*};
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// // create the client
-    /// let client = Client::new("http://doggo.dog", MEILISEARCH_API_KEY);
+    /// let client = Client::new("http://doggo.dog", Some(MEILISEARCH_API_KEY));
     ///
     /// assert_eq!(client.get_host(), "http://doggo.dog");
     /// ```
@@ -87,9 +87,9 @@ impl Client {
     /// # use meilisearch_sdk::{client::*};
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, "doggo");
+    /// let client = Client::new(MEILISEARCH_URL, Some("doggo"));
     ///
-    /// assert_eq!(client.get_api_key(), "doggo");
+    /// assert_eq!(client.get_api_key(), Some("doggo"));
     /// ```
     pub fn get_api_key(&self) -> Option<&str> {
         self.api_key.as_deref()
@@ -107,7 +107,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// let indexes: IndexesResults = client.list_all_indexes().await.unwrap();
     /// println!("{:?}", indexes);
@@ -131,7 +131,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let mut query = IndexesQuery::new(&client);
     /// query.with_limit(1);
     /// let indexes: IndexesResults = client.list_all_indexes_with(&query).await.unwrap();
@@ -161,7 +161,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// let json_indexes = client.list_all_indexes_raw().await.unwrap();
     /// println!("{:?}", json_indexes);
@@ -191,7 +191,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// let mut query = IndexesQuery::new(&client);
     /// query.with_limit(1);
@@ -229,7 +229,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client.create_index("get_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_index"
@@ -256,7 +256,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client.create_index("get_raw_index", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "get_raw_index"
@@ -294,7 +294,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // Create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// // Create a new index called movies and access it
     /// let task = client.create_index("create_index", None).await.unwrap();
@@ -379,7 +379,7 @@ impl Client {
     /// #
     /// # futures::executor::block_on(async move {
     /// // Create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// let task_index_1 = client.create_index("swap_index_1", None).await.unwrap();
     /// let task_index_2 = client.create_index("swap_index_2", None).await.unwrap();
@@ -428,7 +428,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let stats = client.get_stats().await.unwrap();
     /// # });
     /// ```
@@ -453,7 +453,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let health = client.health().await.unwrap();
     /// assert_eq!(health.status, "available");
     /// # });
@@ -479,7 +479,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let health = client.is_healthy().await;
     /// assert_eq!(health, true);
     /// # });
@@ -506,7 +506,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let mut query = KeysQuery::new();
     /// query.with_limit(1);
     /// let keys = client.get_keys_with(&query).await.unwrap();
@@ -540,7 +540,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let keys = client.get_keys().await.unwrap();
     ///
     /// assert_eq!(keys.limit, 20);
@@ -572,7 +572,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let key = client.get_keys().await.unwrap().results.into_iter()
     ///     .find(|k| k.name.as_ref().map_or(false, |name| name.starts_with("Default Search API Key")))
     ///     .unwrap();
@@ -606,7 +606,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let key = KeyBuilder::new();
     /// let key = client.create_key(key).await.unwrap();
     /// let inner_key = key.key.clone();
@@ -641,7 +641,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let name = "create_key".to_string();
     /// let mut key = KeyBuilder::new();
     /// key.with_name(&name);
@@ -678,7 +678,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let new_key = KeyBuilder::new();
     /// let name = "my name".to_string();
     /// let mut new_key = client.create_key(new_key).await.unwrap();
@@ -714,7 +714,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let version = client.get_version().await.unwrap();
     /// # });
     /// ```
@@ -756,7 +756,7 @@ impl Client {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movies = client.index("movies_client_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -812,7 +812,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = client::Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client.create_index("movies_get_task", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     /// let task = index.delete_all_documents().await.unwrap();
     /// let task = client.get_task(task).await.unwrap();
@@ -840,7 +840,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = client::Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// let mut query = tasks::TasksSearchQuery::new(&client);
     /// query.with_index_uids(["get_tasks_with"]);
@@ -873,7 +873,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = client::Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// let mut query = tasks::TasksCancelQuery::new(&client);
     /// query.with_index_uids(["movies"]);
@@ -910,7 +910,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = client::Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// let mut query = tasks::TasksDeleteQuery::new(&client);
     /// query.with_index_uids(["movies"]);
@@ -944,7 +944,7 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = client::Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let tasks = client.get_tasks().await.unwrap();
     ///
     /// # assert!(tasks.results.len() > 0);
@@ -973,10 +973,10 @@ impl Client {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = client::Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = client::Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let api_key_uid = "76cf8b87-fd12-4688-ad34-260d930ca4f4".to_string();
     /// let token = client.generate_tenant_token(api_key_uid, serde_json::json!(["*"]), None, None).unwrap();
-    /// let client = client::Client::new(MEILISEARCH_URL, token);
+    /// let client = client::Client::new(MEILISEARCH_URL, Some(token));
     /// # });
     /// ```
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -99,7 +99,7 @@ impl<'a> DocumentQuery<'a> {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let index = client.index("document_query_with_fields");
     /// let mut document_query = DocumentQuery::new(&index);
     ///
@@ -124,7 +124,7 @@ impl<'a> DocumentQuery<'a> {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// # futures::executor::block_on(async move {
     /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -203,7 +203,7 @@ impl<'a> DocumentsQuery<'a> {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let index = client.index("my_index");
     ///
     /// let mut documents_query = DocumentsQuery::new(&index).with_offset(1);
@@ -223,7 +223,7 @@ impl<'a> DocumentsQuery<'a> {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let index = client.index("my_index");
     ///
     /// let mut documents_query = DocumentsQuery::new(&index);
@@ -245,7 +245,7 @@ impl<'a> DocumentsQuery<'a> {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let index = client.index("my_index");
     ///
     /// let mut documents_query = DocumentsQuery::new(&index);
@@ -271,7 +271,7 @@ impl<'a> DocumentsQuery<'a> {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// # futures::executor::block_on(async move {
     /// # let index = client.create_index("documents_query_execute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -23,7 +23,7 @@
 //! # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
 //! # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 //! #
-//! let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+//! let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 //!
 //! // Create a dump
 //! let task_info = client.create_dump().await.unwrap();
@@ -57,7 +57,7 @@ impl Client {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// #
     /// let task_info = client.create_dump().await.unwrap();
     /// assert!(matches!(

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -72,7 +72,7 @@ impl Client {
     pub async fn create_dump(&self) -> Result<TaskInfo, Error> {
         request::<(), (), TaskInfo>(
             &format!("{}/dumps", self.host),
-            &self.api_key,
+            self.get_api_key(),
             Method::Post {
                 query: (),
                 body: (),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,6 +25,9 @@ pub enum Error {
     #[error("Unable to generate a valid HTTP request. It probably comes from an invalid API key.")]
     InvalidRequest,
 
+    /// Can't call this method without setting an api key in the client.
+    #[error("You need to provide an api key to use the `{0}` method.")]
+    CantUseWithoutApiKey(String),
     /// It is not possible to generate a tenant token with a invalid api key.
     /// Empty strings or with less than 8 characters are considered invalid.
     #[error("The provided api_key is invalid.")]

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -24,7 +24,7 @@ use time::OffsetDateTime;
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
 /// # futures::executor::block_on(async move {
-/// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+/// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 ///
 /// // get the index called movies or create it if it does not exist
 /// let movies = client
@@ -52,7 +52,7 @@ use time::OffsetDateTime;
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
 /// # futures::executor::block_on(async move {
-/// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+/// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 ///
 /// // Meilisearch would be able to create the index if it does not exist during:
 /// // - the documents addition (add and update routes)
@@ -120,7 +120,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let mut index = client
     /// #   .create_index("index_update", None)
     /// #   .await
@@ -166,7 +166,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client.create_index("delete", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the index named "movies" and delete it
@@ -205,7 +205,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movies = client.index("execute_query");
     ///
     /// // add some documents
@@ -250,7 +250,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let mut movies = client.index("search");
     ///
     /// // add some documents
@@ -292,7 +292,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movies = client.index("get_document");
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
@@ -335,7 +335,7 @@ impl Index {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// # futures::executor::block_on(async move {
     /// #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -405,7 +405,7 @@ impl Index {
     ///
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movie_index = client.index("get_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -454,7 +454,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// let movie_index = client.index("get_documents_with");
     ///
@@ -514,7 +514,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movie_index = client.index("add_or_replace");
     ///
     /// let task = movie_index.add_or_replace(&[
@@ -585,7 +585,7 @@ impl Index {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movie_index = client.index("add_or_replace_unchecked_payload");
     ///
     /// let task = movie_index.add_or_replace_unchecked_payload(
@@ -667,7 +667,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movie_index = client.index("add_or_update");
     ///
     /// let task = movie_index.add_or_update(&[
@@ -741,7 +741,7 @@ impl Index {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movie_index = client.index("add_or_replace_unchecked_payload");
     ///
     /// let task = movie_index.add_or_update_unchecked_payload(
@@ -808,7 +808,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movie_index = client.index("delete_all_documents");
     ///
     /// # movie_index.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -855,7 +855,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let mut movies = client.index("delete_document");
     ///
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -903,7 +903,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// #
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movies = client.index("delete_documents");
     ///
     /// // add some documents
@@ -960,7 +960,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client.create_index("fetch_info", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// // get the information of the index named "fetch_info"
@@ -989,7 +989,7 @@ impl Index {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let mut index = client.create_index("get_primary_key", Some("id")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let primary_key = index.get_primary_key().await.unwrap();
@@ -1025,7 +1025,7 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movies = client.index("get_task");
     ///
     /// let task = movies.add_documents(&[
@@ -1069,7 +1069,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client.create_index("get_tasks", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let tasks = index.get_tasks().await.unwrap();
@@ -1097,7 +1097,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client.create_index("get_tasks_with", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let mut query = TasksSearchQuery::new(&client);
@@ -1129,7 +1129,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client.create_index("get_stats", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
     ///
     /// let stats = index.get_stats().await.unwrap();
@@ -1174,7 +1174,7 @@ impl Index {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movies = client.index("movies_index_wait_for_task");
     ///
     /// let task = movies.add_documents(&[
@@ -1220,7 +1220,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movie_index = client.index("add_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[
@@ -1285,7 +1285,7 @@ impl Index {
     /// }
     ///
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movie_index = client.index("update_documents_in_batches");
     ///
     /// let tasks = movie_index.add_documents_in_batches(&[
@@ -1370,7 +1370,7 @@ impl AsRef<str> for Index {
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
 /// # futures::executor::block_on(async move {
-/// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+/// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 /// # let index = client
 /// #   .create_index("index_updater", None)
 /// #   .await
@@ -1425,7 +1425,7 @@ impl<'a> IndexUpdater<'a> {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client
     /// #   .create_index("index_updater_with_primary_key", None)
     /// #   .await
@@ -1467,7 +1467,7 @@ impl<'a> IndexUpdater<'a> {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client
     /// #   .create_index("index_updater_execute", None)
     /// #   .await
@@ -1538,7 +1538,7 @@ pub struct IndexStats {
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
 /// # futures::executor::block_on(async move {
-/// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+/// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 /// # let index = client
 /// #   .create_index("index_query_builder", None)
 /// #   .await
@@ -1600,7 +1600,7 @@ impl<'a> IndexesQuery<'a> {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client
     /// #   .create_index("index_query_with_offset", None)
     /// #   .await
@@ -1636,7 +1636,7 @@ impl<'a> IndexesQuery<'a> {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client
     /// #   .create_index("index_query_with_limit", None)
     /// #   .await
@@ -1670,7 +1670,7 @@ impl<'a> IndexesQuery<'a> {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # let index = client
     /// #   .create_index("index_query_with_execute", None)
     /// #   .await

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -178,7 +178,7 @@ impl Index {
     pub async fn delete(self) -> Result<TaskInfo, Error> {
         request::<(), (), TaskInfo>(
             &format!("{}/indexes/{}", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -223,7 +223,7 @@ impl Index {
     ) -> Result<SearchResults<T>, Error> {
         request::<(), &SearchQuery, SearchResults<T>>(
             &format!("{}/indexes/{}/search", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Post { body, query: () },
             200,
         )
@@ -315,7 +315,13 @@ impl Index {
             self.client.host, self.uid, document_id
         );
 
-        request::<(), (), T>(&url, &self.client.api_key, Method::Get { query: () }, 200).await
+        request::<(), (), T>(
+            &url,
+            self.client.get_api_key(),
+            Method::Get { query: () },
+            200,
+        )
+        .await
     }
 
     /// Get one document with parameters.
@@ -368,7 +374,7 @@ impl Index {
 
         request::<&DocumentQuery, (), T>(
             &url,
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get {
                 query: document_query,
             },
@@ -418,7 +424,7 @@ impl Index {
 
         request::<(), (), DocumentsResults<T>>(
             &url,
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -471,7 +477,7 @@ impl Index {
         let url = format!("{}/indexes/{}/documents", self.client.host, self.uid);
         request::<&DocumentsQuery, (), DocumentsResults<T>>(
             &url,
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get {
                 query: documents_query,
             },
@@ -549,7 +555,7 @@ impl Index {
         };
         request::<(), &[T], TaskInfo>(
             &url,
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Post {
                 query: (),
                 body: documents,
@@ -615,7 +621,7 @@ impl Index {
         };
         stream_request::<(), T, TaskInfo>(
             &url,
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Post {
                 query: (),
                 body: payload,
@@ -705,7 +711,7 @@ impl Index {
         };
         request::<(), &[T], TaskInfo>(
             &url,
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: documents,
@@ -771,7 +777,7 @@ impl Index {
         };
         stream_request::<(), T, TaskInfo>(
             &url,
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: payload,
@@ -822,7 +828,7 @@ impl Index {
     pub async fn delete_all_documents(&self) -> Result<TaskInfo, Error> {
         request::<(), (), TaskInfo>(
             &format!("{}/indexes/{}/documents", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -870,7 +876,7 @@ impl Index {
                 "{}/indexes/{}/documents/{}",
                 self.client.host, self.uid, uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -922,7 +928,7 @@ impl Index {
                 "{}/indexes/{}/documents/delete-batch",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Post {
                 query: (),
                 body: uids,
@@ -1044,7 +1050,7 @@ impl Index {
     pub async fn get_task(&self, uid: impl AsRef<u32>) -> Result<Task, Error> {
         request::<(), (), Task>(
             &format!("{}/tasks/{}", self.client.host, uid.as_ref()),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -1134,7 +1140,7 @@ impl Index {
     pub async fn get_stats(&self) -> Result<IndexStats, Error> {
         request::<(), (), IndexStats>(
             &format!("{}/indexes/{}/stats", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -1490,7 +1496,7 @@ impl<'a> IndexUpdater<'a> {
     pub async fn execute(&'a self) -> Result<TaskInfo, Error> {
         request::<(), &IndexUpdater, TaskInfo>(
             &format!("{}/indexes/{}", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Patch {
                 query: (),
                 body: self,

--- a/src/key.rs
+++ b/src/key.rs
@@ -39,7 +39,7 @@ impl Key {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let description = "My not so little lovely test key".to_string();
     /// let mut key = KeyBuilder::new()
     ///   .with_action(Action::DocumentsAdd)
@@ -67,7 +67,7 @@ impl Key {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///  let name = "lovely key".to_string();
     ///  let mut key = KeyBuilder::new()
     ///   .with_action(Action::DocumentsAdd)
@@ -95,7 +95,7 @@ impl Key {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let mut key = KeyBuilder::new()
     ///   .execute(&client).await.unwrap();
     /// let description = "My not so little lovely test key".to_string();
@@ -131,7 +131,7 @@ impl Key {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let mut key = KeyBuilder::new()
     ///   .execute(&client).await.unwrap();
     ///
@@ -184,7 +184,7 @@ impl KeyUpdater {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///  let mut new_key = KeyBuilder::new()
     ///     .execute(&client)
     ///     .await
@@ -217,7 +217,7 @@ impl KeyUpdater {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///  let mut new_key = KeyBuilder::new()
     ///     .execute(&client)
     ///     .await
@@ -251,7 +251,7 @@ impl KeyUpdater {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let description = "My little lovely test key".to_string();
     /// let key = KeyBuilder::new()
     ///   .execute(&client).await.unwrap();
@@ -324,7 +324,7 @@ impl KeysQuery {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///  let mut keys = KeysQuery::new()
     ///   .with_offset(1)
     ///   .execute(&client).await.unwrap();
@@ -348,7 +348,7 @@ impl KeysQuery {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///  let mut keys = KeysQuery::new()
     ///   .with_limit(1)
     ///   .execute(&client).await.unwrap();
@@ -372,7 +372,7 @@ impl KeysQuery {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///  let mut keys = KeysQuery::new()
     ///   .with_limit(1)
     ///   .execute(&client).await.unwrap();
@@ -397,7 +397,7 @@ impl KeysQuery {
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
 /// # futures::executor::block_on(async move {
-/// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+/// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 /// let description = "My little lovely test key".to_string();
 /// let key = KeyBuilder::new()
 ///   .with_description(&description)
@@ -490,7 +490,7 @@ impl KeyBuilder {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let mut key = KeyBuilder::new()
     ///   .with_indexes(vec!["test", "movies"])
     ///   .execute(&client)
@@ -537,7 +537,7 @@ impl KeyBuilder {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///  let description = "My not so little lovely test key".to_string();
     ///
     ///  let mut key = KeyBuilder::new()
@@ -564,7 +564,7 @@ impl KeyBuilder {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///  let name = "lovely key".to_string();
     ///
     ///  let mut key = KeyBuilder::new()
@@ -591,7 +591,7 @@ impl KeyBuilder {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///  let uid = "93bcd7fb-2196-4fd9-acb7-3fca8a96e78f".to_string();
     ///
     ///  let mut key = KeyBuilder::new()
@@ -619,7 +619,7 @@ impl KeyBuilder {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let description = "My little lovely test key".to_string();
     /// let key = KeyBuilder::new()
     ///    .with_description(&description)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! #   let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
 //! #   let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 //!     // Create a client (without sending any request so that can't fail)
-//!     let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+//!     let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 //!
 //! #    let index = client.create_index("movies", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //!     // An index is where the documents are stored.
@@ -55,7 +55,7 @@
 //! # fn main() { block_on(async move {
 //! #    let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
 //! #    let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-//! #    let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+//! #    let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 //! #    let movies = client.create_index("movies_2", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! // Meilisearch is typo-tolerant:
 //! println!("{:?}", client.index("movies_2").search().with_query("caorl").execute::<Movie>().await.unwrap().hits);
@@ -98,7 +98,7 @@
 //! # fn main() { block_on(async move {
 //! #   let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
 //! #   let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-//! #    let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+//! #    let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 //! #    let movies = client.create_index("movies_3", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let search_result = client.index("movies_3")
 //!   .search()
@@ -145,7 +145,7 @@
 //! # fn main() { block_on(async move {
 //! #    let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
 //! #    let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-//! #    let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+//! #    let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 //! #    let movies = client.create_index("movies_4", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! let filterable_attributes = [
 //!     "id",
@@ -175,7 +175,7 @@
 //! # fn main() { block_on(async move {
 //! # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
 //! # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-//! # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+//! # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 //! # let movies = client.create_index("movies_5", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
 //! # let filterable_attributes = [
 //! #     "id",

--- a/src/search.rs
+++ b/src/search.rs
@@ -960,7 +960,7 @@ mod tests {
             .execute(&client)
             .await
             .unwrap();
-        let allowed_client = Client::new(meilisearch_url, key.key);
+        let allowed_client = Client::new(meilisearch_url, Some(key.key));
 
         let search_rules = vec![
             json!({ "*": {}}),
@@ -975,7 +975,7 @@ mod tests {
                 .generate_tenant_token(key.uid.clone(), rules, None, None)
                 .expect("Cannot generate tenant token.");
 
-            let new_client = Client::new(meilisearch_url, token.clone());
+            let new_client = Client::new(meilisearch_url, Some(token.clone()));
 
             let result: SearchResults<Document> = new_client
                 .index(index.uid.to_string())

--- a/src/search.rs
+++ b/src/search.rs
@@ -140,7 +140,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 /// }
 ///
 /// # futures::executor::block_on(async move {
-/// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+/// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 /// # let index = client
 /// #  .create_index("search_query_builder", None)
 /// #  .await
@@ -169,7 +169,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
-/// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+/// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
 /// # let index = client.index("search_query_builder_build");
 /// let query = index.search()
 ///     .with_query("space")
@@ -328,7 +328,7 @@ impl<'a> SearchQuery<'a> {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// #[derive(Serialize, Deserialize, Debug)]
     /// struct Movie {
     ///     name: String,
@@ -358,7 +358,7 @@ impl<'a> SearchQuery<'a> {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// #[derive(Serialize, Deserialize, Debug)]
     /// struct Movie {
     ///     name: String,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -239,7 +239,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_settings");
     /// let settings = index.get_settings().await.unwrap();
@@ -265,7 +265,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_synonyms");
     /// let synonyms = index.get_synonyms().await.unwrap();
@@ -294,7 +294,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_pagination", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_pagination");
     /// let pagination = index.get_pagination().await.unwrap();
@@ -323,7 +323,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_stop_words");
     /// let stop_words = index.get_stop_words().await.unwrap();
@@ -352,7 +352,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_ranking_rules");
     /// let ranking_rules = index.get_ranking_rules().await.unwrap();
@@ -381,7 +381,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_filterable_attributes");
     /// let filterable_attributes = index.get_filterable_attributes().await.unwrap();
@@ -410,7 +410,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_sortable_attributes");
     /// let sortable_attributes = index.get_sortable_attributes().await.unwrap();
@@ -439,7 +439,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_distinct_attribute");
     /// let distinct_attribute = index.get_distinct_attribute().await.unwrap();
@@ -468,7 +468,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_searchable_attributes");
     /// let searchable_attributes = index.get_searchable_attributes().await.unwrap();
@@ -497,7 +497,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_displayed_attributes");
     /// let displayed_attributes = index.get_displayed_attributes().await.unwrap();
@@ -526,7 +526,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_faceting", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_faceting");
     /// let faceting = index.get_faceting().await.unwrap();
@@ -558,7 +558,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_settings");
     ///
@@ -596,7 +596,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_synonyms");
     ///
@@ -639,7 +639,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_pagination", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_pagination");
     /// let pagination = PaginationSetting {max_total_hits:100};
@@ -674,7 +674,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_stop_words");
     ///
@@ -716,7 +716,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_ranking_rules");
     ///
@@ -767,7 +767,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_filterable_attributes");
     ///
@@ -809,7 +809,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_sortable_attributes");
     ///
@@ -851,7 +851,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_distinct_attribute");
     ///
@@ -889,7 +889,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_searchable_attributes");
     ///
@@ -930,7 +930,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_displayed_attributes");
     ///
@@ -971,7 +971,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("set_faceting", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_faceting");
     ///
@@ -1011,7 +1011,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_settings", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_settings");
     ///
@@ -1040,7 +1040,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_synonyms", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_synonyms");
     ///
@@ -1072,7 +1072,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_pagination", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_pagination");
     ///
@@ -1103,7 +1103,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_stop_words", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_stop_words");
     ///
@@ -1136,7 +1136,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_ranking_rules", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_ranking_rules");
     ///
@@ -1168,7 +1168,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_filterable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_filterable_attributes");
     ///
@@ -1200,7 +1200,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_sortable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_sortable_attributes");
     ///
@@ -1232,7 +1232,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_distinct_attribute", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_distinct_attribute");
     ///
@@ -1264,7 +1264,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_searchable_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_searchable_attributes");
     ///
@@ -1296,7 +1296,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_displayed_attributes", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_displayed_attributes");
     ///
@@ -1328,7 +1328,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("reset_faceting", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("reset_faceting");
     ///

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -249,7 +249,7 @@ impl Index {
     pub async fn get_settings(&self) -> Result<Settings, Error> {
         request::<(), (), Settings>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -278,7 +278,7 @@ impl Index {
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -307,7 +307,7 @@ impl Index {
                 "{}/indexes/{}/settings/pagination",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -336,7 +336,7 @@ impl Index {
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -365,7 +365,7 @@ impl Index {
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -394,7 +394,7 @@ impl Index {
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -423,7 +423,7 @@ impl Index {
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -452,7 +452,7 @@ impl Index {
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -481,7 +481,7 @@ impl Index {
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -510,7 +510,7 @@ impl Index {
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -539,7 +539,7 @@ impl Index {
                 "{}/indexes/{}/settings/faceting",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Get { query: () },
             200,
         )
@@ -575,7 +575,7 @@ impl Index {
     pub async fn set_settings(&self, settings: &Settings) -> Result<TaskInfo, Error> {
         request::<(), &Settings, TaskInfo>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Patch {
                 query: (),
                 body: settings,
@@ -618,7 +618,7 @@ impl Index {
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: synonyms,
@@ -653,7 +653,7 @@ impl Index {
                 "{}/indexes/{}/settings/pagination",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Patch {
                 query: (),
                 body: &pagination,
@@ -692,7 +692,7 @@ impl Index {
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: stop_words
@@ -743,7 +743,7 @@ impl Index {
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: ranking_rules
@@ -785,7 +785,7 @@ impl Index {
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: filterable_attributes
@@ -827,7 +827,7 @@ impl Index {
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: sortable_attributes
@@ -868,7 +868,7 @@ impl Index {
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: distinct_attribute.as_ref().to_string(),
@@ -906,7 +906,7 @@ impl Index {
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: searchable_attributes
@@ -947,7 +947,7 @@ impl Index {
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Put {
                 query: (),
                 body: displayed_attributes
@@ -989,7 +989,7 @@ impl Index {
                 "{}/indexes/{}/settings/faceting",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Patch {
                 query: (),
                 body: faceting,
@@ -1022,7 +1022,7 @@ impl Index {
     pub async fn reset_settings(&self) -> Result<TaskInfo, Error> {
         request::<(), (), TaskInfo>(
             &format!("{}/indexes/{}/settings", self.client.host, self.uid),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1054,7 +1054,7 @@ impl Index {
                 "{}/indexes/{}/settings/synonyms",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1086,7 +1086,7 @@ impl Index {
                 "{}/indexes/{}/settings/pagination",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1117,7 +1117,7 @@ impl Index {
                 "{}/indexes/{}/settings/stop-words",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1150,7 +1150,7 @@ impl Index {
                 "{}/indexes/{}/settings/ranking-rules",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1182,7 +1182,7 @@ impl Index {
                 "{}/indexes/{}/settings/filterable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1214,7 +1214,7 @@ impl Index {
                 "{}/indexes/{}/settings/sortable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1246,7 +1246,7 @@ impl Index {
                 "{}/indexes/{}/settings/distinct-attribute",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1278,7 +1278,7 @@ impl Index {
                 "{}/indexes/{}/settings/searchable-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1310,7 +1310,7 @@ impl Index {
                 "{}/indexes/{}/settings/displayed-attributes",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )
@@ -1342,7 +1342,7 @@ impl Index {
                 "{}/indexes/{}/settings/faceting",
                 self.client.host, self.uid
             ),
-            &self.client.api_key,
+            self.client.get_api_key(),
             Method::Delete { query: () },
             202,
         )

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -51,7 +51,7 @@ impl TaskInfo {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new("http://localhost:7700", "masterKey");
+    /// let client = Client::new("http://localhost:7700", Some("masterKey"));
     /// let movies = client.index("movies_wait_for_completion");
     ///
     /// let status = movies.add_documents(&[
@@ -166,10 +166,7 @@ mod test {
 
     #[meilisearch_test]
     async fn test_failing_task(client: Client, index: Index) -> Result<(), Error> {
-        let task_info = client
-            .create_index("meilisearch_sdk-task_info-test-test_failing_task", None)
-            .await
-            .unwrap();
+        let task_info = client.create_index(index.uid, None).await.unwrap();
         let task = client.wait_for_task(task_info, None, None).await?;
 
         let error = task.unwrap_failure();

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -847,7 +847,7 @@ mod test {
     async fn test_get_tasks_no_params() -> Result<(), Error> {
         let mut s = mockito::Server::new_async().await;
         let mock_server_url = s.url();
-        let client = Client::new(mock_server_url, "masterKey");
+        let client = Client::new(mock_server_url, Some("masterKey"));
         let path = "/tasks";
 
         let mock_res = s.mock("GET", path).with_status(200).create_async().await;
@@ -861,7 +861,7 @@ mod test {
     async fn test_get_tasks_with_params() -> Result<(), Error> {
         let mut s = mockito::Server::new_async().await;
         let mock_server_url = s.url();
-        let client = Client::new(mock_server_url, "masterKey");
+        let client = Client::new(mock_server_url, Some("masterKey"));
         let path =
             "/tasks?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1&limit=0&from=1";
 
@@ -887,7 +887,7 @@ mod test {
     async fn test_get_tasks_with_date_params() -> Result<(), Error> {
         let mut s = mockito::Server::new_async().await;
         let mock_server_url = s.url();
-        let client = Client::new(mock_server_url, "masterKey");
+        let client = Client::new(mock_server_url, Some("masterKey"));
         let path = "/tasks?\
             beforeEnqueuedAt=2022-02-03T13%3A02%3A38.369634Z\
             &afterEnqueuedAt=2023-02-03T13%3A02%3A38.369634Z\
@@ -952,7 +952,7 @@ mod test {
     async fn test_get_tasks_on_struct_with_params() -> Result<(), Error> {
         let mut s = mockito::Server::new_async().await;
         let mock_server_url = s.url();
-        let client = Client::new(mock_server_url, "masterKey");
+        let client = Client::new(mock_server_url, Some("masterKey"));
         let path =
             "/tasks?indexUids=movies,test&statuses=equeued&types=documentDeletion&canceledBy=9";
 
@@ -1013,7 +1013,7 @@ mod test {
     async fn test_cancel_tasks_with_params() -> Result<(), Error> {
         let mut s = mockito::Server::new_async().await;
         let mock_server_url = s.url();
-        let client = Client::new(mock_server_url, "masterKey");
+        let client = Client::new(mock_server_url, Some("masterKey"));
         let path =
             "/tasks/cancel?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1";
 
@@ -1037,7 +1037,7 @@ mod test {
     async fn test_cancel_tasks_with_params_execute() -> Result<(), Error> {
         let mut s = mockito::Server::new_async().await;
         let mock_server_url = s.url();
-        let client = Client::new(mock_server_url, "masterKey");
+        let client = Client::new(mock_server_url, Some("masterKey"));
         let path =
             "/tasks/cancel?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1";
 
@@ -1062,7 +1062,7 @@ mod test {
         let mut s = mockito::Server::new_async().await;
         //         let mut s = mockito::Server::new_async().await;
         let mock_server_url = s.url();
-        let client = Client::new(mock_server_url, "masterKey");
+        let client = Client::new(mock_server_url, Some("masterKey"));
         let path = "/tasks?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1";
 
         let mock_res = s.mock("DELETE", path).with_status(200).create_async().await;
@@ -1085,7 +1085,7 @@ mod test {
     async fn test_delete_tasks_with_params_execute() -> Result<(), Error> {
         let mut s = mockito::Server::new_async().await;
         let mock_server_url = s.url();
-        let client = Client::new(mock_server_url, "masterKey");
+        let client = Client::new(mock_server_url, Some("masterKey"));
         let path = "/tasks?indexUids=movies,test&statuses=equeued&types=documentDeletion&uids=1";
 
         let mock_res = s.mock("DELETE", path).with_status(200).create_async().await;

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -240,7 +240,7 @@ impl Task {
     /// #
     /// #
     /// # futures::executor::block_on(async move {
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movies = client.index("movies_wait_for_completion");
     ///
     /// let status = movies.add_documents(&[
@@ -280,7 +280,7 @@ impl Task {
     /// #
     /// # futures::executor::block_on(async move {
     /// // create the client
-    /// let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     ///
     /// let task = client.create_index("try_make_index", None).await.unwrap();
     /// let index = client.wait_for_task(task, None, None).await.unwrap().try_make_index(&client).unwrap();
@@ -318,7 +318,7 @@ impl Task {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let task = client.create_index("unwrap_failure", None).await.unwrap();
     /// let task = client
     ///     .create_index("unwrap_failure", None)
@@ -356,7 +356,7 @@ impl Task {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let task = client.create_index("is_failure", None).await.unwrap();
     /// let task = client
     ///     .create_index("is_failure", None)
@@ -385,7 +385,7 @@ impl Task {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let task = client
     ///   .create_index("is_success", None)
     ///   .await
@@ -414,7 +414,7 @@ impl Task {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, MEILISEARCH_API_KEY);
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let task_info = client
     ///   .create_index("is_pending", None)
     ///   .await
@@ -996,10 +996,7 @@ mod test {
 
     #[meilisearch_test]
     async fn test_failing_task(client: Client, index: Index) -> Result<(), Error> {
-        let task_info = client
-            .create_index("meilisearch_sdk-tasks-test-test_failing_task", None)
-            .await
-            .unwrap();
+        let task_info = client.create_index(index.uid, None).await.unwrap();
         let task = client.get_task(task_info).await?;
         let task = client.wait_for_task(task, None, None).await?;
 


### PR DESCRIPTION
# Pull Request

Since we introduced the `Authentication: Bearer {api_key}` header, sending an empty `api_key` doesn't work anymore, which means it's impossible to use this SDK without an API key.

A lot of noise is due to the doctest update; it's probably easier to review this PR by reading the first commit alone

## Related issue
Fixes #240

## What does this PR do?
- Makes the API key optional when creating a client

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
