### PR TITLE
meilisearch#499 (attributesToSearchOn)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -692,6 +692,15 @@ search_parameter_guide_query_1: |-
     .execute()
     .await
     .unwrap();
+search_parameter_guide_attributes_to_search_on_1: |-
+  let results: SearchResults<Movie> = client
+    .index("movies")
+    .search()
+    .with_query("adventure")
+    .with_attributes_to_search_on(&["overview"])
+    .execute()
+    .await
+    .unwrap();
 search_parameter_guide_offset_1: |-
   let results: SearchResults<Movie> = client
     .index("movies")


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #499 

## What does this PR do?
- adds support for the attributesToSearchOn (which was added in meilisearch  v1.3) to the rust client as `with_attributes_to_search_on`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
