### PR TITLE
tests: Fix tests failures when testing against 1.15.1

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -395,7 +395,7 @@ mod test {
             reqwest::Client::new()
                 .execute(reqwest::Request::new(
                     reqwest::Method::POST,
-                    // there will never be a `meilisearch.gouv.fr` addr since these domain name are controlled by the state of france
+                    // there will never be a `meilisearch.gouv.fr` addr since these domain names are controlled by the state of france
                     reqwest::Url::parse("https://meilisearch.gouv.fr").unwrap(),
                 ))
                 .await
@@ -403,7 +403,7 @@ mod test {
         );
         assert_eq!(
             error.to_string(),
-            "HTTP request failed: error sending request for url (https://meilisearch.gouv.fr/)"
+            "HTTP request failed: error sending request"
         );
 
         let error = Error::InvalidTenantToken(jsonwebtoken::errors::Error::from(InvalidToken));

--- a/src/key.rs
+++ b/src/key.rs
@@ -656,6 +656,9 @@ pub enum Action {
     /// Provides access to everything.
     #[serde(rename = "*")]
     All,
+    /// Provides access to the `/chatCompletions` endpoint, since Meilisearch 1.15.1.
+    #[serde(rename = "chatCompletions")]
+    ChatCompletions,
     /// Provides access to both [`POST`](https://www.meilisearch.com/docs/reference/api/search#search-in-an-index-with-post-route) and [`GET`](https://www.meilisearch.com/docs/reference/api/search#search-in-an-index-with-get-route) search endpoints on authorized indexes.
     #[serde(rename = "search")]
     Search,


### PR DESCRIPTION
E.g. https://github.com/meilisearch/meilisearch-rust/actions/runs/15610369450/job/43969605803?pr=625

# Pull Request

## Related issue
https://github.com/meilisearch/meilisearch-rust/pull/625 IT tests fail 

## What does this PR do?
- Fixes tests assertions against Meilisearch 1.15.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `/chatCompletions` endpoint, enabling new actions related to chat completions.

- **Style**
  - Improved clarity in test comments and simplified error messages for HTTP request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->