### PR TITLE
fix(indexes): allow None `primary_key` in `add_or_update` function

### DIFF
--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -899,14 +899,12 @@ impl Index {
     pub async fn add_or_update<T: Serialize>(
         &self,
         documents: &[T],
-        primary_key: Option<impl AsRef<str>>,
+        primary_key: Option<&str>,
     ) -> Result<TaskInfo, Error> {
         let url = if let Some(primary_key) = primary_key {
             format!(
                 "{}/indexes/{}/documents?primaryKey={}",
-                self.client.host,
-                self.uid,
-                primary_key.as_ref()
+                self.client.host, self.uid, primary_key
             )
         } else {
             format!("{}/indexes/{}/documents", self.client.host, self.uid)

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -2063,21 +2063,31 @@ mod tests {
 
     #[meilisearch_test]
     async fn test_update_document_json(client: Client, index: Index) -> Result<(), Error> {
-        let old_json = r#"{ "id": 1, "body": "doggo" }{ "id": 2, "body": "catto" }"#.as_bytes();
-        let updated_json = r#"{ "id": 1, "second_body": "second_doggo" }{ "id": 2, "second_body": "second_catto" }"#.as_bytes();
+        let old_json = [
+            json!({ "id": 1, "body": "doggo" }),
+            json!({ "id": 2, "body": "catto" }),
+        ];
+        let updated_json = [
+            json!({ "id": 1, "second_body": "second_doggo" }),
+            json!({ "id": 2, "second_body": "second_catto" }),
+        ];
 
         let task = index
-            .add_documents(old_json, Some("id"))
-            .await?
+            .add_documents(&old_json, Some("id"))
+            .await
+            .unwrap()
             .wait_for_completion(&client, None, None)
-            .await?;
+            .await
+            .unwrap();
         let _ = index.get_task(task).await?;
 
         let task = index
-            .add_or_update(updated_json, None)
-            .await?
+            .add_or_update(&updated_json, None)
+            .await
+            .unwrap()
             .wait_for_completion(&client, None, None)
-            .await?;
+            .await
+            .unwrap();
 
         let status = index.get_task(task).await?;
         let elements = index.get_documents::<serde_json::Value>().await.unwrap();


### PR DESCRIPTION
# Pull Request

## Related issue
Cannot pass `None` value to `add_or_update` function

## What does this PR do?
Replace `impl AsRef<str>` to `&str`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
