### PR TITLE
Fix deleted_tasks field type in TaskDeletion struct

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -116,7 +116,7 @@ pub struct TaskCancelation {
 #[serde(rename_all = "camelCase")]
 pub struct TaskDeletion {
     pub matched_tasks: usize,
-    pub deleted_tasks: usize,
+    pub deleted_tasks: Option<usize>,
     pub original_filter: String,
 }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #665

## What does this PR do?
- Change the type of `deleted_tasks` field in `TaskDeletion` from `usize` to `Option<usize>`
  - This should be `Option<usize>` since it can be null according to the [API documentation](https://www.meilisearch.com/docs/reference/api/tasks#taskdeletion)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
