### PR TITLE
expose isach/rustls-tls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ wasm-bindgen-futures = "0.4"
 default = ["isahc-static-curl"]
 isahc-static-curl = ["isahc/static-curl"]
 isahc-static-ssl = ["isahc/static-ssl"]
+isach-rustls-tls = ["isahc/rustls-tls"]
 
 [dev-dependencies]
 env_logger = "0.11"


### PR DESCRIPTION
This makes it possible to use `rustls` via the upstream feature flag.

See: https://github.com/sagebind/isahc/blob/096aff7b13f4ff5bb474fdc27bc30b297a2968f6/Cargo.toml#L29