### PR TITLE
Add delete_documents_with method for Meilisearch v1.2

### DIFF
--- a/src/documents.rs
+++ b/src/documents.rs
@@ -310,16 +310,19 @@ pub struct DocumentDeletionQuery<'a> {
     /// Filters to apply.
     ///
     /// Read the [dedicated guide](https://docs.meilisearch.com/reference/features/filtering.html) to learn the syntax.
-    pub filter: &'a str,
+    pub filter: Option<&'a str>,
 }
 
 impl<'a> DocumentDeletionQuery<'a> {
     pub fn new(index: &Index) -> DocumentDeletionQuery {
-        DocumentDeletionQuery { index, filter: "" }
+        DocumentDeletionQuery {
+            index,
+            filter: None,
+        }
     }
 
     pub fn with_filter<'b>(&'b mut self, filter: &'a str) -> &'b mut DocumentDeletionQuery<'a> {
-        self.filter = filter;
+        self.filter = Some(filter);
         self
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -162,6 +162,8 @@ pub enum ErrorCode {
     InvalidIndexOffset,
     InvalidIndexLimit,
     InvalidIndexPrimaryKey,
+    InvalidDocumentFilter,
+    MissingDocumentFilter,
     InvalidDocumentFields,
     InvalidDocumentLimit,
     InvalidDocumentOffset,

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -66,7 +66,7 @@ pub struct DocumentAdditionOrUpdate {
 pub struct DocumentDeletion {
     pub provided_ids: Option<usize>,
     pub deleted_documents: Option<usize>,
-    pub original_filter: String,
+    pub original_filter: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -66,6 +66,7 @@ pub struct DocumentAdditionOrUpdate {
 pub struct DocumentDeletion {
     pub provided_ids: Option<usize>,
     pub deleted_documents: Option<usize>,
+    pub original_filter: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
following this spec: https://github.com/meilisearch/specifications/pull/236

- Add a method `index.delete_documents_with`  that lets you select a range of documents to delete based on the provided filters.
