### PR TITLE
Add documents and embbedings database metrics to stats response

### DIFF
--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1792,6 +1792,7 @@ impl<'a, Http: HttpClient> AsRef<IndexUpdater<'a, Http>> for IndexUpdater<'a, Ht
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexStats {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #650
Fixes #649

## What does this PR do?

This pull request includes an update to the `IndexStats` struct in the `src/indexes.rs` file to add several new fields for more detailed tracking of index statistics.

Changes in `IndexStats` struct:

* Added `raw_document_db_size` field to track the size of the raw document database.
* Added `avg_document_size` field to track the average size of documents.
* Added `number_of_embedded_documents` field to track the number of embedded documents.
* Added `number_of_embeddings` field to track the number of embeddings.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded index statistics with new details, including storage size, average document size, number of documents with embeddings, and total embeddings count.

* **Documentation**
  * Improved descriptions for all index statistics fields in the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->