### PR TITLE
Add `usedDatabaseSize` to stats

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1119,6 +1119,7 @@ impl<Http: HttpClient> Client<Http> {
 #[serde(rename_all = "camelCase")]
 pub struct ClientStats {
     pub database_size: usize,
+    pub used_database_size: usize,
     #[serde(with = "time::serde::rfc3339::option")]
     pub last_update: Option<OffsetDateTime>,
     pub indexes: HashMap<String, IndexStats>,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #648

## What does this PR do?

This pull request includes an update to the `ClientStats` struct in the `src/client.rs` file to add a new field for tracking the used database size.

* [`src/client.rs`](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R1122): Added a new field `used_database_size` to the `ClientStats` struct to track the used size of the database.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
