### PR TITLE
add functions for csv documents

### DIFF
--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -823,7 +823,7 @@ impl Index {
     /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
     /// let movie_index = client.index("update_documents_ndjson");
     ///
-    /// let task = movie_index.add_documents_csv(
+    /// let task = movie_index.update_documents_csv(
     ///     r#"1,body
     ///     1,"doggo"
     ///     2,"catto""#.as_bytes(),
@@ -2067,17 +2067,11 @@ mod tests {
 
     #[meilisearch_test]
     async fn test_update_documents_csv(client: Client, index: Index) -> Result<(), Error> {
-        let old_csv = r#"1,body
-             1,"doggo"
-             2,"catto""#
-            .as_bytes();
-        let updated_csv = r#"1,body
-             1,"new_doggo"
-             2,"new_catto""#
-            .as_bytes();
+        let old_csv = "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes();
+        let updated_csv = "id,body\n1,\"new_doggo\"\n2,\"new_catto\"".as_bytes();
         // Add first njdson document
         let task = index
-            .add_documents_ndjson(old_csv, Some("id"))
+            .add_documents_csv(old_csv, Some("id"))
             .await?
             .wait_for_completion(&client, None, None)
             .await?;
@@ -2085,7 +2079,7 @@ mod tests {
 
         // Update via njdson document
         let task = index
-            .update_documents_ndjson(updated_csv, Some("id"))
+            .update_documents_csv(updated_csv, Some("id"))
             .await?
             .wait_for_completion(&client, None, None)
             .await?;
@@ -2097,8 +2091,8 @@ mod tests {
         assert!(elements.results.len() == 2);
 
         let expected_result = vec![
-            json!( {"body": "doggo", "id": 1, "second_body": "second_doggo"}),
-            json!( {"body": "catto", "id": 2, "second_body": "second_catto"}),
+            json!( {"body": "new_doggo", "id": "1"}),
+            json!( {"body": "new_catto", "id": "2"}),
         ];
 
         assert_eq!(elements.results, expected_result);
@@ -2108,10 +2102,7 @@ mod tests {
 
     #[meilisearch_test]
     async fn test_add_documents_csv(client: Client, index: Index) -> Result<(), Error> {
-        let csv_input = r#"1,body
-             1,"doggo"
-             2,"catto""#
-            .as_bytes();
+        let csv_input = "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes();
 
         let task = index
             .add_documents_csv(csv_input, Some("id"))

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -753,51 +753,6 @@ impl Index {
             .await
     }
 
-    /// Add a raw csv payload to meilisearch.
-    ///
-    /// It configures the correct content type for csv data.
-    ///
-    /// If you send an already existing document (same id) the **whole existing document** will be overwritten by the new document.
-    /// Fields previously in the document not present in the new document are removed.
-    ///
-    /// For a partial update of the document see [`Index::update_documents_csv`].
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use serde::{Serialize, Deserialize};
-    /// # use meilisearch_sdk::{client::*, indexes::*};
-    /// # use std::thread::sleep;
-    /// # use std::time::Duration;
-    /// #
-    /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
-    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
-    /// # futures::executor::block_on(async move {
-    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
-    /// let movie_index = client.index("add_documents_ndjson");
-    ///
-    /// let task = movie_index.add_documents_csv(
-    ///     "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes(),
-    ///     Some("id"),
-    ///   ).await.unwrap();
-    /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed
-    /// client.wait_for_task(task, None, None).await.unwrap();
-    ///
-    /// let movies = movie_index.get_documents::<serde_json::Value>().await.unwrap();
-    /// assert!(movies.results.len() == 2);
-    /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
-    /// # });
-    /// ```
-    #[cfg(not(target_arch = "wasm32"))]
-    pub async fn add_documents_csv<T: futures_io::AsyncRead + Send + Sync + 'static>(
-        &self,
-        payload: T,
-        primary_key: Option<&str>,
-    ) -> Result<TaskInfo, Error> {
-        self.add_or_replace_unchecked_payload(payload, "text/csv", primary_key)
-            .await
-    }
-
     /// Add a raw csv payload and update them if they already.
     ///
     /// It configures the correct content type for csv data.
@@ -819,7 +774,7 @@ impl Index {
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// # futures::executor::block_on(async move {
     /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
-    /// let movie_index = client.index("update_documents_ndjson");
+    /// let movie_index = client.index("update_documents_csv");
     ///
     /// let task = movie_index.update_documents_csv(
     ///     "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes(),
@@ -840,6 +795,51 @@ impl Index {
         primary_key: Option<&str>,
     ) -> Result<TaskInfo, Error> {
         self.add_or_update_unchecked_payload(payload, "text/csv", primary_key)
+            .await
+    }
+
+    /// Add a raw csv payload to meilisearch.
+    ///
+    /// It configures the correct content type for csv data.
+    ///
+    /// If you send an already existing document (same id) the **whole existing document** will be overwritten by the new document.
+    /// Fields previously in the document not present in the new document are removed.
+    ///
+    /// For a partial update of the document see [`Index::update_documents_csv`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use serde::{Serialize, Deserialize};
+    /// # use meilisearch_sdk::{client::*, indexes::*};
+    /// # use std::thread::sleep;
+    /// # use std::time::Duration;
+    /// #
+    /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
+    /// let movie_index = client.index("add_documents_csv");
+    ///
+    /// let task = movie_index.add_documents_csv(
+    ///     "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes(),
+    ///     Some("id"),
+    ///   ).await.unwrap();
+    /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed
+    /// client.wait_for_task(task, None, None).await.unwrap();
+    ///
+    /// let movies = movie_index.get_documents::<serde_json::Value>().await.unwrap();
+    /// assert!(movies.results.len() == 2);
+    /// # movie_index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn add_documents_csv<T: futures_io::AsyncRead + Send + Sync + 'static>(
+        &self,
+        payload: T,
+        primary_key: Option<&str>,
+    ) -> Result<TaskInfo, Error> {
+        self.add_or_replace_unchecked_payload(payload, "text/csv", primary_key)
             .await
     }
 
@@ -2062,59 +2062,6 @@ mod tests {
     }
 
     #[meilisearch_test]
-    async fn test_update_documents_csv(client: Client, index: Index) -> Result<(), Error> {
-        let old_csv = "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes();
-        let updated_csv = "id,body\n1,\"new_doggo\"\n2,\"new_catto\"".as_bytes();
-        // Add first njdson document
-        let task = index
-            .add_documents_csv(old_csv, Some("id"))
-            .await?
-            .wait_for_completion(&client, None, None)
-            .await?;
-        let _ = index.get_task(task).await?;
-
-        // Update via njdson document
-        let task = index
-            .update_documents_csv(updated_csv, Some("id"))
-            .await?
-            .wait_for_completion(&client, None, None)
-            .await?;
-
-        let status = index.get_task(task).await?;
-        let elements = index.get_documents::<serde_json::Value>().await.unwrap();
-
-        assert!(matches!(status, Task::Succeeded { .. }));
-        assert!(elements.results.len() == 2);
-
-        let expected_result = vec![
-            json!( {"body": "new_doggo", "id": "1"}),
-            json!( {"body": "new_catto", "id": "2"}),
-        ];
-
-        assert_eq!(elements.results, expected_result);
-
-        Ok(())
-    }
-
-    #[meilisearch_test]
-    async fn test_add_documents_csv(client: Client, index: Index) -> Result<(), Error> {
-        let csv_input = "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes();
-
-        let task = index
-            .add_documents_csv(csv_input, Some("id"))
-            .await?
-            .wait_for_completion(&client, None, None)
-            .await?;
-
-        let status = index.get_task(task).await?;
-        let elements = index.get_documents::<serde_json::Value>().await.unwrap();
-        assert!(matches!(status, Task::Succeeded { .. }));
-        assert!(elements.results.len() == 2);
-
-        Ok(())
-    }
-
-    #[meilisearch_test]
     async fn test_update_documents_ndjson(client: Client, index: Index) -> Result<(), Error> {
         let old_ndjson = r#"{ "id": 1, "body": "doggo" }{ "id": 2, "body": "catto" }"#.as_bytes();
         let updated_ndjson =
@@ -2150,6 +2097,58 @@ mod tests {
         Ok(())
     }
 
+    #[meilisearch_test]
+    async fn test_add_documents_csv(client: Client, index: Index) -> Result<(), Error> {
+        let csv_input = "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes();
+
+        let task = index
+            .add_documents_csv(csv_input, Some("id"))
+            .await?
+            .wait_for_completion(&client, None, None)
+            .await?;
+
+        let status = index.get_task(task).await?;
+        let elements = index.get_documents::<serde_json::Value>().await.unwrap();
+        assert!(matches!(status, Task::Succeeded { .. }));
+        assert!(elements.results.len() == 2);
+
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_update_documents_csv(client: Client, index: Index) -> Result<(), Error> {
+        let old_csv = "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes();
+        let updated_csv = "id,body\n1,\"new_doggo\"\n2,\"new_catto\"".as_bytes();
+        // Add first njdson document
+        let task = index
+            .add_documents_csv(old_csv, Some("id"))
+            .await?
+            .wait_for_completion(&client, None, None)
+            .await?;
+        let _ = index.get_task(task).await?;
+
+        // Update via njdson document
+        let task = index
+            .update_documents_csv(updated_csv, Some("id"))
+            .await?
+            .wait_for_completion(&client, None, None)
+            .await?;
+
+        let status = index.get_task(task).await?;
+        let elements = index.get_documents::<serde_json::Value>().await.unwrap();
+
+        assert!(matches!(status, Task::Succeeded { .. }));
+        assert!(elements.results.len() == 2);
+
+        let expected_result = vec![
+            json!( {"body": "new_doggo", "id": "1"}),
+            json!( {"body": "new_catto", "id": "2"}),
+        ];
+
+        assert_eq!(elements.results, expected_result);
+
+        Ok(())
+    }
     #[meilisearch_test]
     async fn test_get_one_task(client: Client, index: Index) -> Result<(), Error> {
         let task = index

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -777,9 +777,7 @@ impl Index {
     /// let movie_index = client.index("add_documents_ndjson");
     ///
     /// let task = movie_index.add_documents_csv(
-    ///     r#"1,body
-    ///     1,"doggo"
-    ///     2,"catto""#.as_bytes(),
+    ///     "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes(),
     ///     Some("id"),
     ///   ).await.unwrap();
     /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed
@@ -824,9 +822,7 @@ impl Index {
     /// let movie_index = client.index("update_documents_ndjson");
     ///
     /// let task = movie_index.update_documents_csv(
-    ///     r#"1,body
-    ///     1,"doggo"
-    ///     2,"catto""#.as_bytes(),
+    ///     "id,body\n1,\"doggo\"\n2,\"catto\"".as_bytes(),
     ///     Some("id"),
     ///   ).await.unwrap();
     /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes partially #191

## What does this PR do?
Added the first two functions (with their tests) for issue #191. It includes two functions for sending csv payloads 
- `add_documents_csv`
-  `update_documents_csv`


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
