### PR TITLE
Add support for typo tolerance customization

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -400,7 +400,6 @@ getting_started_typo_tolerance: |-
   }
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
-    disable_on_attributes: Some(vec![]),
     disable_on_words: Some(vec!["title".to_string()]),
     min_word_size_for_typos: Some(min_word_size_for_typos),
   };
@@ -844,7 +843,6 @@ settings_guide_typo_tolerance_1: |-
   }
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
-    disable_on_attributes: Some(vec![]),
     disable_on_words: Some(vec!["title".to_string()]),
     min_word_size_for_typos: Some(min_word_size_for_typos),
   };
@@ -860,8 +858,6 @@ settings_guide_typo_tolerance_1: |-
 typo_tolerance_guide_1: |-
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(false),
-    disable_on_attributes: Some(vec![]),
-    disable_on_words: Some(vec![]),
     min_word_size_for_typos: Some(MinWordSizeForTypos::default()),
   };
 
@@ -878,7 +874,6 @@ typo_tolerance_guide_2: |-
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
     disable_on_attributes: Some(vec!["title".to_string()]),
-    disable_on_words: Some(vec![]),
     min_word_size_for_typos: Some(min_word_size_for_typos),
   };
 
@@ -894,7 +889,6 @@ typo_tolerance_guide_3: |-
   }
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
-    disable_on_attributes: Some(vec![]),
     disable_on_words: Some(vec!["shrek".to_string()]),
     min_word_size_for_typos: Some(min_word_size_for_typos),
   };
@@ -911,7 +905,6 @@ typo_tolerance_guide_4: |-
   };
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
-    disable_on_attributes: Some(vec![]),
     disable_on_words: Some(vec!["title".to_string()]),
     min_word_size_for_typos: Some(min_word_size_for_typos),
   };

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -256,7 +256,7 @@ getting_started_typo_tolerance: |-
 
   let task: TaskInfo = client
     .index("movies")
-    .set_update_typo_tolerance(&typo_tolerance)
+    .set_typo_tolerance(&typo_tolerance)
     .await
     .unwrap();
 get_typo_tolerance_1: |-
@@ -271,7 +271,7 @@ update_typo_tolerance_1: |-
 
   let task: TaskInfo = client
     .index("books")
-    .set_typo_tolerance(typo_tolerance)
+    .set_typo_tolerance(&typo_tolerance)
     .await
     .unwrap();
 reset_typo_tolerance_1: |-
@@ -780,12 +780,9 @@ typo_tolerance_guide_1: |-
   let typo_tolerance = TypoToleranceSettings::new()
     .with_enabled(false);
 
-  let settings = Settings::new()
-    .with_typo_tolerance(&typo_tolerance);
-
   let task: TaskInfo = client
     .index("movies")
-    .set_settings(&settings)
+    .set_typo_tolerance(&typo_tolerance)
     .await
     .unwrap();
 typo_tolerance_guide_2: |-
@@ -793,25 +790,19 @@ typo_tolerance_guide_2: |-
     .with_min_word_size_for_two_typo(12)
     .with_disable_on_attributes(["title".to_string()]);
 
-  let settings = Settings::new()
-    .with_typo_tolerance(&typo_tolerance);
-
   let task: TaskInfo = client
     .index("movies")
-    .set_settings(&settings)
+    .set_typo_tolerance(&typo_tolerance)
     .await
     .unwrap();
 typo_tolerance_guide_3: |-
   let typo_tolerance = TypoToleranceSettings::new()
     .with_min_word_size_for_two_typo(12)
     .with_disable_on_words(["shrek".to_string()]);
-
-  let settings = Settings::new()
-    .with_typo_tolerance(&typo_tolerance);
-
+  
   let task: TaskInfo = client
     .index("movies")
-    .set_settings(&settings)
+    .set_typo_tolerance(&typo_tolerance)
     .await
     .unwrap();
 typo_tolerance_guide_4: |-
@@ -822,12 +813,9 @@ typo_tolerance_guide_4: |-
   let typo_tolerance = TypoToleranceSettings::new()
     .with_min_word_size_for_typos(min_word_size_for_typos);
 
-  let settings = Settings::new()
-    .with_typo_tolerance(&typo_tolerance);
-
   let task: TaskInfo = client
     .index("movies")
-    .set_settings(&settings)
+    .set_typo_tolerance(&typo_tolerance)
     .await
     .unwrap();
 add_movies_json_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -3,6 +3,75 @@
 # the documentation on build
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
+synonyms_guide_1: |-
+  let mut synonyms = std::collections::HashMap::new();
+  synonyms.insert(String::from("great"), vec![String::from("fantastic")]);
+  synonyms.insert(String::from("fantastic"), vec![String::from("great")]);
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_synonyms(&synonyms)
+    .await
+    .unwrap();
+date_guide_index_1: |-
+  let mut file = File::open("games.json")
+    .unwrap();
+  let mut content = String::new();
+  file
+    .read_to_string(&mut content)
+    .unwrap();
+  let docs: Vec<Game> = serde_json::from_str(&content)
+    .unwrap();
+
+  client
+    .index("games")
+    .add_documents(&docs, None)
+    .await
+    .unwrap();
+date_guide_filterable_attributes_1: |-
+  let settings = Settings::new()
+    .with_filterable_attributes(["release_timestamp"]);
+
+  let task: TaskInfo = client
+    .index("games")
+    .set_settings(&settings)
+    .await
+    .unwrap();
+date_guide_filter_1: |-
+  let results: SearchResults<Game> = client
+    .index("games")
+    .search()
+    .with_filter("release_timestamp >= 1514761200 AND release_timestamp < 1672527600")
+    .execute()
+    .await
+    .unwrap();
+date_guide_sortable_attributes_1: |-
+  let settings = Settings::new()
+    .with_sortable_attributes(["release_timestamp"]);
+
+  let task: TaskInfo = client
+    .index("games")
+    .set_settings(&settings)
+    .await
+    .unwrap();
+date_guide_sort_1: |-
+  let results: SearchResults<Game> = client
+    .index("games")
+    .search()
+    .with_sort(["release_timestamp:desc"])
+    .execute()
+    .await
+    .unwrap();
+delete_tasks_1: |-
+  let mut query = tasks::TasksDeleteQuery::new(&client);
+  query.with_uids([1, 2]);
+
+  let res = client.delete_tasks_with(&query).await.unwrap();
+cancel_tasks_1: |-
+  let mut query = tasks::TasksCancelQuery::new(&client);
+  query.with_uids([1, 2]);
+
+  let res = client.cancel_task_with(&query).await.unwrap();
 get_one_index_1: |-
   let movies: Index = client
     .get_index("movies")
@@ -29,6 +98,19 @@ delete_an_index_1: |-
     .delete()
     .await
     .unwrap();
+swap_indexes_1: |-
+  client.swap_indexes([
+    &SwapIndexes {
+      indexes: (
+          "indexA".to_string(),
+          "indexB".to_string(),
+      ),
+    }, &SwapIndexes {
+      indexes: (
+          "indexX".to_string(),
+          "indexY".to_string(),
+      ),
+  }])
 get_one_document_1: |-
   let index = client
     .index("movies");
@@ -38,9 +120,18 @@ get_one_document_1: |-
     .await
     .unwrap();
 get_documents_1: |-
-  let index = client
-    .index("movies");
+  let index = client.index("movies");
   let documents: DocumentsResults = DocumentsQuery::new(&index)
+    .with_filter("genres = action")
+    .with_limit(2)
+    .execute::<Movies>()
+    .await
+    .unwrap();
+get_documents_post_1: |-
+  let index = client.index("books");
+  let documents: DocumentsResults = DocumentsQuery::new(&index)
+    .with_filter("(rating > 3 AND (genres = Adventure OR genres = Fiction)) AND language = English")
+    .with_fields(["title", "genres", "rating", "language"])
     .with_limit(2)
     .execute::<Movies>()
     .await
@@ -89,10 +180,17 @@ delete_one_document_1: |-
     .delete_document(25684)
     .await
     .unwrap();
-delete_documents_1: |-
+delete_documents_by_batch_1: |-
   let task: TaskInfo = client
     .index("movies")
     .delete_documents(&[23488, 153738, 437035, 363869])
+    .await
+    .unwrap();
+delete_documents_by_filter_1: |-
+  let index = client.index("movies");
+  let task = DocumentDeletionQuery::new(&index)
+    .with_filter("genres = action OR genres = adventure")
+    .execute()
     .await
     .unwrap();
 search_post_1: |-
@@ -108,28 +206,15 @@ get_all_tasks_1: |-
     .get_tasks()
     .await
     .unwrap();
-get_all_tasks_filtering_1: |-
-  let mut query = TasksQuery::new(&client)
-      .with_index_uid(["movies"])
-      .execute()
-      .await
-      .unwrap();
-get_all_tasks_filtering_2: |-
-  let mut query = TasksQuery::new(&client)
-      .with_status(["succeeded", "failed"])
-      .with_type(["documentAdditionOrUpdate"])
-      .execute()
-      .await
-      .unwrap();
 get_all_tasks_paginating_1: |-
-  let mut query = TasksQuery::new(&client)
+  let mut query = TasksSearchQuery::new(&client)
       .with_limit(2)
       .with_from(10)
       .execute()
       .await
       .unwrap();
 get_all_tasks_paginating_2: |-
-  let mut query = TasksQuery::new(&client)
+  let mut query = TasksSearchQuery::new(&client)
       .with_limit(2)
       .from(8)
       .execute()
@@ -138,6 +223,62 @@ get_all_tasks_paginating_2: |-
 get_task_1: |-
   let task: Task = client
     .get_task(1)
+    .await
+    .unwrap();
+async_guide_filter_by_date_1: |-
+  let date = OffsetDateTime::parse(
+      "2020-10-11T11:49:53.000Z",
+      &::time::format_description::well_known::Rfc3339,
+  )
+
+  let mut query = TasksQuery::new(&client);
+  let tasks = query
+    .with_after_enqueued_at(&date)
+    .execute()
+    .await
+    .unwrap();
+async_guide_multiple_filters_1: |-
+  let mut query = TasksQuery::new(&client);
+  let tasks = query
+    .with_index_uids(["movies"])
+    .with_types(["documentAdditionOrUpdate","documentDeletion"])
+    .with_statuses(["processing"])
+    .execute()
+    .await
+    .unwrap();
+async_guide_filter_by_ids_1: |-
+  let mut query = TasksQuery::new(&client);
+  let tasks = query
+    .with_uids([5, 10, 13])
+    .execute()
+    .await
+    .unwrap();
+async_guide_filter_by_statuses_1: |-
+  let mut query = TasksQuery::new(&client);
+  let tasks = query
+    .with_statuses(["failed", "canceled"])
+    .execute()
+    .await
+    .unwrap();
+async_guide_filter_by_types_1: |-
+  let mut query = TasksQuery::new(&client);
+  let tasks = query
+    .with_types(["dumpCreation", "indexSwap"])
+    .execute()
+    .await
+    .unwrap();
+async_guide_filter_by_index_uids_1: |-
+  let mut query = TasksQuery::new(&client);
+  let tasks = query
+    .with_index_uids(["movies"])
+    .execute()
+    .await
+    .unwrap();
+async_guide_canceled_by_1: |-
+  let mut query = TasksQuery::new(&client);
+  let tasks = query
+    .with_canceled_by([9, 15])
+    .execute()
     .await
     .unwrap();
 get_settings_1: |-
@@ -151,6 +292,17 @@ update_settings_1: |-
   let mut synonyms = std::collections::HashMap::new();
   synonyms.insert(String::from("wolverine"), vec!["xmen", "logan"]);
   synonyms.insert(String::from("logan"), vec!["wolverine"]);
+
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(4),
+    two_typos; Some(12)
+  }
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec!["title".to_string()]),
+    disable_on_words: Some(vec![])
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
 
   let settings = Settings::new()
     .with_ranking_rules([
@@ -184,7 +336,8 @@ update_settings_1: |-
       "title",
       "release_date"
     ])
-    .with_synonyms(synonyms);
+    .with_synonyms(synonyms)
+    .with_typo_tolerance(typo_tolerance);
 
   let task: TaskInfo = client
     .index("movies")
@@ -238,6 +391,48 @@ reset_pagination_settings_1: |-
   let task: TaskInfo = client
     .index("books")
     .reset_pagination()
+    .await
+    .unwrap();
+getting_started_typo_tolerance: |-
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(5),
+    two_typos: Some(4)
+  }
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec!["title".to_string()]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_typo_tolerance(&typo_tolerance)
+    .await
+    .unwrap();
+get_typo_tolerance_1: |-
+  let typo_tolerance: TypoToleranceSettings = client
+    .index("books")
+    .get_typo_tolerance()
+    .await
+    .unwrap();
+update_typo_tolerance_1: |-
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(false),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec![]),
+    min_word_size_for_typos: Some(MinWordSizeForTypos::default()),
+  };
+
+  let task: TaskInfo = client
+    .index("books")
+    .set_typo_tolerance(&typo_tolerance)
+    .await
+    .unwrap();
+reset_typo_tolerance_1: |-
+  let task: TaskInfo = client
+    .index("books")
+    .reset_typo_tolerance()
     .await
     .unwrap();
 get_stop_words_1: |-
@@ -480,6 +675,15 @@ filtering_guide_3: |-
     .execute()
     .await
     .unwrap();
+filtering_guide_nested_1: |-
+  let results: SearchResults<MovieRatings> = client
+    .index("movie_rating")
+    .search()
+    .with_query("thriller")
+    .with_filter("rating.users >= 90")
+    .execute()
+    .await
+    .unwrap();
 search_parameter_guide_query_1: |-
   let results: SearchResults<Movie> = client
     .index("movies")
@@ -599,32 +803,28 @@ search_parameter_guide_show_matches_position_1: |-
     .iter()
     .map(|r| r.matches_position.as_ref().unwrap())
     .collect();
-settings_guide_synonyms_1: |-
-  let mut synonyms = HashMap::new();
-  synonyms.insert(String::from("sweater"), vec![String::from("jumper")]);
-  synonyms.insert(String::from("jumper"), vec![String::from("sweater")]);
-
-  let settings = Settings::new()
-    .with_synonyms(synonyms);
-
-  let task = client
-    .index("tops")
-    .set_settings(&settings)
-    .await
-    .unwrap();
-settings_guide_stop_words_1: |-
-  let settings = Settings::new()
-    .with_stop_words([
-      "the",
-      "a",
-      "an"
-    ]);
-
-  let task: TaskInfo = client
-    .index("movies")
-    .set_settings(&settings)
-    .await
-    .unwrap();
+search_parameter_guide_matching_strategy_1: |-
+  let results: SearchResults<Movie> = client
+  .index("movies")
+  .search()
+  .with_query("big fat liar")
+  .with_matching_strategy(MatchingStrategies::LAST)
+  .execute()
+  .await
+  .unwrap();
+search_parameter_guide_matching_strategy_2: |-
+  let results: SearchResults<Movie> = client
+  .index("movies")
+  .search()
+  .with_query("big fat liar")
+  .with_matching_strategy(MatchingStrategies::ALL)
+  .execute()
+  .await
+  .unwrap();
+search_parameter_guide_hitsperpage_1: |-
+  client.index("movies").search().with_hits_per_page(15).execute().await?;
+search_parameter_guide_page_1: |-
+  client.index("movies").search().with_page(2).execute().await?;
 settings_guide_filterable_attributes_1: |-
   let settings = Settings::new()
     .with_filterable_attributes([
@@ -637,90 +837,88 @@ settings_guide_filterable_attributes_1: |-
     .set_settings(&settings)
     .await
     .unwrap();
-settings_guide_ranking_rules_1: |-
-  let settings = Settings::new()
-    .with_ranking_rules([
-      "words",
-      "typo",
-      "proximity",
-      "attribute",
-      "sort",
-      "exactness",
-      "release_date:asc",
-      "rank:desc",
-    ]);
-
-  let task: TaskInfo = client
-    .index("movies")
-    .set_settings(&settings)
-    .await
-    .unwrap();
-settings_guide_distinct_1: |-
-  let settings = Settings::new()
-    .with_distinct_attribute("product_id");
-
-  let task: TaskInfo = client
-    .index("jackets")
-    .set_settings(&settings)
-    .await
-    .unwrap();
-settings_guide_searchable_1: |-
-  let settings = Settings::new()
-    .with_searchable_attributes([
-      "title",
-      "overview",
-      "genres"
-    ]);
-
-  let task: TaskInfo = client
-    .index("movies")
-    .set_settings(&settings)
-    .await
-    .unwrap();
-settings_guide_pagination_1: |-
-  let pagination = PaginationSetting {max_total_hits:100};
-
-  let task: TaskInfo = client
-    .index("movies")
-    .set_pagination(pagination)
-    .await
-    .unwrap();
-settings_guide_displayed_1: |-
-  let settings = Settings::new()
-    .with_displayed_attributes([
-      "title",
-      "overview",
-      "genres",
-      "release_date"
-    ]);
-
-  let task: TaskInfo = client
-    .index("movies")
-    .set_settings(&settings)
-    .await
-    .unwrap();
-settings_guide_sortable_1: |-
-  let settings = Settings::new()
-    .with_sortable_attributes([
-      "author",
-      "price"
-    ]);
-
-  let task: TaskInfo = client
-    .index("books")
-    .set_settings(&settings)
-    .await
-    .unwrap();
-settings_guide_faceting_1: |-
-  let faceting = FacetingSettings {
-      max_values_per_facet: 5,
+settings_guide_typo_tolerance_1: |-
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(5),
+    two_typos: Some(12)
+  }
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec!["title".to_string()]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
   };
+
   let settings = Settings::new()
-    .with_faceting(&faceting);
+    .with_typo_tolerance(&typo_tolerance);
 
   let task: TaskInfo = client
     .index("movies")
     .set_settings(&settings)
+    .await
+    .unwrap();
+typo_tolerance_guide_1: |-
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(false),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec![]),
+    min_word_size_for_typos: Some(MinWordSizeForTypos::default()),
+  };
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_typo_tolerance(&typo_tolerance)
+    .await
+    .unwrap();
+typo_tolerance_guide_2: |-
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(5),
+    two_typos: Some(12)
+  }
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec!["title".to_string()]),
+    disable_on_words: Some(vec![]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_typo_tolerance(&typo_tolerance)
+    .await
+    .unwrap();
+typo_tolerance_guide_3: |-
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(5),
+    two_typos: Some(12)
+  }
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec!["shrek".to_string()]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
+  
+  let task: TaskInfo = client
+    .index("movies")
+    .set_typo_tolerance(&typo_tolerance)
+    .await
+    .unwrap();
+typo_tolerance_guide_4: |-
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(4),
+    two_typos: Some(12)
+  };
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec!["title".to_string()]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_typo_tolerance(&typo_tolerance)
     .await
     .unwrap();
 add_movies_json_1: |-
@@ -735,7 +933,7 @@ add_movies_json_1: |-
   use futures::executor::block_on;
 
   fn main() { block_on(async move {
-    let client = Client::new("http://localhost:7700", "masterKey");
+    let client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // reading and parsing the file
     let mut file = File::open("movies.json")
@@ -810,7 +1008,7 @@ primary_field_guide_add_document_primary_key: |-
 getting_started_add_documents_md: |-
   ```toml
     [dependencies]
-    meilisearch-sdk = "0.20"
+    meilisearch-sdk = "0.24.0"
     # futures: because we want to block on futures
     futures = "0.3"
     # serde: required if you are going to use documents
@@ -824,7 +1022,7 @@ getting_started_add_documents_md: |-
   ```rust
   #[derive(Serialize, Deserialize)]
   struct Movie {
-    id: String,
+    id: i64,
     title: String,
     poster: String,
     overview: String,
@@ -839,7 +1037,7 @@ getting_started_add_documents_md: |-
   ```rust
   #[derive(Serialize, Deserialize)]
   struct Movie {
-    id: String,
+    id: i64,
     #[serde(flatten)]
     value: serde_json::Value,
   }
@@ -859,7 +1057,7 @@ getting_started_add_documents_md: |-
   use futures::executor::block_on;
 
   fn main() { block_on(async move {
-    let client = Client::new("http://localhost:7700", "masterKey");
+    let client = Client::new("http://localhost:7700", Some("masterKey"));
 
     // reading and parsing the file
     let mut file = File::open("movies.json")
@@ -978,7 +1176,7 @@ getting_started_update_displayed_attributes: |-
     .await
     .unwrap();
 getting_started_communicating_with_a_protected_instance: |-
-  let client = Client::new("http://localhost:7700", "apiKey");
+  let client = Client::new("http://localhost:7700", Some("apiKey"));
   client
     .index("movies")
     .search()
@@ -1059,6 +1257,14 @@ getting_started_faceting: |-
     .set_faceting(&faceting)
     .await
     .unwrap();
+getting_started_pagination: |-
+  let pagination = PaginationSetting {max_total_hits:500};
+
+  let task: TaskInfo = client
+    .index("books")
+    .set_pagination(pagination)
+    .await
+    .unwrap();
 getting_started_filtering: |-
   let results: SearchResults<Meteorite> = client
     .index("meteorites")
@@ -1067,7 +1273,7 @@ getting_started_filtering: |-
     .execute()
     .await
     .unwrap();
-faceted_search_update_settings_1: |-
+filtering_update_settings_1: |-
   let task: TaskInfo = client
     .index("movies")
     .set_filterable_attributes(["director", "genres"])
@@ -1104,6 +1310,44 @@ faceted_search_walkthrough_filter_1: |-
     .execute()
     .await
     .unwrap();
+faceted_search_update_settings_1: |-
+  let task: TaskInfo = client
+    .index("books")
+    .set_filterable_attributes(&["genres", "rating", "language"])
+    .await
+    .unwrap();
+faceted_search_1: |-
+  let books = client.index("books");
+
+  let results: SearchResults<Book> = SearchQuery::new(&books)
+    .with_query("classic")
+    .with_facets(Selectors::Some(&["genres", "rating", "language"]))
+    .execute()
+    .await
+    .unwrap();
+faceted_search_2: |-
+  let books = client.index("books");
+  let search_query_1 = SearchQuery::new(&books)
+      .with_facets(Selectors::Some(&["language", "genres", "author", "format"]))
+      .with_filter("(language = English OR language = French) AND genres = Fiction")
+      .build();
+  let search_query_2 = SearchQuery::new(&books)
+      .with_facets(Selectors::Some(&["language"]))
+      .with_filter("genres = Fiction")
+      .build();
+  let search_query_3 = SearchQuery::new(&books)
+      .with_facets(Selectors::Some(&["genres"]))
+      .with_filter("language = English OR language = French")  
+      .build();
+
+  let books_response = client
+      .multi_search()
+      .with_search_query(search_query_1)
+      .with_search_query(search_query_2)
+      .with_search_query(search_query_3)
+      .execute::<Book>()
+      .await
+      .unwrap();
 post_dump_1: |-
   client
     .create_dump()
@@ -1158,6 +1402,15 @@ sorting_guide_sort_parameter_2: |-
     .search()
     .with_query("butler")
     .with_sort(&["author:desc"])
+    .execute()
+    .await
+    .unwrap();
+sorting_guide_sort_nested_1: |-
+  let results: SearchResults<Books> = client
+    .index("books")
+    .search()
+    .with_query("science fiction")
+    .with_sort(&["rating.users:asc"])
     .execute()
     .await
     .unwrap();
@@ -1237,6 +1490,14 @@ geosearch_guide_sort_usage_2: |-
     .execute()
     .await
     .unwrap();
+geosearch_guide_filter_usage_3: |-
+  let results: SearchResults<Restaurant> = client
+    .index("restaurants")
+    .search()
+    .with_filter("_geoBoundingBox([45.494181, 9.179175], [45.449484, 9.214024])")
+    .execute()
+    .await
+    .unwrap();
 get_one_key_1: |-
   let key = client
     .get_key("6062abda-a5aa-4414-ac91-ecd7944c0f8d")
@@ -1278,20 +1539,20 @@ delete_a_key_1: |-
     .delete_key(&key)
     .await?;
 authorization_header_1:
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let keys = client
-    .get_keys()
-    .await
-    .unwrap();
+  .get_keys()
+  .await
+  .unwrap();
 security_guide_search_key_1: |-
-  let client = Client::new("http://localhost:7700", "apiKey");
+  let client = Client::new("http://localhost:7700", Some("apiKey"));
   let result = client.index("patient_medical_records")
     .search()
     .execute()
     .await
     .unwrap();
 security_guide_update_key_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let mut key = client
     .get_key("74c9c733-3368-4738-bbe5-1d18a5fecb37")
     .await
@@ -1300,7 +1561,7 @@ security_guide_update_key_1: |-
     .with_description("Default Search API key".to_string())
     .update(&client);
 security_guide_create_key_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let mut key_options = KeyBuilder::new("Search patient records key");
   key_options
     .with_action(Action::Search)
@@ -1311,13 +1572,13 @@ security_guide_create_key_1: |-
     .await
     .unwrap();
 security_guide_list_keys_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let keys = client
     .get_keys()
     .await
     .unwrap();
 security_guide_delete_key_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
   let key = client
     .get_key("ac5cd97d-5a4b-4226-a868-2d0eb6d197ab")
     .await
@@ -1326,7 +1587,7 @@ security_guide_delete_key_1: |-
     .delete_key(&key)
     .await?;
 landing_getting_started_1: |-
-  let client = Client::new("http://localhost:7700", "masterKey");
+  let client = Client::new("http://localhost:7700", Some("masterKey"));
 
   #[derive(Serialize, Deserialize)]
   struct Movie {
@@ -1355,11 +1616,41 @@ tenant_token_guide_generate_sdk_1: |-
     .generate_tenant_token(api_key_uid, search_rules, api_key, expires_at)
     .unwrap();
 tenant_token_guide_search_sdk_1: |-
-  let front_end_client = Client::new("http://localhost:7700", token);
+  let front_end_client = Client::new("http://localhost:7700", Some(token));
   let results: SearchResults<Patient> = front_end_client
     .index("patient_medical_records")
     .search()
     .with_query("blood test")
     .execute()
+    .await
+    .unwrap();
+multi_search_1: |-
+  let movie = client.index("movie");
+  let search_query_1 = SearchQuery::new(&movie)
+      .with_query("pooh")
+      .with_limit(5)
+      .build();
+  let search_query_2 = SearchQuery::new(&movie)
+      .with_query("nemo")
+      .with_limit(5)      
+      .build();
+
+  let movie_response = client
+      .multi_search()
+      .with_search_query(search_query_1)
+      .with_search_query(search_query_2)
+      .execute::<Movie>()
+      .await
+      .unwrap();
+
+  let movie_ratings = client.index("movie_ratings");
+  let search_query_3 = SearchQuery::new(&movie_ratings)
+      .with_query("us")
+      .build();
+
+  let movie_ratings_response = client
+    .multi_search()
+    .with_search_query(search_query_3)
+    .execute::<MovieRatings>()
     .await
     .unwrap();

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -153,13 +153,15 @@ update_settings_1: |-
   synonyms.insert(String::from("logan"), vec!["wolverine"]);
 
   let min_word_size_for_typos = MinWordSizeForTypos {
-    one_typo: 4,
-    two_typos; 12
+    one_typo: Some(4),
+    two_typos; Some(12)
   }
-  let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_typos(min_word_size_for_typos)
-    .with_disable_on_attributes(["title".to_string()])
-  ;
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec!["title".to_string()]),
+    disable_on_words: Some(vec![])
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
 
   let settings = Settings::new()
     .with_ranking_rules([
@@ -251,8 +253,16 @@ reset_pagination_settings_1: |-
     .await
     .unwrap();
 getting_started_typo_tolerance: |-
-  let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_two_typos(4);
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(5),
+    two_typos: Some(4)
+  }
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec!["title".to_string()]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
 
   let task: TaskInfo = client
     .index("movies")
@@ -266,8 +276,12 @@ get_typo_tolerance_1: |-
     .await
     .unwrap();
 update_typo_tolerance_1: |-
-  let typo_tolerance = TypoToleranceSettings::new()
-    .with_enabled(false);
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(false),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec![]),
+    min_word_size_for_typos: Some(MinWordSizeForTypos::default()),
+  };
 
   let task: TaskInfo = client
     .index("books")
@@ -764,9 +778,16 @@ settings_guide_faceting_1: |-
     .await
     .unwrap();
 settings_guide_typo_tolerance_1: |-
-  let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_two_typos(12)
-    .with_disable_on_attributes(["title".to_string()]);
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(5),
+    two_typos: Some(12)
+  }
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec!["title".to_string()]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
 
   let settings = Settings::new()
     .with_typo_tolerance(&typo_tolerance);
@@ -777,8 +798,12 @@ settings_guide_typo_tolerance_1: |-
     .await
     .unwrap();
 typo_tolerance_guide_1: |-
-  let typo_tolerance = TypoToleranceSettings::new()
-    .with_enabled(false);
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(false),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec![]),
+    min_word_size_for_typos: Some(MinWordSizeForTypos::default()),
+  };
 
   let task: TaskInfo = client
     .index("movies")
@@ -786,9 +811,16 @@ typo_tolerance_guide_1: |-
     .await
     .unwrap();
 typo_tolerance_guide_2: |-
-  let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_two_typos(12)
-    .with_disable_on_attributes(["title".to_string()]);
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(5),
+    two_typos: Some(12)
+  }
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec!["title".to_string()]),
+    disable_on_words: Some(vec![]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
 
   let task: TaskInfo = client
     .index("movies")
@@ -796,9 +828,16 @@ typo_tolerance_guide_2: |-
     .await
     .unwrap();
 typo_tolerance_guide_3: |-
-  let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_two_typos(12)
-    .with_disable_on_words(["shrek".to_string()]);
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: Some(5),
+    two_typos: Some(12)
+  }
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec!["shrek".to_string()]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
   
   let task: TaskInfo = client
     .index("movies")
@@ -807,11 +846,15 @@ typo_tolerance_guide_3: |-
     .unwrap();
 typo_tolerance_guide_4: |-
   let min_word_size_for_typos = MinWordSizeForTypos {
-    one_typo: 4,
-    two_typos; 12
+    one_typo: Some(4),
+    two_typos: Some(12)
   };
-  let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_typos(min_word_size_for_typos);
+  let typo_tolerance = TypoToleranceSettings {
+    enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
+    disable_on_words: Some(vec!["title".to_string()]),
+    min_word_size_for_typos: Some(min_word_size_for_typos),
+  };
 
   let task: TaskInfo = client
     .index("movies")

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -252,7 +252,7 @@ reset_pagination_settings_1: |-
     .unwrap();
 getting_started_typo_tolerance: |-
   let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_two_typo(4);
+    .with_min_word_size_for_two_typos(4);
 
   let task: TaskInfo = client
     .index("movies")
@@ -765,7 +765,7 @@ settings_guide_faceting_1: |-
     .unwrap();
 settings_guide_typo_tolerance_1: |-
   let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_two_typo(12)
+    .with_min_word_size_for_two_typos(12)
     .with_disable_on_attributes(["title".to_string()]);
 
   let settings = Settings::new()
@@ -787,7 +787,7 @@ typo_tolerance_guide_1: |-
     .unwrap();
 typo_tolerance_guide_2: |-
   let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_two_typo(12)
+    .with_min_word_size_for_two_typos(12)
     .with_disable_on_attributes(["title".to_string()]);
 
   let task: TaskInfo = client
@@ -797,7 +797,7 @@ typo_tolerance_guide_2: |-
     .unwrap();
 typo_tolerance_guide_3: |-
   let typo_tolerance = TypoToleranceSettings::new()
-    .with_min_word_size_for_two_typo(12)
+    .with_min_word_size_for_two_typos(12)
     .with_disable_on_words(["shrek".to_string()]);
   
   let task: TaskInfo = client

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -152,6 +152,15 @@ update_settings_1: |-
   synonyms.insert(String::from("wolverine"), vec!["xmen", "logan"]);
   synonyms.insert(String::from("logan"), vec!["wolverine"]);
 
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: 4,
+    two_typos; 12
+  }
+  let typo_tolerance = TypoToleranceSettings::new()
+    .with_min_word_size_for_typos(min_word_size_for_typos)
+    .with_disable_on_attributes(["title".to_string()])
+  ;
+
   let settings = Settings::new()
     .with_ranking_rules([
       "words",
@@ -184,7 +193,8 @@ update_settings_1: |-
       "title",
       "release_date"
     ])
-    .with_synonyms(synonyms);
+    .with_synonyms(synonyms)
+    .with_typo_tolerance(typo_tolerance);
 
   let task: TaskInfo = client
     .index("movies")
@@ -238,6 +248,36 @@ reset_pagination_settings_1: |-
   let task: TaskInfo = client
     .index("books")
     .reset_pagination()
+    .await
+    .unwrap();
+getting_started_typo_tolerance: |-
+  let typo_tolerance = TypoToleranceSettings::new()
+    .with_min_word_size_for_two_typo(4);
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_update_typo_tolerance(&typo_tolerance)
+    .await
+    .unwrap();
+get_typo_tolerance_1: |-
+  let typo_tolerance: TypoToleranceSettings = client
+    .index("books")
+    .get_typo_tolerance()
+    .await
+    .unwrap();
+update_typo_tolerance_1: |-
+  let typo_tolerance = TypoToleranceSettings::new()
+    .with_enabled(false);
+
+  let task: TaskInfo = client
+    .index("books")
+    .set_typo_tolerance(typo_tolerance)
+    .await
+    .unwrap();
+reset_typo_tolerance_1: |-
+  let task: TaskInfo = client
+    .index("books")
+    .reset_typo_tolerance()
     .await
     .unwrap();
 get_stop_words_1: |-
@@ -717,6 +757,73 @@ settings_guide_faceting_1: |-
   };
   let settings = Settings::new()
     .with_faceting(&faceting);
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_settings(&settings)
+    .await
+    .unwrap();
+settings_guide_typo_tolerance_1: |-
+  let typo_tolerance = TypoToleranceSettings::new()
+    .with_min_word_size_for_two_typo(12)
+    .with_disable_on_attributes(["title".to_string()]);
+
+  let settings = Settings::new()
+    .with_typo_tolerance(&typo_tolerance);
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_settings(&settings)
+    .await
+    .unwrap();
+typo_tolerance_guide_1: |-
+  let typo_tolerance = TypoToleranceSettings::new()
+    .with_enabled(false);
+
+  let settings = Settings::new()
+    .with_typo_tolerance(&typo_tolerance);
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_settings(&settings)
+    .await
+    .unwrap();
+typo_tolerance_guide_2: |-
+  let typo_tolerance = TypoToleranceSettings::new()
+    .with_min_word_size_for_two_typo(12)
+    .with_disable_on_attributes(["title".to_string()]);
+
+  let settings = Settings::new()
+    .with_typo_tolerance(&typo_tolerance);
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_settings(&settings)
+    .await
+    .unwrap();
+typo_tolerance_guide_3: |-
+  let typo_tolerance = TypoToleranceSettings::new()
+    .with_min_word_size_for_two_typo(12)
+    .with_disable_on_words(["shrek".to_string()]);
+
+  let settings = Settings::new()
+    .with_typo_tolerance(&typo_tolerance);
+
+  let task: TaskInfo = client
+    .index("movies")
+    .set_settings(&settings)
+    .await
+    .unwrap();
+typo_tolerance_guide_4: |-
+  let min_word_size_for_typos = MinWordSizeForTypos {
+    one_typo: 4,
+    two_typos; 12
+  };
+  let typo_tolerance = TypoToleranceSettings::new()
+    .with_min_word_size_for_typos(min_word_size_for_typos);
+
+  let settings = Settings::new()
+    .with_typo_tolerance(&typo_tolerance);
 
   let task: TaskInfo = client
     .index("movies")

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -400,6 +400,7 @@ getting_started_typo_tolerance: |-
   }
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
     disable_on_words: Some(vec!["title".to_string()]),
     min_word_size_for_typos: Some(min_word_size_for_typos),
   };
@@ -418,9 +419,9 @@ get_typo_tolerance_1: |-
 update_typo_tolerance_1: |-
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(false),
-    disable_on_attributes: Some(vec![]),
-    disable_on_words: Some(vec![]),
-    min_word_size_for_typos: Some(MinWordSizeForTypos::default()),
+    disable_on_attributes: None,
+    disable_on_words: None,
+    min_word_size_for_typos: None,
   };
 
   let task: TaskInfo = client
@@ -843,6 +844,7 @@ settings_guide_typo_tolerance_1: |-
   }
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
+    disable_on_attributes: None,
     disable_on_words: Some(vec!["title".to_string()]),
     min_word_size_for_typos: Some(min_word_size_for_typos),
   };
@@ -858,7 +860,9 @@ settings_guide_typo_tolerance_1: |-
 typo_tolerance_guide_1: |-
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(false),
-    min_word_size_for_typos: Some(MinWordSizeForTypos::default()),
+    disable_on_attributes: None,
+    disable_on_words: None,
+    min_word_size_for_typos: None,
   };
 
   let task: TaskInfo = client
@@ -874,7 +878,8 @@ typo_tolerance_guide_2: |-
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
     disable_on_attributes: Some(vec!["title".to_string()]),
-    min_word_size_for_typos: Some(min_word_size_for_typos),
+    disable_on_words: None,
+    min_word_size_for_typos: None,
   };
 
   let task: TaskInfo = client
@@ -889,6 +894,7 @@ typo_tolerance_guide_3: |-
   }
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
+    disable_on_attributes: None,
     disable_on_words: Some(vec!["shrek".to_string()]),
     min_word_size_for_typos: Some(min_word_size_for_typos),
   };
@@ -905,6 +911,7 @@ typo_tolerance_guide_4: |-
   };
   let typo_tolerance = TypoToleranceSettings {
     enabled: Some(true),
+    disable_on_attributes: Some(vec![]),
     disable_on_words: Some(vec!["title".to_string()]),
     min_word_size_for_typos: Some(min_word_size_for_typos),
   };

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,7 +29,7 @@ impl Default for MinWordSizeForTypos {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 
 pub struct TypoToleranceSettings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,7 +13,7 @@ pub struct PaginationSetting {
     pub max_total_hits: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MinWordSizeForTypos {
     pub one_typo: u8,
@@ -56,10 +56,7 @@ impl TypoToleranceSettings {
     }
 
     pub fn with_enabled(self, enabled: bool) -> TypoToleranceSettings {
-        TypoToleranceSettings {
-            enabled,
-            ..self
-        }
+        TypoToleranceSettings { enabled, ..self }
     }
 
     pub fn with_disable_on_attributes(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -23,10 +23,10 @@ pub struct MinWordSizeForTypos {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TypoToleranceSettings {
-    pub enabled: bool,
-    pub disable_on_attributes: Vec<String>,
-    pub disable_on_words: Vec<String>,
-    pub min_word_size_for_typos: MinWordSizeForTypos,
+    pub enabled: Option<bool>,
+    pub disable_on_attributes: Option<Vec<String>>,
+    pub disable_on_words: Option<Vec<String>>,
+    pub min_word_size_for_typos: Option<MinWordSizeForTypos>,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
@@ -1051,10 +1051,12 @@ impl Index {
     /// let mut index = client.index("set_typo_tolerance");
     ///
     /// let mut typo_tolerance = TypoToleranceSettings {
-    ///     enabled: true,
-    ///     disable_on_attributes: vec!(),
-    ///     disable_on_words: vec!(),
-    ///     min_word_size_for_typos: MinWordSizeForTypos { one_typo : 1, two_typos: 2},
+    ///     enabled: Some(true),
+    ///     disable_on_attributes: None,
+    ///     disable_on_words: None,
+    ///     min_word_size_for_typos: Some(MinWordSizeForTypos {
+    ///     one_typo: 5,
+    ///     two_typos: 9})
     /// };
     ///
     /// let task = index.set_typo_tolerance(&typo_tolerance).await.unwrap();
@@ -1562,13 +1564,13 @@ mod tests {
     #[meilisearch_test]
     async fn test_get_typo_tolerance(index: Index) {
         let typo_tolerance = TypoToleranceSettings {
-            enabled: true,
-            disable_on_attributes: vec![],
-            disable_on_words: vec![],
-            min_word_size_for_typos: MinWordSizeForTypos {
+            enabled: Some(true),
+            disable_on_attributes: None,
+            disable_on_words: None,
+            min_word_size_for_typos: Some(MinWordSizeForTypos {
                 one_typo: 5,
                 two_typos: 9,
-            },
+            }),
         };
 
         let res = index.get_typo_tolerance().await.unwrap();
@@ -1579,13 +1581,13 @@ mod tests {
     #[meilisearch_test]
     async fn test_set_typo_tolerance(client: Client, index: Index) {
         let typo_tolerance = TypoToleranceSettings {
-            enabled: false,
-            disable_on_attributes: vec![],
-            disable_on_words: vec![],
-            min_word_size_for_typos: MinWordSizeForTypos {
+            enabled: Some(false),
+            disable_on_attributes: None,
+            disable_on_words: None,
+            min_word_size_for_typos: Some(MinWordSizeForTypos {
                 one_typo: 6,
                 two_typos: 9,
-            },
+            }),
         };
         let task_info = index.set_typo_tolerance(&typo_tolerance).await.unwrap();
         client.wait_for_task(task_info, None, None).await.unwrap();
@@ -1598,22 +1600,22 @@ mod tests {
     #[meilisearch_test]
     async fn test_reset_typo_tolerance(index: Index) {
         let typo_tolerance = TypoToleranceSettings {
-            enabled: false,
-            disable_on_attributes: vec![],
-            disable_on_words: vec![],
-            min_word_size_for_typos: MinWordSizeForTypos {
+            enabled: Some(false),
+            disable_on_attributes: None,
+            disable_on_words: None,
+            min_word_size_for_typos: Some(MinWordSizeForTypos {
                 one_typo: 1,
                 two_typos: 2,
-            },
+            }),
         };
         let default = TypoToleranceSettings {
-            enabled: true,
-            disable_on_attributes: vec![],
-            disable_on_words: vec![],
-            min_word_size_for_typos: MinWordSizeForTypos {
+            enabled: Some(true),
+            disable_on_attributes: None,
+            disable_on_words: None,
+            min_word_size_for_typos: Some(MinWordSizeForTypos {
                 one_typo: 5,
                 two_typos: 9,
-            },
+            }),
         };
 
         let task = index.set_typo_tolerance(&typo_tolerance).await.unwrap();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,20 +13,40 @@ pub struct PaginationSetting {
     pub max_total_hits: usize,
 }
 
-#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MinWordSizeForTypos {
-    pub one_typo: i64,
-    pub two_typos: i64,
+    pub one_typo: Option<i64>,
+    pub two_typos: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+impl Default for MinWordSizeForTypos {
+    fn default() -> Self {
+        MinWordSizeForTypos {
+            one_typo: Some(5),
+            two_typos: Some(9),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TypoToleranceSettings {
     pub enabled: Option<bool>,
     pub disable_on_attributes: Option<Vec<String>>,
     pub disable_on_words: Option<Vec<String>>,
     pub min_word_size_for_typos: Option<MinWordSizeForTypos>,
+}
+
+impl Default for TypoToleranceSettings {
+    fn default() -> Self {
+        TypoToleranceSettings {
+            enabled: Some(true),
+            disable_on_attributes: Some(vec![]),
+            disable_on_words: Some(vec![]),
+            min_word_size_for_typos: Some(MinWordSizeForTypos::default()),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
@@ -1050,14 +1070,7 @@ impl Index {
     /// # client.create_index("set_typo_tolerance", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let mut index = client.index("set_typo_tolerance");
     ///
-    /// let mut typo_tolerance = TypoToleranceSettings {
-    ///     enabled: Some(true),
-    ///     disable_on_attributes: None,
-    ///     disable_on_words: None,
-    ///     min_word_size_for_typos: Some(MinWordSizeForTypos {
-    ///     one_typo: 5,
-    ///     two_typos: 9})
-    /// };
+    /// let mut typo_tolerance = TypoToleranceSettings::default();
     ///
     /// let task = index.set_typo_tolerance(&typo_tolerance).await.unwrap();
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
@@ -1563,15 +1576,7 @@ mod tests {
 
     #[meilisearch_test]
     async fn test_get_typo_tolerance(index: Index) {
-        let typo_tolerance = TypoToleranceSettings {
-            enabled: Some(true),
-            disable_on_attributes: None,
-            disable_on_words: None,
-            min_word_size_for_typos: Some(MinWordSizeForTypos {
-                one_typo: 5,
-                two_typos: 9,
-            }),
-        };
+        let typo_tolerance = TypoToleranceSettings::default();
 
         let res = index.get_typo_tolerance().await.unwrap();
 
@@ -1582,11 +1587,11 @@ mod tests {
     async fn test_set_typo_tolerance(client: Client, index: Index) {
         let typo_tolerance = TypoToleranceSettings {
             enabled: Some(false),
-            disable_on_attributes: None,
-            disable_on_words: None,
+            disable_on_attributes: Some(vec![]),
+            disable_on_words: Some(vec![]),
             min_word_size_for_typos: Some(MinWordSizeForTypos {
-                one_typo: 6,
-                two_typos: 9,
+                one_typo: Some(6),
+                two_typos: Some(9),
             }),
         };
         let task_info = index.set_typo_tolerance(&typo_tolerance).await.unwrap();
@@ -1601,20 +1606,11 @@ mod tests {
     async fn test_reset_typo_tolerance(index: Index) {
         let typo_tolerance = TypoToleranceSettings {
             enabled: Some(false),
-            disable_on_attributes: None,
-            disable_on_words: None,
+            disable_on_attributes: Some(vec![]),
+            disable_on_words: Some(vec![]),
             min_word_size_for_typos: Some(MinWordSizeForTypos {
-                one_typo: 1,
-                two_typos: 2,
-            }),
-        };
-        let default = TypoToleranceSettings {
-            enabled: Some(true),
-            disable_on_attributes: None,
-            disable_on_words: None,
-            min_word_size_for_typos: Some(MinWordSizeForTypos {
-                one_typo: 5,
-                two_typos: 9,
+                one_typo: Some(1),
+                two_typos: Some(2),
             }),
         };
 
@@ -1626,6 +1622,6 @@ mod tests {
 
         let res = index.get_typo_tolerance().await.unwrap();
 
-        assert_eq!(default, res);
+        assert_eq!(TypoToleranceSettings::default(), res);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,29 +13,81 @@ pub struct PaginationSetting {
     pub max_total_hits: usize,
 }
 
+fn is_min_word_size_object_default(s: &MinWordSizeForTypos) -> bool {
+    if *s == MinWordSizeForTypos::default() {
+        return true;
+    }
+    false
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MinWordSizeForTypos {
+    #[serde(default = "default_one_typo_size")]
+    #[serde(skip_serializing_if = "is_default_for_one_typo")]
     pub one_typo: u8,
+    #[serde(skip_serializing_if = "is_default_for_two_typos")]
+    #[serde(default = "default_two_typos_size")]
     pub two_typos: u8,
 }
 
 impl Default for MinWordSizeForTypos {
     fn default() -> Self {
         MinWordSizeForTypos {
-            one_typo: 5,
-            two_typos: 9,
+            one_typo: default_one_typo_size(),
+            two_typos: default_two_typos_size(),
         }
     }
 }
 
+const fn default_as_true() -> bool {
+    true
+}
+
+const fn default_one_typo_size() -> u8 {
+    5
+}
+
+const fn default_two_typos_size() -> u8 {
+    9
+}
+
+const fn is_true(val: &bool) -> bool {
+    if *val {
+        return true;
+    }
+
+    false
+}
+
+const fn is_default_for_one_typo(s: &u8) -> bool {
+    if *s == default_one_typo_size() {
+        return true;
+    }
+
+    false
+}
+
+const fn is_default_for_two_typos(s: &u8) -> bool {
+    if *s == default_two_typos_size() {
+        return true;
+    }
+
+    false
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-
+#[serde(default)]
 pub struct TypoToleranceSettings {
+    #[serde(default = "default_as_true")]
+    #[serde(skip_serializing_if = "is_true")]
     pub enabled: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub disable_on_attributes: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub disable_on_words: Vec<String>,
+    #[serde(skip_serializing_if = "is_min_word_size_object_default")]
     pub min_word_size_for_typos: MinWordSizeForTypos,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,9 +17,9 @@ pub struct PaginationSetting {
 #[serde(rename_all = "camelCase")]
 pub struct MinWordSizeForTypos {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub one_typo: Option<i64>,
+    pub one_typo: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub two_typos: Option<i64>,
+    pub two_typos: Option<u8>,
 }
 
 impl Default for MinWordSizeForTypos {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -618,7 +618,8 @@ impl Index {
     /// let client = Client::new(MEILISEARCH_HOST, Some(MEILISEARCH_API_KEY));
     /// # client.create_index("get_typo_tolerance", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// let index = client.index("get_typo_tolerance");
-    /// let typotolerance = index.get_typo_tolerance().await.unwrap();
+    ///
+    /// let typo_tolerance = index.get_typo_tolerance().await.unwrap();
     /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -16,7 +16,9 @@ pub struct PaginationSetting {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MinWordSizeForTypos {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub one_typo: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub two_typos: Option<i64>,
 }
 
@@ -31,10 +33,15 @@ impl Default for MinWordSizeForTypos {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+
 pub struct TypoToleranceSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_on_attributes: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_on_words: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_word_size_for_typos: Option<MinWordSizeForTypos>,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -57,7 +57,7 @@ impl TypoToleranceSettings {
 
     pub fn with_enabled(self, enabled: bool) -> TypoToleranceSettings {
         TypoToleranceSettings {
-            enabled: enabled,
+            enabled,
             ..self
         }
     }
@@ -94,7 +94,7 @@ impl TypoToleranceSettings {
         min_word_size_for_typos: MinWordSizeForTypos,
     ) -> TypoToleranceSettings {
         TypoToleranceSettings {
-            min_word_size_for_typos: min_word_size_for_typos,
+            min_word_size_for_typos,
             ..self
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -104,8 +104,8 @@ impl TypoToleranceSettings {
         self
     }
 
-    pub fn with_min_word_size_for_two_typo(mut self, two_typo: u8) -> TypoToleranceSettings {
-        self.min_word_size_for_typos.two_typos = two_typo;
+    pub fn with_min_word_size_for_two_typos(mut self, two_typos: u8) -> TypoToleranceSettings {
+        self.min_word_size_for_typos.two_typos = two_typos;
         self
     }
 }


### PR DESCRIPTION
It's coming after https://github.com/meilisearch/meilisearch-rust/pull/351 PR.
I fixed the comments of the other PR here.

fixes #260 