### PR TITLE
Vector search embedder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ wasm-bindgen-futures = "0.4"
 default = ["isahc-static-curl"]
 isahc-static-curl = ["isahc/static-curl"]
 isahc-static-ssl = ["isahc/static-ssl"]
+experimental-vector-search = []
 
 [dev-dependencies]
 futures-await-test = "0.3"

--- a/src/search.rs
+++ b/src/search.rs
@@ -135,6 +135,22 @@ pub enum Selectors<T> {
     All,
 }
 
+#[cfg(feature = "experimental-vector-search")]
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HybridSearch<'a> {
+    /// Indicates one of the embedders configured for the queried index
+    ///
+    /// **Default: `"default"`**
+    embedder: &'a str,
+    /// number between `0` and `1`:
+    /// - `0.0` indicates full keyword search
+    /// - `1.0` indicates full semantic search
+    ///
+    /// **Default: `0.5`**
+    semantic_ratio: f32,
+}
+
 type AttributeToCrop<'a> = (&'a str, Option<usize>);
 
 /// A struct representing a query.
@@ -325,6 +341,12 @@ pub struct SearchQuery<'a> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) index_uid: Option<&'a str>,
+
+    /// EXPERIMENTAL
+    /// Defines whether to utilise previously defined embedders for semantic searching
+    #[cfg(feature = "experimental-vector-search")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hybrid: Option<HybridSearch<'a>>,
 }
 
 #[allow(missing_docs)]
@@ -353,6 +375,8 @@ impl<'a> SearchQuery<'a> {
             show_ranking_score: None,
             matching_strategy: None,
             index_uid: None,
+            #[cfg(feature = "experimental-vector-search")]
+            hybrid: None,
         }
     }
     pub fn with_query<'b>(&'b mut self, query: &'a str) -> &'b mut SearchQuery<'a> {
@@ -525,6 +549,19 @@ impl<'a> SearchQuery<'a> {
         self.index_uid = Some(&self.index.uid);
         self
     }
+    #[cfg(feature = "experimental-vector-search")]
+    pub fn with_hybrid<'b>(
+        &'b mut self,
+        embedder: &'a str,
+        semantic_ratio: f32,
+    ) -> &'b mut SearchQuery<'a> {
+        self.hybrid = Some(HybridSearch {
+            embedder,
+            semantic_ratio,
+        });
+        self
+    }
+
     #[must_use]
     pub fn build(&mut self) -> SearchQuery<'a> {
         self.clone()
@@ -582,6 +619,7 @@ mod tests {
     use meilisearch_test_macro::meilisearch_test;
     use serde::{Deserialize, Serialize};
     use serde_json::{json, Map, Value};
+    use std::time::Duration;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Nested {
@@ -623,9 +661,15 @@ mod tests {
             .await?;
         let t2 = index.set_sortable_attributes(["title"]).await?;
 
-        t2.wait_for_completion(client, None, None).await?;
-        t1.wait_for_completion(client, None, None).await?;
-        t0.wait_for_completion(client, None, None).await?;
+        // the vector search has longer indexing times leading to the timeout being triggered
+        let timeout = if cfg!(feature = "experimental-vector-search") {
+            Some(Duration::from_secs(120))
+        } else {
+            None
+        };
+        t2.wait_for_completion(client, None, timeout).await?;
+        t1.wait_for_completion(client, None, timeout).await?;
+        t0.wait_for_completion(client, None, timeout).await?;
 
         Ok(())
     }
@@ -1172,6 +1216,89 @@ mod tests {
 
             assert!(!result.hits.is_empty());
         }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "experimental-vector-search")]
+    #[meilisearch_test]
+    async fn test_hybrid(client: Client, index: Index) -> Result<(), Error> {
+        log::warn!("You are executing the vector search test. This WILL take a while and might lead to timeouts in other tests. You can disable this testcase by not enabling the `experimental-vector-search`-feature and running this ");
+        // enable vector searching and configure an embedder
+        let features = crate::ExperimentalFeatures::new(&client)
+            .set_vector_store(true)
+            .update()
+            .await
+            .expect("could not enable the vector store");
+        assert_eq!(features.vector_store, true);
+        let embedder_setting = crate::Embedder::HuggingFace(crate::HuggingFaceEmbedderSettings {
+            model: "BAAI/bge-base-en-v1.5".into(),
+            revision: None,
+            document_template: Some("{{ doc.value }}".into()),
+        });
+        let t3 = index
+            .set_settings(&crate::Settings {
+                embedders: Some(HashMap::from([("default".to_string(), embedder_setting)])),
+                ..crate::Settings::default()
+            })
+            .await?;
+        t3.wait_for_completion(&client, None, None).await?;
+
+        setup_test_index(&client, &index).await?;
+
+        // "zweite" = "second" in german
+        // => an embedding should be able to detect that this is equivalent, but not the regular search
+        let results: SearchResults<Document> = index
+            .search()
+            .with_query("Facebook")
+            .with_hybrid("default", 1.0) // entirely rely on semantic searching
+            .execute()
+            .await?;
+        assert_eq!(results.hits.len(), 1);
+        assert_eq!(
+            &Document {
+                id: 1,
+                value: S("dolor sit amet, consectetur adipiscing elit"),
+                kind: S("text"),
+                number: 10,
+                nested: Nested { child: S("second") },
+            },
+            &results.hits[0].result
+        );
+        let results: SearchResults<Document> = index
+            .search()
+            .with_query("zweite")
+            .with_hybrid("default", 0.0) // no semantic searching => no matches
+            .execute()
+            .await?;
+        assert_eq!(results.hits.len(), 0);
+
+        // word that has a typo => would have been found via traditional means
+        // if entirely relying on semantic searching, no result is found
+        let results: SearchResults<Document> = index
+            .search()
+            .with_query("lohrem")
+            .with_hybrid("default", 1.0)
+            .execute()
+            .await?;
+        assert_eq!(results.hits.len(), 0);
+        let results: SearchResults<Document> = index
+            .search()
+            .with_query("lohrem")
+            .with_hybrid("default", 0.0)
+            .execute()
+            .await?;
+        assert_eq!(results.hits.len(), 1);
+        assert_eq!(
+            &Document {
+                id: 0,
+                value: S("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
+                kind: S("text"),
+                number: 0,
+                nested: Nested { child: S("first") }
+            },
+            &results.hits[0].result.id
+        );
 
         Ok(())
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -77,6 +77,7 @@ pub struct OpenapiEmbedderSettings {
     /// The openapi model name
     /// Example: `text-embedding-ada-002`
     pub model: String,
+    pub dimensions: usize,
     /// if present, document_template must be a [Liquid template](https://shopify.github.io/liquid/).
     /// Use `{{ doc.attribute }}` to access document field values.
     /// Meilisearch also exposes a `{{ fields }}` array containing one object per document field, which you may access with `{{ field.name }}` and `{{ field.value }}`.
@@ -90,7 +91,7 @@ pub struct OpenapiEmbedderSettings {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq, Copy)]
 pub struct CustomEmbedderSettings {
     /// dimensions of your custom embedding
-    pub dimensions: u32,
+    pub dimensions: usize,
 }
 
 /// Struct reprensenting a set of settings.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -55,6 +55,8 @@ pub struct HuggingFaceEmbedderSettings {
     /// the BERT embedding model you want to use from HuggingFace
     /// Example: `bge-base-en-v1.5`
     pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
     /// if present, document_template must be a [Liquid template](https://shopify.github.io/liquid/).
     /// Use `{{ doc.attribute }}` to access document field values.
     /// Meilisearch also exposes a `{{ fields }}` array containing one object per document field, which you may access with `{{ field.name }}` and `{{ field.value }}`.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -34,6 +34,63 @@ pub struct FacetingSettings {
     pub max_values_per_facet: usize,
 }
 
+#[cfg(feature = "experimental-vector-search")]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", tag = "source")]
+pub enum Embedder {
+    /// Compute embeddings locally.
+    /// This is a resource-intensive operation and might affect indexing performance.
+    HuggingFace(HuggingFaceEmbedderSettings),
+    /// Use OpenAi's API to generate embeddings
+    OpenAi(OpenapiEmbedderSettings),
+    /// Provide custom embeddings.
+    /// In this case, you must manually update your embeddings when adding, updating, and removing documents to your index.
+    UserProvided(CustomEmbedderSettings),
+}
+
+#[cfg(feature = "experimental-vector-search")]
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct HuggingFaceEmbedderSettings {
+    /// the BERT embedding model you want to use from HuggingFace
+    /// Example: `bge-base-en-v1.5`
+    pub model: String,
+    /// if present, document_template must be a [Liquid template](https://shopify.github.io/liquid/).
+    /// Use `{{ doc.attribute }}` to access document field values.
+    /// Meilisearch also exposes a `{{ fields }}` array containing one object per document field, which you may access with `{{ field.name }}` and `{{ field.value }}`.
+    ///
+    /// For best results, use short strings indicating the type of document in that index, only include highly relevant document fields, and truncate long fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub document_template: Option<String>,
+}
+
+#[cfg(feature = "experimental-vector-search")]
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenapiEmbedderSettings {
+    /// API key used to authorize against OpenAI.
+    /// [Generate an API key](https://platform.openai.com/api-keys) from your OpenAI account.
+    /// Use [tier 2 keys](https://platform.openai.com/docs/guides/rate-limits/usage-tiers?context=tier-two) or above for optimal performance.
+    pub api_key: String,
+    /// The openapi model name
+    /// Example: `text-embedding-ada-002`
+    pub model: String,
+    /// if present, document_template must be a [Liquid template](https://shopify.github.io/liquid/).
+    /// Use `{{ doc.attribute }}` to access document field values.
+    /// Meilisearch also exposes a `{{ fields }}` array containing one object per document field, which you may access with `{{ field.name }}` and `{{ field.value }}`.
+    ///
+    /// For best results, use short strings indicating the type of document in that index, only include highly relevant document fields, and truncate long fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub document_template: Option<String>,
+}
+
+#[cfg(feature = "experimental-vector-search")]
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq, Copy)]
+pub struct CustomEmbedderSettings {
+    /// dimensions of your custom embedding
+    pub dimensions: u32,
+}
+
 /// Struct reprensenting a set of settings.
 ///
 /// You can build this struct using the builder syntax.
@@ -101,6 +158,10 @@ pub struct Settings {
     /// Proximity precision settings.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proximity_precision: Option<String>,
+    /// Settings how the embeddings for the experimental vector search feature are generated
+    #[cfg(feature = "experimental-vector-search")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embedders: Option<HashMap<String, Embedder>>,
 }
 
 #[allow(missing_docs)]
@@ -281,6 +342,23 @@ impl Settings {
     pub fn with_proximity_precision(self, proximity_precision: impl AsRef<str>) -> Settings {
         Settings {
             proximity_precision: Some(proximity_precision.as_ref().to_string()),
+            ..self
+        }
+    }
+
+    #[must_use]
+    #[cfg(feature = "experimental-vector-search")]
+    pub fn with_embedders<S>(self, embedders: HashMap<S, Embedder>) -> Settings
+    where
+        S: AsRef<str>,
+    {
+        Settings {
+            embedders: Some(
+                embedders
+                    .into_iter()
+                    .map(|(key, value)| (key.as_ref().to_string(), value))
+                    .collect(),
+            ),
             ..self
         }
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch-rust/issues/541

## What does this PR do?
- introduces the `experimental-vector-search`-feture flag
- Adds the required settings
- adds the `hybrid` field to search via the vector search 

TODO:
- [ ] added `{get,set,reset}_embedders` settings
- [ ] add testcases for these settings
- [ ] find a combination of semantic search model + configuration that does not fail the assumptions (see search testcase) spectacularly
- [ ] double-check that every line is guarded by `cfg`-makros

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
