### PR TITLE
Serialize for MultiSearchResponse

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -6,7 +6,7 @@ use serde::{de::DeserializeOwned, ser::SerializeStruct, Deserialize, Serialize, 
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 
-#[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct MatchRange {
     pub start: usize,
     pub length: usize,
@@ -50,7 +50,7 @@ pub enum MatchingStrategies {
 /// A single result.
 ///
 /// Contains the complete object, optionally the formatted object, and optionally an object that contains information about the matches.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SearchResult<T> {
     /// The full result.
     #[serde(flatten)]
@@ -68,14 +68,14 @@ pub struct SearchResult<T> {
     pub ranking_score_details: Option<Map<String, Value>>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FacetStats {
     pub min: f64,
     pub max: f64,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 /// A struct containing search results and other information about the search.
 pub struct SearchResults<T> {
@@ -657,7 +657,7 @@ impl<'a, 'b, Http: HttpClient> MultiSearchQuery<'a, 'b, Http> {
         self.client.execute_multi_search_query::<T>(self).await
     }
 }
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MultiSearchResponse<T> {
     pub results: Vec<SearchResults<T>>,
 }


### PR DESCRIPTION
## What does this PR do?

This adds `serde::Serialize` to `MultiSearchResponse`.

I'm in a situation where I proxy requests between client and Meilisearch. During which I have authentication via OAuth and although client has logic in place, I want to inspect responses from Meilisearch and ensure the authenticated user is only getting data they are authorized for given group associations, whether indices or specific records in other index hits. 

The knee-jerk suggestion is to use different API keys. However, we have indices where for different users they have different permissions on what they can see and it's just not feasible/practical to duplicate indices/records into every combination of access rights.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved support for exporting search results and related data in serialized formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->