### PR TITLE
Remove the capital from our custom header name when running in wasm

### DIFF
--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -32,7 +32,7 @@ impl ReqwestClient {
         );
         #[cfg(target_arch = "wasm32")]
         headers.insert(
-            header::HeaderName::from_static("X-Meilisearch-Client"),
+            header::HeaderName::from_static("x-meilisearch-client"),
             header::HeaderValue::from_str(&qualified_version()).unwrap(),
         );
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch-rust/issues/580
