### PR TITLE
Make the error type implement Send + Sync + 'static

### DIFF
--- a/examples/cli-app-with-awc/Cargo.toml
+++ b/examples/cli-app-with-awc/Cargo.toml
@@ -18,3 +18,4 @@ tokio = { version = "1.27.0", features = ["full"] }
 yaup = "0.2.0"
 tokio-util = { version = "0.7.10", features = ["full"] }
 actix-rt = "2.9.0"
+anyhow = "1.0.82"

--- a/examples/cli-app-with-awc/src/main.rs
+++ b/examples/cli-app-with-awc/src/main.rs
@@ -59,12 +59,12 @@ impl HttpClient for AwcClient {
                 .content_type(content_type)
                 .send_stream(stream)
                 .await
-                .map_err(|err| Error::Other(Box::new(err)))?
+                .map_err(|err| Error::Other(anyhow::anyhow!(err.to_string()).into()))?
         } else {
             request
                 .send()
                 .await
-                .map_err(|err| Error::Other(Box::new(err)))?
+                .map_err(|err| Error::Other(anyhow::anyhow!(err.to_string()).into()))?
         };
 
         let status = response.status().as_u16();
@@ -72,10 +72,10 @@ impl HttpClient for AwcClient {
             response
                 .body()
                 .await
-                .map_err(|err| Error::Other(Box::new(err)))?
+                .map_err(|err| Error::Other(anyhow::anyhow!(err.to_string()).into()))?
                 .to_vec(),
         )
-        .map_err(|err| Error::Other(Box::new(err)))?;
+        .map_err(|err| Error::Other(anyhow::anyhow!(err.to_string()).into()))?;
 
         if body.is_empty() {
             body = "null".to_string();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -62,7 +62,7 @@ pub enum Error {
     InvalidUuid4Version,
 
     #[error(transparent)]
-    Other(Box<dyn std::error::Error>),
+    Other(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 #[derive(Debug, Clone, Deserialize, Error)]


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch-rust/issues/570

## What does this PR do?
- Make the error type implement Send + Sync + 'static
- Fix the awc example since their Error type doesn’t implement Send or Sync
