### PR TITLE
Use resolver = "2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Rust wrapper for the Meilisearch API. Meilisearch is a powerful, 
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/meilisearch/meilisearch-sdk"
+resolver = "2"
 
 [workspace]
 members = ["examples/*"]


### PR DESCRIPTION
Fixes `cargo test` on stable

Context: https://github.com/rustwasm/wasm-bindgen/issues/4304