### PR TITLE
Add feature isahc-static-ssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ wasm-bindgen-futures = "0.4"
 [features]
 default = ["isahc-static-curl"]
 isahc-static-curl = ["isahc/static-curl"]
+isahc-static-ssl = ["isahc/static-ssl"]
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -50,9 +50,11 @@ impl TaskInfo {
     /// #    kind: String,
     /// # }
     /// #
+    /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
     /// # futures::executor::block_on(async move {
-    /// # let client = Client::new("http://localhost:7700", Some("masterKey"));
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movies = client.index("movies_wait_for_completion");
     ///
     /// let status = movies.add_documents(&[


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #468

## What does this PR do?
- With isahc-static-curl feature compiling a static build was still not achievable since it still needed system-wide installed OpenSSL libraries. With the isahc-static-ssl feature was added, now its possible to compile the library without OpenSSL libraries installed.

- The src/task_info.rs file had a failing doc test due not using environmental variables like other tests do. This issue was fixed.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
