### PR TITLE
Add feature: dictionary settings

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -595,6 +595,26 @@ reset_faceting_settings_1: |-
     .reset_faceting()
     .await
     .unwrap();
+
+get_dictionary_1: |-
+  let task: TaskInfo = client
+    .index('books')
+    .get_dictionary()
+    .await
+    .unwrap();
+update_dictionary_1: |-
+  let task: TaskInfo = client
+    .index('books')
+    .set_dictionary(['J. R. R.', 'W. E. B.'])
+    .await
+    .unwrap();
+reset_dictionary_1: |-
+  let task: TaskInfo = client
+    .index('books')
+    .reset_dictionary()
+    .await
+    .unwrap();
+    
 get_index_stats_1: |-
   let stats: IndexStats = client
     .index("movies")

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -243,6 +243,7 @@ pub enum ErrorCode {
     InvalidSettingsDistinctAttributes,
     InvalidSettingsTypoTolerance,
     InvalidSettingsFaceting,
+    InvalidSettingsDictionary,
     InvalidSettingsPagination,
     InvalidTaskBeforeEnqueuedAt,
     InvalidTaskAfterEnqueuedAt,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -95,6 +95,9 @@ pub struct Settings {
     /// TypoTolerance settings
     #[serde(skip_serializing_if = "Option::is_none")]
     pub typo_tolerance: Option<TypoToleranceSettings>,
+    /// Dictionary settings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dictionary: Option<Vec<String>>,
 }
 
 #[allow(missing_docs)]
@@ -240,6 +243,21 @@ impl Settings {
     pub fn with_faceting(self, faceting: &FacetingSettings) -> Settings {
         Settings {
             faceting: Some(*faceting),
+            ..self
+        }
+    }
+
+    pub fn with_dictionary(
+        self,
+        dictionary: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Settings {
+        Settings {
+            dictionary: Some(
+                dictionary
+                    .into_iter()
+                    .map(|v| v.as_ref().to_string())
+                    .collect(),
+            ),
             ..self
         }
     }
@@ -595,6 +613,38 @@ impl Index {
         request::<(), (), FacetingSettings>(
             &format!(
                 "{}/indexes/{}/settings/faceting",
+                self.client.host, self.uid
+            ),
+            self.client.get_api_key(),
+            Method::Get { query: () },
+            200,
+        )
+        .await
+    }
+
+    /// Get [dictionary](https://www.meilisearch.com/docs/reference/api/settings#dictionary) of the [Index].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*};
+    /// #
+    /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
+    /// # client.create_index("get_dictionary", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// let index = client.index("get_dictionary");
+    ///
+    /// let dictionary = index.get_dictionary().await.unwrap();
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn get_dictionary(&self) -> Result<Vec<String>, Error> {
+        request::<(), (), Vec<String>>(
+            &format!(
+                "{}/indexes/{}/settings/dictionary",
                 self.client.host, self.uid
             ),
             self.client.get_api_key(),
@@ -1089,6 +1139,47 @@ impl Index {
         .await
     }
 
+    /// Update [dictionary](https://www.meilisearch.com/docs/reference/api/settings#dictionary) of the [Index].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
+    /// #
+    /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
+    /// # client.create_index("set_dictionary", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// let mut index = client.index("set_dictionary");
+    ///
+    /// let task = index.set_dictionary(["J. K.", "J. R. R."]).await.unwrap();
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn set_dictionary(
+        &self,
+        dictionary: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<TaskInfo, Error> {
+        request::<(), Vec<String>, TaskInfo>(
+            &format!(
+                "{}/indexes/{}/settings/dictionary",
+                self.client.host, self.uid
+            ),
+            self.client.get_api_key(),
+            Method::Put {
+                query: (),
+                body: dictionary
+                    .into_iter()
+                    .map(|v| v.as_ref().to_string())
+                    .collect(),
+            },
+            202,
+        )
+        .await
+    }
+
     /// Update [typo tolerance](https://www.meilisearch.com/docs/learn/configuration/typo_tolerance#typo-tolerance) settings of the [Index].
     ///
     /// # Example
@@ -1487,6 +1578,38 @@ impl Index {
         .await
     }
 
+    /// Reset [dictionary](https://www.meilisearch.com/docs/reference/api/settings#dictionary) of the [Index].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*, settings::Settings};
+    /// #
+    /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # futures::executor::block_on(async move {
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY));
+    /// # client.create_index("reset_dictionary", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// let mut index = client.index("reset_dictionary");
+    ///
+    /// let task = index.reset_dictionary().await.unwrap();
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn reset_dictionary(&self) -> Result<TaskInfo, Error> {
+        request::<(), (), TaskInfo>(
+            &format!(
+                "{}/indexes/{}/settings/dictionary",
+                self.client.host, self.uid
+            ),
+            self.client.get_api_key(),
+            Method::Delete { query: () },
+            202,
+        )
+        .await
+    }
+
     /// Reset [typo tolerance](https://www.meilisearch.com/docs/learn/configuration/typo_tolerance#typo-tolerance) settings of the [Index].
     ///
     /// # Example
@@ -1577,6 +1700,49 @@ mod tests {
         let res = index.get_faceting().await.unwrap();
 
         assert_eq!(faceting, res);
+    }
+
+    #[meilisearch_test]
+    async fn test_get_dicitonary(index: Index) {
+        let dictionary: Vec<String> = vec![];
+
+        let res = index.get_dictionary().await.unwrap();
+
+        assert_eq!(dictionary, res);
+    }
+
+    #[meilisearch_test]
+    async fn test_set_dicitonary(client: Client, index: Index) {
+        let dictionary: Vec<&str> = vec!["J. K.", "J. R. R."];
+        let task_info = index.set_dictionary(&dictionary).await.unwrap();
+        client.wait_for_task(task_info, None, None).await.unwrap();
+
+        let res = index.get_dictionary().await.unwrap();
+
+        assert_eq!(dictionary, res);
+    }
+
+    #[meilisearch_test]
+    async fn test_set_empty_dicitonary(client: Client, index: Index) {
+        let dictionary: Vec<&str> = vec![];
+        let task_info = index.set_dictionary(&dictionary).await.unwrap();
+        client.wait_for_task(task_info, None, None).await.unwrap();
+
+        let res = index.get_dictionary().await.unwrap();
+
+        assert_eq!(dictionary, res);
+    }
+
+
+    #[meilisearch_test]
+    async fn test_reset_dictionary(client: Client, index: Index) {
+        let dictionary: Vec<&str> = vec![];
+        let task_info = index.reset_dictionary().await.unwrap();
+        client.wait_for_task(task_info, None, None).await.unwrap();
+        
+        let res = index.get_dictionary().await.unwrap();
+
+        assert_eq!(dictionary, res);
     }
 
     #[meilisearch_test]


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #527

## What does this PR do?
 - Added the `dictionary` setting to the `Settings` struct, providing users with a flexible way to manage their search dictionary.
 - Implemented three new methods for interacting with the `dictionary` setting:
   - `get_dictionary`: Retrieves the current dictionary configuration.
   - `set_dictionary`: Updates the dictionary with a new configuration.
   - `reset_dictionary`: Resets the dictionary configuration to default values.
- Created comprehensive integration tests to ensure the correctness and robustness of these new methods.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Added integration tests for the new methods.
- [x] Verified the correctness of existing unit tests.
- [x] Ensured that the codebase adheres to the project's coding style guidelines.
- [x] Updated the `.code-samples.meilisearch.yaml` file to incorporate new examples for the `get_dictionary`, `set_dictionary`, and `reset_dictionary` methods.

Please review and provide feedback on the changes introduced in this pull request.
