### PR TITLE
Replace `iso8601-duration` with `iso8601` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = ["examples/*"]
 
 [dependencies]
 async-trait = "0.1.51"
-iso8601-duration = "0.1.0"
+iso8601 = "0.6.1"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -137,8 +137,8 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    let iso_duration = iso8601_duration::Duration::parse(&s).map_err(serde::de::Error::custom)?;
-    Ok(iso_duration.to_std())
+    let iso_duration = iso8601::duration(&s).map_err(serde::de::Error::custom)?;
+    Ok(iso_duration.into())
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -809,7 +809,7 @@ mod test {
                     ..
                 }
             }
-            if duration == Duration::from_secs_f32(10.848957061)
+            if duration == Duration::from_millis(10_848)
         ));
     }
 


### PR DESCRIPTION


# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?

Replace `iso8601-duration` with `iso8601` crate.

For one, this updates the indirect dependency `nom` from 5.x to 7.x, which gets rid of a future incompatibility warning produced by the compiler:

    warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2
    note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 67`

But to achieve that I could have updated `iso8601-duration` to 0.2. However, the 0.2 version makes conversion into an `std::time::Duration` weirdly hard. And I'm also confused by the fields being `f32` for no reason I can think of. Additionally, the crate has very few users and there is no changelog. So in general, the `iso8601` crate looks much better. Even if it gives us date parsing, which we don't need, I think it's still a better option.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
