### PR TITLE
Implement federated multi search

### DIFF
--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -68,6 +68,7 @@ There are a few rules, though:
 - `String`: It returns the name of the test.
 - `Client`: It creates a client like that: `Client::new("http://localhost:7700", "masterKey")`.
 - `Index`: It creates and deletes an index, as we've seen before.
+  You can include multiple `Index` parameter to automatically create multiple indices.
 
 2. You only get what you asked for. That means if you don't ask for an index, no index will be created in meilisearch.
    So, if you are testing the creation of indexes, you can ask for a `Client` and a `String` and then create it yourself.

--- a/src/client.rs
+++ b/src/client.rs
@@ -128,6 +128,21 @@ impl<Http: HttpClient> Client<Http> {
             .await
     }
 
+    pub async fn execute_federated_multi_search_query<
+        T: 'static + DeserializeOwned + Send + Sync,
+    >(
+        &self,
+        body: &FederatedMultiSearchQuery<'_, '_, Http>,
+    ) -> Result<FederatedMultiSearchResponse<T>, Error> {
+        self.http_client
+            .request::<(), &FederatedMultiSearchQuery<Http>, FederatedMultiSearchResponse<T>>(
+                &format!("{}/multi-search", &self.host),
+                Method::Post { body, query: () },
+                200,
+            )
+            .await
+    }
+
     /// Make multiple search requests.
     ///
     /// # Example
@@ -170,6 +185,22 @@ impl<Http: HttpClient> Client<Http> {
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
+    ///
+    /// # Federated Search
+    ///
+    /// You can use [`MultiSearchQuery::with_federation`] to perform a [federated
+    /// search][1] where results from different indexes are merged and returned as
+    /// one list.
+    ///
+    /// When executing a federated query, the type parameter `T` is less clear,
+    /// as the documents in the different indexes potentially have different
+    /// fields and you might have one Rust type per index. In most cases, you
+    /// either want to create an enum with one variant per index and `#[serde
+    /// (untagged)]` attribute, or if you need more control, just pass
+    /// `serde_json::Map<String, serde_json::Value>` and then deserialize that
+    /// into the appropriate target types later.
+    ///
+    /// [1]: https://www.meilisearch.com/docs/learn/multi_search/multi_search_vs_federated_search#what-is-federated-search
     #[must_use]
     pub fn multi_search(&self) -> MultiSearchQuery<Http> {
         MultiSearchQuery::new(self)

--- a/src/search.rs
+++ b/src/search.rs
@@ -364,6 +364,16 @@ pub struct SearchQuery<'a, Http: HttpClient> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) index_uid: Option<&'a str>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) federation_options: Option<QueryFederationOptions>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryFederationOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f32>,
 }
 
 #[allow(missing_docs)]
@@ -396,6 +406,7 @@ impl<'a, Http: HttpClient> SearchQuery<'a, Http> {
             distinct: None,
             ranking_score_threshold: None,
             locales: None,
+            federation_options: None,
         }
     }
     pub fn with_query<'b>(&'b mut self, query: &'a str) -> &'b mut SearchQuery<'a, Http> {
@@ -601,6 +612,14 @@ impl<'a, Http: HttpClient> SearchQuery<'a, Http> {
     }
     pub fn with_locales<'b>(&'b mut self, locales: &'a [&'a str]) -> &'b mut SearchQuery<'a, Http> {
         self.locales = Some(locales);
+        self
+    }
+    /// Only usable in federated multi search queries.
+    pub fn with_federation_options<'b>(
+        &'b mut self,
+        federation_options: QueryFederationOptions,
+    ) -> &'b mut SearchQuery<'a, Http> {
+        self.federation_options = Some(federation_options);
         self
     }
     pub fn build(&mut self) -> SearchQuery<'a, Http> {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #609

## What does this PR do?
This PR adds types and methods to use the federated multi search API. There are multiple ways to add this to this library, depending on how strictly one wants to type everything. I decided to:

- Add a new `FederatedMultiSearchResponse`, which also required a new `Client::execute_federated_multi_search_query`. The response of federated searches is just very different from normal multi searches, and I didn't think having an enum returned by `execute_multi_search_query` was a particularly nice design (and it would have been a breaking change).
- Add a `federation: Option<FederationHitInfo>` to each `SearchResult` (which is `None` for non-federated searches). I don't think it's worth to have a dedicated `FederatedSearchResult`.
- Add `MultiSearchQuery::with_federation` which returns a new `FederatedMultiSearchQuery`. One could also change `MultiSearchQuery` to be able to represent federated queries, but I had a slight preference for my solution. 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced federated multi-search, allowing users to combine results from multiple indexes into a single, merged list.
  - Added support for specifying federation options such as weighting, offsets, limits, and facet merging in multi-search queries.
  - Search results now include federation metadata, providing more context about each hit in federated searches.
  - Enhanced test support for federated multi-search scenarios across diverse document types.
  - Improved test macro to support automatic creation and management of multiple indexes in test functions.

- **Documentation**
  - Expanded documentation to explain federated search usage and options in multi-search queries.
  - Clarified test macro documentation to reflect support for multiple index parameters in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->