### PR TITLE
add feature for clients that do not implement send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ wasm-bindgen-futures = "0.4"
 [features]
 default = ["reqwest"]
 reqwest = ["dep:reqwest", "pin-project-lite", "bytes"]
+futures-unsend = []
 
 [dev-dependencies]
 futures-await-test = "0.3"

--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ The SDK lets you customize the http client by implementing the `HttpClient` trai
 initializing the `Client` with the `new_with_client` method.
 You may be interested by the `futures-unsend` feature which lets you specify a non-Send http client.
 
+#### Wasm support <!-- omit in TOC -->
+
+The SDK supports wasm through reqwest. You'll need to enable the `futures-unsend` feature while importing it, though.
+
 ## 🌐 Running in the Browser with WASM <!-- omit in TOC -->
 
 This crate fully supports WASM.

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Json output:
 By default, the SDK uses [`reqwest`](https://docs.rs/reqwest/latest/reqwest/) to make http calls.
 The SDK lets you customize the http client by implementing the `HttpClient` trait yourself and
 initializing the `Client` with the `new_with_client` method.
+You may be interested by the `futures-unsend` feature which lets you specify a non-Send http client.
 
 ## 🌐 Running in the Browser with WASM <!-- omit in TOC -->
 

--- a/examples/cli-app-with-awc/Cargo.toml
+++ b/examples/cli-app-with-awc/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-meilisearch-sdk = { path = "../..", default-features = false }
+meilisearch-sdk = { path = "../..", default-features = false, features = ["futures-unsend"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/web_app/Cargo.toml
+++ b/examples/web_app/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.18"
 yew = {version="0.21", features = ["csr"]}
-meilisearch-sdk = {path="../.."}
+meilisearch-sdk = { path="../..", features = ["futures-unsend"] }
 lazy_static = "1.4"
 serde = {version="1.0", features=["derive"]}
 web-sys = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,7 @@
 //! By default, the SDK uses [`reqwest`](https://docs.rs/reqwest/latest/reqwest/) to make http calls.
 //! The SDK lets you customize the http client by implementing the `HttpClient` trait yourself and
 //! initializing the `Client` with the `new_with_client` method.
+//! You may be interested by the `futures-unsend` feature which lets you specify a non-Send http client.
 #![warn(clippy::all)]
 #![allow(clippy::needless_doctest_main)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,10 @@
 //! The SDK lets you customize the http client by implementing the `HttpClient` trait yourself and
 //! initializing the `Client` with the `new_with_client` method.
 //! You may be interested by the `futures-unsend` feature which lets you specify a non-Send http client.
+//!
+//! ### Wasm support <!-- omit in TOC -->
+//!
+//! The SDK supports wasm through reqwest. You'll need to enable the `futures-unsend` feature while importing it, though.
 #![warn(clippy::all)]
 #![allow(clippy::needless_doctest_main)]
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -65,7 +65,8 @@ impl<Q, B> Method<Q, B> {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "futures-unsend", async_trait(?Send))]
+#[cfg_attr(not(feature = "futures-unsend"), async_trait)]
 pub trait HttpClient: Clone + Send + Sync {
     async fn request<Query, Body, Output>(
         &self,
@@ -143,7 +144,8 @@ pub fn parse_response<Output: DeserializeOwned>(
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "futures-unsend", async_trait(?Send))]
+#[cfg_attr(not(feature = "futures-unsend"), async_trait)]
 impl HttpClient for Infallible {
     async fn request<Query, Body, Output>(
         &self,

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -50,7 +50,8 @@ impl ReqwestClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "futures-unsend", async_trait(?Send))]
+#[cfg_attr(not(feature = "futures-unsend"), async_trait)]
 impl HttpClient for ReqwestClient {
     async fn stream_request<
         Query: Serialize + Send + Sync,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #577

## What does this PR do?
Some clients do not have Send compatible futures. To fix this I propose adding a feature disabled by default to support this kind of clients like acw, Send should be supported by default.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
