### PR TITLE
Add support for similar docs query

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,16 @@ jobs:
         with:
           command: check
           args: --workspace --all-targets --all --no-default-features
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true
 
   linter:
     name: clippy-check
@@ -83,36 +93,3 @@ jobs:
         uses: ibiqlik/action-yamllint@v3
         with:
           config_file: .yamllint.yml
-
-  coverage:
-    # Will not run if the actor is Dependabot (dependabot PRs)
-    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
-    if: github.actor != 'dependabot[bot]' && !( github.event_name == 'pull_request' && startsWith(github.base_ref, 'bump-meilisearch-v') )
-    runs-on: ubuntu-latest
-    needs: integration_tests
-    name: Code Coverage
-    steps:
-      - uses: actions/checkout@v4
-      # Nightly Rust is used for cargo llvm-cov --doc below.
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: llvm-tools-preview
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
-      - name: Meilisearch (latest version) setup with Docker
-        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --no-analytics --master-key=masterKey
-      - name: Collect coverage data
-        # Generate separate reports for tests and doctests, and combine them.
-        run: |
-          set -euo pipefail
-          cargo llvm-cov --no-report --all-features --workspace --exclude 'meilisearch-test-macro'
-          cargo llvm-cov --no-report --doc --all-features --workspace --exclude 'meilisearch-test-macro'
-          cargo llvm-cov report --doctests --codecov --output-path codecov.json
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: codecov.json
-          fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,16 +37,6 @@ jobs:
         with:
           command: check
           args: --workspace --all-targets --all --no-default-features
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-          fail_ci_if_error: true
 
   linter:
     name: clippy-check
@@ -93,3 +83,23 @@ jobs:
         uses: ibiqlik/action-yamllint@v3
         with:
           config_file: .yamllint.yml
+
+  coverage:
+    if: github.actor != 'dependabot[bot]' && !( github.event_name == 'pull_request' && startsWith(github.base_ref, 'bump-meilisearch-v') )
+    runs-on: ubuntu-latest
+    needs: integration_tests
+    name: Code Coverage
+    steps:
+      - uses: actions/checkout@v4
+      - name: Meilisearch (latest version) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --no-analytics --master-key=masterKey
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -193,7 +193,7 @@ pub struct DocumentsQuery<'a, Http: HttpClient> {
     /// Filters to apply.
     ///
     /// Available since v1.2 of Meilisearch
-    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/fine_tuning_results/filtering#filter-basics) to learn the syntax.
+    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting) to learn the syntax.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<&'a str>,
 }

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1694,7 +1694,7 @@ impl<Http: HttpClient> Index<Http> {
     /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
     /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
     /// # let movies = client.index("similar_query");
-    /// # 
+    /// #
     /// let query = SimilarQuery::new(&movies, "1", "default").build();
     /// let results = movies.similar_query::<Movie>(&query).await.unwrap();
     ///

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1694,10 +1694,7 @@ impl<Http: HttpClient> Index<Http> {
     /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
     /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
     /// # let movies = client.index("similar_query");
-    /// #
-    /// # // add some documents
-    /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")},Movie{name:String::from("Unknown"), description:String::from("Unknown")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
-    /// #
+    /// # 
     /// let query = SimilarQuery::new(&movies, "1", "default").build();
     /// let results = movies.similar_query::<Movie>(&query).await.unwrap();
     ///

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1648,7 +1648,7 @@ impl<Http: HttpClient> Index<Http> {
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")},Movie{name:String::from("Unknown"), description:String::from("Unknown")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     ///
     /// let query = SimilarQuery::new(&movies, "1", "default").build();
-    /// let results = query.similar_query::<Movie>(&query).await.unwrap();
+    /// let results = movies.similar_query::<Movie>(&query).await.unwrap();
     ///
     /// assert!(results.hits.len() > 0);
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1679,25 +1679,25 @@ impl<Http: HttpClient> Index<Http> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # use serde::{Serialize, Deserialize};
     /// # use meilisearch_sdk::{client::*, indexes::*, similar::*};
     /// #
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// #
-    /// #[derive(Serialize, Deserialize, Debug)]
-    /// struct Movie {
-    ///     name: String,
-    ///     description: String,
-    /// }
+    /// # #[derive(Serialize, Deserialize, Debug)]
+    /// # struct Movie {
+    /// #    name: String,
+    /// #    description: String,
+    /// # }
     /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
     /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
-    /// let movies = client.index("execute_query");
-    ///
-    /// // add some documents
+    /// # let movies = client.index("similar_query");
+    /// #
+    /// # // add some documents
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), description:String::from("Interstellar chronicles the adventures of a group of explorers who make use of a newly discovered wormhole to surpass the limitations on human space travel and conquer the vast distances involved in an interstellar voyage.")},Movie{name:String::from("Unknown"), description:String::from("Unknown")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
-    ///
+    /// #
     /// let query = SimilarQuery::new(&movies, "1", "default").build();
     /// let results = movies.similar_query::<Movie>(&query).await.unwrap();
     ///

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1695,7 +1695,7 @@ impl<Http: HttpClient> Index<Http> {
     /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
     /// # let movies = client.index("similar_query");
     /// #
-    /// let query = SimilarQuery::new(&movies, "1", "default").build();
+    /// let query = SimilarQuery::new(&movies, "1", "default");
     /// let results = movies.similar_query::<Movie>(&query).await.unwrap();
     ///
     /// assert!(results.hits.len() > 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,9 @@ mod tenant_tokens;
 /// Module containing utilizes functions.
 mod utils;
 
+/// Module related to similar queries and results.
+pub mod similar;
+
 #[cfg(feature = "reqwest")]
 pub mod reqwest;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,8 @@ pub mod request;
 pub mod search;
 /// Module containing [`Settings`](settings::Settings).
 pub mod settings;
+/// Module related to [similar queries](https://www.meilisearch.com/docs/learn/ai_powered_search/retrieve_related_search_results#return-similar-documents).
+pub mod similar;
 /// Module containing the [snapshots](snapshots::create_snapshot)-feature.
 pub mod snapshots;
 /// Module representing the [`TaskInfo`](task_info::TaskInfo)s.
@@ -260,9 +262,6 @@ pub mod tasks;
 mod tenant_tokens;
 /// Module containing utilizes functions.
 mod utils;
-
-/// Module related to similar queries and results.
-pub mod similar;
 
 #[cfg(feature = "reqwest")]
 pub mod reqwest;

--- a/src/search.rs
+++ b/src/search.rs
@@ -107,7 +107,7 @@ pub struct SearchResults<T> {
     pub index_uid: Option<String>,
 }
 
-fn serialize_with_wildcard<S: Serializer, T: Serialize>(
+pub(crate) fn serialize_with_wildcard<S: Serializer, T: Serialize>(
     data: &Option<Selectors<T>>,
     s: S,
 ) -> Result<S::Ok, S::Error> {

--- a/src/search.rs
+++ b/src/search.rs
@@ -158,7 +158,7 @@ pub enum Selectors<T> {
     All,
 }
 
-impl Serialize for Selectors<&[&str]> {
+impl<T: Serialize> Serialize for Selectors<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         match self {
             Selectors::Some(data) => data.serialize(s),

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -1,0 +1,431 @@
+use crate::{
+    errors::Error,
+    indexes::Index,
+    request::HttpClient,
+    search::{serialize_with_wildcard, Filter, Selectors},
+};
+use either::Either;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// A single result.
+#[derive(Deserialize, Debug, Clone)]
+pub struct SimilarResult<T> {
+    /// The full result.
+    #[serde(flatten)]
+    pub result: T,
+    /// The relevancy score of the match.
+    #[serde(rename = "_rankingScore")]
+    pub ranking_score: Option<f64>,
+    #[serde(rename = "_rankingScoreDetails")]
+    pub ranking_score_details: Option<Map<String, Value>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+/// A struct containing search results and other information about the search.
+pub struct SimilarResults<T> {
+    /// Results of the query.
+    pub hits: Vec<SimilarResult<T>>,
+    /// Number of documents skipped.
+    pub offset: Option<usize>,
+    /// Number of results returned.
+    pub limit: Option<usize>,
+    /// Estimated total number of matches.
+    pub estimated_total_hits: Option<usize>,
+    /// Processing time of the query.
+    pub processing_time_ms: usize,
+    /// Search Doc ID
+    pub id: String,
+}
+
+/// A struct representing a query.
+///
+/// You can add similar parameters using the builder syntax.
+///
+/// See [this page](https://www.meilisearch.com/docs/reference/api/similar#get-similar-documents-with-post) for the official list and description of all parameters.
+///
+/// # Examples
+///
+/// ```
+/// # use serde::{Serialize, Deserialize};
+/// # use meilisearch_sdk::{client::Client, search::*, indexes::Index};
+/// #
+/// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
+/// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+/// #
+/// #[derive(Serialize, Deserialize, Debug)]
+/// struct Movie {
+///     name: String,
+///     description: String,
+/// }
+/// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+/// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
+/// # let index = client
+/// #  .create_index("similar_query_builder", None)
+/// #  .await
+/// #  .unwrap()
+/// #  .wait_for_completion(&client, None, None)
+/// #  .await.unwrap()
+/// #  .try_make_index(&client)
+/// #  .unwrap();
+///
+/// let mut res = SimilarQuery::new(&index, "100", "default")
+///     .execute::<Movie>()
+///     .await
+///     .unwrap();
+///
+/// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+/// # });
+
+/// ```
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SimilarQuery<'a, Http: HttpClient> {
+    #[serde(skip_serializing)]
+    index: &'a Index<Http>,
+    /// Document id
+    pub id: &'a str,
+    /// embedder name
+    pub embedder: &'a str,
+    /// The number of documents to skip.
+    /// If the value of the parameter `offset` is `n`, the `n` first documents (ordered by relevance) will not be returned.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you want to skip the first document, set offset to `1`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+    /// The maximum number of documents returned.
+    ///
+    /// If the value of the parameter `limit` is `n`, there will never be more than `n` documents in the response.
+    /// This is helpful for pagination.
+    ///
+    /// Example: If you don't want to get more than two documents, set limit to `2`.
+    ///
+    /// **Default: `20`**
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    /// Filter applied to documents.
+    ///
+    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/advanced/filtering) to learn the syntax.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Filter<'a>>,
+    /// Attributes to display in the returned documents.
+    ///
+    /// Can be set to a [wildcard value](enum.Selectors.html#variant.All) that will select all existing attributes.
+    ///
+    /// **Default: all attributes found in the documents.**
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(serialize_with = "serialize_with_wildcard")]
+    pub attributes_to_retrieve: Option<Selectors<&'a [&'a str]>>,
+
+    /// Defines whether to show the relevancy score of the match.
+    ///
+    /// **Default: `false`**
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_ranking_score: Option<bool>,
+
+    ///Adds a detailed global ranking score field to each document.
+    ///
+    /// **Default: `false`**
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_ranking_score_details: Option<bool>,
+
+    ///Excludes results below the specified ranking score.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ranking_score_threshold: Option<f64>,
+
+    /// **Default: `false`**
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retrieve_vectors: Option<bool>,
+}
+
+#[allow(missing_docs)]
+impl<'a, Http: HttpClient> SimilarQuery<'a, Http> {
+    #[must_use]
+    pub fn new(index: &'a Index<Http>, id: &'a str, embedder: &'a str) -> SimilarQuery<'a, Http> {
+        SimilarQuery {
+            index,
+            id,
+            embedder,
+            offset: None,
+            limit: None,
+            filter: None,
+            attributes_to_retrieve: None,
+            show_ranking_score: None,
+            show_ranking_score_details: None,
+            ranking_score_threshold: None,
+            retrieve_vectors: None,
+        }
+    }
+
+    pub fn with_offset<'b>(&'b mut self, offset: usize) -> &'b mut SimilarQuery<'a, Http> {
+        self.offset = Some(offset);
+        self
+    }
+    pub fn with_limit<'b>(&'b mut self, limit: usize) -> &'b mut SimilarQuery<'a, Http> {
+        self.limit = Some(limit);
+        self
+    }
+    pub fn with_filter<'b>(&'b mut self, filter: &'a str) -> &'b mut SimilarQuery<'a, Http> {
+        self.filter = Some(Filter::new(Either::Left(filter)));
+        self
+    }
+    pub fn with_array_filter<'b>(
+        &'b mut self,
+        filter: Vec<&'a str>,
+    ) -> &'b mut SimilarQuery<'a, Http> {
+        self.filter = Some(Filter::new(Either::Right(filter)));
+        self
+    }
+    pub fn with_attributes_to_retrieve<'b>(
+        &'b mut self,
+        attributes_to_retrieve: Selectors<&'a [&'a str]>,
+    ) -> &'b mut SimilarQuery<'a, Http> {
+        self.attributes_to_retrieve = Some(attributes_to_retrieve);
+        self
+    }
+
+    pub fn with_show_ranking_score<'b>(
+        &'b mut self,
+        show_ranking_score: bool,
+    ) -> &'b mut SimilarQuery<'a, Http> {
+        self.show_ranking_score = Some(show_ranking_score);
+        self
+    }
+
+    pub fn with_show_ranking_score_details<'b>(
+        &'b mut self,
+        show_ranking_score_details: bool,
+    ) -> &'b mut SimilarQuery<'a, Http> {
+        self.show_ranking_score_details = Some(show_ranking_score_details);
+        self
+    }
+
+    pub fn with_ranking_score_threshold<'b>(
+        &'b mut self,
+        ranking_score_threshold: f64,
+    ) -> &'b mut SimilarQuery<'a, Http> {
+        self.ranking_score_threshold = Some(ranking_score_threshold);
+        self
+    }
+    pub fn build(&mut self) -> SimilarQuery<'a, Http> {
+        self.clone()
+    }
+    /// Execute the query and fetch the results.
+    pub async fn execute<T: 'static + DeserializeOwned + Send + Sync>(
+        &'a self,
+    ) -> Result<SimilarResults<T>, Error> {
+        self.index.similar_query::<T>(self).await
+    }
+}
+
+// TODO: set UserProvided EembdderConfig
+// Embedder have not been implemented
+// But Now It does't work
+// #[cfg(test)]
+// mod tests {
+//     use std::vec;
+
+//     use super::*;
+//     use crate::{client::*, search::*};
+//     use meilisearch_test_macro::meilisearch_test;
+//     use serde::{Deserialize, Serialize};
+//     use std::collections::HashMap;
+
+//     #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//     struct Nested {
+//         child: String,
+//     }
+
+//     #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//     struct Document {
+//         id: usize,
+//         title: String,
+//         _vectors: HashMap<String, Vec<f64>>,
+//     }
+
+//     async fn setup_test_vector_index(client: &Client, index: &Index) -> Result<(), Error> {
+//         let v = vec![0.5, 0.5];
+//         let mut vectors = HashMap::new();
+
+//         vectors.insert("default".to_string(), v.clone());
+
+//         let t0 = index
+//             .add_documents(
+//                 &[
+//                     Document {
+//                         id: 0,
+//                         title: "text".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                     Document {
+//                         id: 1,
+//                         title: "text".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                     Document {
+//                         id: 2,
+//                         title: "title".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                     Document {
+//                         id: 3,
+//                         title: "title".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                     Document {
+//                         id: 4,
+//                         title: "title".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                     Document {
+//                         id: 5,
+//                         title: "title".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                     Document {
+//                         id: 6,
+//                         title: "title".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                     Document {
+//                         id: 7,
+//                         title: "title".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                     Document {
+//                         id: 8,
+//                         title: "title".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                     Document {
+//                         id: 9,
+//                         title: "title".into(),
+//                         _vectors: vectors.clone(),
+//                     },
+//                 ],
+//                 None,
+//             )
+//             .await?;
+
+//         let t1 = index.set_filterable_attributes(["title"]).await?;
+//         t1.wait_for_completion(client, None, None).await?;
+//         t0.wait_for_completion(client, None, None).await?;
+//         Ok(())
+//     }
+
+//     #[meilisearch_test]
+//     async fn test_similar_builder(_client: Client, index: Index) -> Result<(), Error> {
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+//         query.with_offset(1).with_limit(1);
+
+//         Ok(())
+//     }
+
+//     #[meilisearch_test]
+//     async fn test_query_limit(client: Client, index: Index) -> Result<(), Error> {
+//         setup_test_vector_index(&client, &index).await?;
+
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+//         query.with_limit(5);
+
+//         let results: SimilarResults<Document> = query.execute().await?;
+//         assert_eq!(results.hits.len(), 5);
+//         Ok(())
+//     }
+
+//     #[meilisearch_test]
+//     async fn test_query_offset(client: Client, index: Index) -> Result<(), Error> {
+//         setup_test_vector_index(&client, &index).await?;
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+//         query.with_offset(6);
+
+//         let results: SimilarResults<Document> = query.execute().await?;
+//         assert_eq!(results.hits.len(), 3);
+//         Ok(())
+//     }
+
+//     #[meilisearch_test]
+//     async fn test_query_filter(client: Client, index: Index) -> Result<(), Error> {
+//         setup_test_vector_index(&client, &index).await?;
+
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+
+//         let results: SimilarResults<Document> =
+//             query.with_filter("title = \"title\"").execute().await?;
+//         assert_eq!(results.hits.len(), 8);
+
+//         let results: SimilarResults<Document> =
+//             query.with_filter("NOT title = \"title\"").execute().await?;
+//         assert_eq!(results.hits.len(), 2);
+//         Ok(())
+//     }
+
+//     #[meilisearch_test]
+//     async fn test_query_filter_with_array(client: Client, index: Index) -> Result<(), Error> {
+//         setup_test_vector_index(&client, &index).await?;
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+//         let results: SimilarResults<Document> = query
+//             .with_array_filter(vec!["title = \"title\"", "title = \"text\""])
+//             .execute()
+//             .await?;
+//         assert_eq!(results.hits.len(), 10);
+
+//         Ok(())
+//     }
+
+//     #[meilisearch_test]
+//     async fn test_query_attributes_to_retrieve(client: Client, index: Index) -> Result<(), Error> {
+//         setup_test_vector_index(&client, &index).await?;
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+//         let results: SimilarResults<Document> = query
+//             .with_attributes_to_retrieve(Selectors::All)
+//             .execute()
+//             .await?;
+//         assert_eq!(results.hits.len(), 10);
+
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+//         query.with_attributes_to_retrieve(Selectors::Some(&["title", "id"])); // omit the "value" field
+//         assert!(query.execute::<Document>().await.is_err()); // error: missing "value" field
+//         Ok(())
+//     }
+
+//     #[meilisearch_test]
+//     async fn test_query_show_ranking_score(client: Client, index: Index) -> Result<(), Error> {
+//         setup_test_vector_index(&client, &index).await?;
+
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+//         query.with_show_ranking_score(true);
+//         let results: SimilarResults<Document> = query.execute().await?;
+//         assert!(results.hits[0].ranking_score.is_some());
+//         Ok(())
+//     }
+
+//     #[meilisearch_test]
+//     async fn test_query_show_ranking_score_details(
+//         client: Client,
+//         index: Index,
+//     ) -> Result<(), Error> {
+//         setup_test_vector_index(&client, &index).await?;
+
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+//         query.with_show_ranking_score_details(true);
+//         let results: SimilarResults<Document> = query.execute().await?;
+//         assert!(results.hits[0].ranking_score_details.is_some());
+//         Ok(())
+//     }
+
+//     #[meilisearch_test]
+//     async fn test_query_show_ranking_score_threshold(
+//         client: Client,
+//         index: Index,
+//     ) -> Result<(), Error> {
+//         setup_test_vector_index(&client, &index).await?;
+//         let mut query = SimilarQuery::new(&index, "1", "default");
+//         query.with_ranking_score_threshold(1.0);
+//         let results: SimilarResults<Document> = query.execute().await?;
+//         assert!(results.hits.is_empty());
+//         Ok(())
+//     }
+// }

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -83,10 +83,13 @@ pub struct SimilarResults<T> {
 pub struct SimilarQuery<'a, Http: HttpClient> {
     #[serde(skip_serializing)]
     index: &'a Index<Http>,
+    
     /// Document id
     pub id: &'a str,
+
     /// embedder name
     pub embedder: &'a str,
+    
     /// The number of documents to skip.
     /// If the value of the parameter `offset` is `n`, the `n` first documents (ordered by relevance) will not be returned.
     /// This is helpful for pagination.
@@ -94,6 +97,7 @@ pub struct SimilarQuery<'a, Http: HttpClient> {
     /// Example: If you want to skip the first document, set offset to `1`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<usize>,
+
     /// The maximum number of documents returned.
     ///
     /// If the value of the parameter `limit` is `n`, there will never be more than `n` documents in the response.
@@ -104,11 +108,13 @@ pub struct SimilarQuery<'a, Http: HttpClient> {
     /// **Default: `20`**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
+
     /// Filter applied to documents.
     ///
     /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/advanced/filtering) to learn the syntax.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<Filter<'a>>,
+
     /// Attributes to display in the returned documents.
     ///
     /// Can be set to a [wildcard value](enum.Selectors.html#variant.All) that will select all existing attributes.
@@ -162,14 +168,17 @@ impl<'a, Http: HttpClient> SimilarQuery<'a, Http> {
         self.offset = Some(offset);
         self
     }
+
     pub fn with_limit<'b>(&'b mut self, limit: usize) -> &'b mut SimilarQuery<'a, Http> {
         self.limit = Some(limit);
         self
     }
+
     pub fn with_filter<'b>(&'b mut self, filter: &'a str) -> &'b mut SimilarQuery<'a, Http> {
         self.filter = Some(Filter::new(Either::Left(filter)));
         self
     }
+    
     pub fn with_array_filter<'b>(
         &'b mut self,
         filter: Vec<&'a str>,
@@ -177,6 +186,7 @@ impl<'a, Http: HttpClient> SimilarQuery<'a, Http> {
         self.filter = Some(Filter::new(Either::Right(filter)));
         self
     }
+
     pub fn with_attributes_to_retrieve<'b>(
         &'b mut self,
         attributes_to_retrieve: Selectors<&'a [&'a str]>,
@@ -208,9 +218,11 @@ impl<'a, Http: HttpClient> SimilarQuery<'a, Http> {
         self.ranking_score_threshold = Some(ranking_score_threshold);
         self
     }
+
     pub fn build(&mut self) -> SimilarQuery<'a, Http> {
         self.clone()
     }
+
     /// Execute the query and fetch the results.
     pub async fn execute<T: 'static + DeserializeOwned + Send + Sync>(
         &'a self,
@@ -219,212 +231,209 @@ impl<'a, Http: HttpClient> SimilarQuery<'a, Http> {
     }
 }
 
-// TODO: set UserProvided EembdderConfig
-// Embedder have not been implemented
-// But Now It does't work
-// #[cfg(test)]
-// mod tests {
-//     use std::vec;
+#[cfg(test)]
+mod tests {
+    use std::vec;
 
-//     use super::*;
-//     use crate::{client::*, search::*};
-//     use meilisearch_test_macro::meilisearch_test;
-//     use serde::{Deserialize, Serialize};
-//     use std::collections::HashMap;
+    use super::*;
+    use crate::{client::*, search::*};
+    use meilisearch_test_macro::meilisearch_test;
+    use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
 
-//     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-//     struct Nested {
-//         child: String,
-//     }
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Nested {
+        child: String,
+    }
 
-//     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-//     struct Document {
-//         id: usize,
-//         title: String,
-//         _vectors: HashMap<String, Vec<f64>>,
-//     }
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Document {
+        id: usize,
+        title: String,
+        _vectors: HashMap<String, Vec<f64>>,
+    }
 
-//     async fn setup_test_vector_index(client: &Client, index: &Index) -> Result<(), Error> {
-//         let v = vec![0.5, 0.5];
-//         let mut vectors = HashMap::new();
+    async fn setup_test_vector_index(client: &Client, index: &Index) -> Result<(), Error> {
+        let v = vec![0.5, 0.5];
+        let mut vectors = HashMap::new();
 
-//         vectors.insert("default".to_string(), v.clone());
+        vectors.insert("default".to_string(), v.clone());
 
-//         let t0 = index
-//             .add_documents(
-//                 &[
-//                     Document {
-//                         id: 0,
-//                         title: "text".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                     Document {
-//                         id: 1,
-//                         title: "text".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                     Document {
-//                         id: 2,
-//                         title: "title".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                     Document {
-//                         id: 3,
-//                         title: "title".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                     Document {
-//                         id: 4,
-//                         title: "title".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                     Document {
-//                         id: 5,
-//                         title: "title".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                     Document {
-//                         id: 6,
-//                         title: "title".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                     Document {
-//                         id: 7,
-//                         title: "title".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                     Document {
-//                         id: 8,
-//                         title: "title".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                     Document {
-//                         id: 9,
-//                         title: "title".into(),
-//                         _vectors: vectors.clone(),
-//                     },
-//                 ],
-//                 None,
-//             )
-//             .await?;
+        let t0 = index
+            .add_documents(
+                &[
+                    Document {
+                        id: 0,
+                        title: "text".into(),
+                        _vectors: vectors.clone(),
+                    },
+                    Document {
+                        id: 1,
+                        title: "text".into(),
+                        _vectors: vectors.clone(),
+                    },
+                    Document {
+                        id: 2,
+                        title: "title".into(),
+                        _vectors: vectors.clone(),
+                    },
+                    Document {
+                        id: 3,
+                        title: "title".into(),
+                        _vectors: vectors.clone(),
+                    },
+                    Document {
+                        id: 4,
+                        title: "title".into(),
+                        _vectors: vectors.clone(),
+                    },
+                    Document {
+                        id: 5,
+                        title: "title".into(),
+                        _vectors: vectors.clone(),
+                    },
+                    Document {
+                        id: 6,
+                        title: "title".into(),
+                        _vectors: vectors.clone(),
+                    },
+                    Document {
+                        id: 7,
+                        title: "title".into(),
+                        _vectors: vectors.clone(),
+                    },
+                    Document {
+                        id: 8,
+                        title: "title".into(),
+                        _vectors: vectors.clone(),
+                    },
+                    Document {
+                        id: 9,
+                        title: "title".into(),
+                        _vectors: vectors.clone(),
+                    },
+                ],
+                None,
+            )
+            .await?;
 
-//         let t1 = index.set_filterable_attributes(["title"]).await?;
-//         t1.wait_for_completion(client, None, None).await?;
-//         t0.wait_for_completion(client, None, None).await?;
-//         Ok(())
-//     }
+        let t1 = index.set_filterable_attributes(["title"]).await?;
+        t1.wait_for_completion(client, None, None).await?;
+        t0.wait_for_completion(client, None, None).await?;
+        Ok(())
+    }
 
-//     #[meilisearch_test]
-//     async fn test_similar_builder(_client: Client, index: Index) -> Result<(), Error> {
-//         let mut query = SimilarQuery::new(&index, "1", "default");
-//         query.with_offset(1).with_limit(1);
+    #[meilisearch_test]
+    async fn test_similar_builder(_client: Client, index: Index) -> Result<(), Error> {
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        query.with_offset(1).with_limit(1);
 
-//         Ok(())
-//     }
+        Ok(())
+    }
 
-//     #[meilisearch_test]
-//     async fn test_query_limit(client: Client, index: Index) -> Result<(), Error> {
-//         setup_test_vector_index(&client, &index).await?;
+    #[meilisearch_test]
+    async fn test_query_limit(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_vector_index(&client, &index).await?;
 
-//         let mut query = SimilarQuery::new(&index, "1", "default");
-//         query.with_limit(5);
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        query.with_limit(5);
 
-//         let results: SimilarResults<Document> = query.execute().await?;
-//         assert_eq!(results.hits.len(), 5);
-//         Ok(())
-//     }
+        let results: SimilarResults<Document> = query.execute().await?;
+        assert_eq!(results.hits.len(), 5);
+        Ok(())
+    }
 
-//     #[meilisearch_test]
-//     async fn test_query_offset(client: Client, index: Index) -> Result<(), Error> {
-//         setup_test_vector_index(&client, &index).await?;
-//         let mut query = SimilarQuery::new(&index, "1", "default");
-//         query.with_offset(6);
+    #[meilisearch_test]
+    async fn test_query_offset(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_vector_index(&client, &index).await?;
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        query.with_offset(6);
 
-//         let results: SimilarResults<Document> = query.execute().await?;
-//         assert_eq!(results.hits.len(), 3);
-//         Ok(())
-//     }
+        let results: SimilarResults<Document> = query.execute().await?;
+        assert_eq!(results.hits.len(), 3);
+        Ok(())
+    }
 
-//     #[meilisearch_test]
-//     async fn test_query_filter(client: Client, index: Index) -> Result<(), Error> {
-//         setup_test_vector_index(&client, &index).await?;
+    #[meilisearch_test]
+    async fn test_query_filter(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_vector_index(&client, &index).await?;
 
-//         let mut query = SimilarQuery::new(&index, "1", "default");
+        let mut query = SimilarQuery::new(&index, "1", "default");
 
-//         let results: SimilarResults<Document> =
-//             query.with_filter("title = \"title\"").execute().await?;
-//         assert_eq!(results.hits.len(), 8);
+        let results: SimilarResults<Document> =
+            query.with_filter("title = \"title\"").execute().await?;
+        assert_eq!(results.hits.len(), 8);
 
-//         let results: SimilarResults<Document> =
-//             query.with_filter("NOT title = \"title\"").execute().await?;
-//         assert_eq!(results.hits.len(), 2);
-//         Ok(())
-//     }
+        let results: SimilarResults<Document> =
+            query.with_filter("NOT title = \"title\"").execute().await?;
+        assert_eq!(results.hits.len(), 2);
+        Ok(())
+    }
 
-//     #[meilisearch_test]
-//     async fn test_query_filter_with_array(client: Client, index: Index) -> Result<(), Error> {
-//         setup_test_vector_index(&client, &index).await?;
-//         let mut query = SimilarQuery::new(&index, "1", "default");
-//         let results: SimilarResults<Document> = query
-//             .with_array_filter(vec!["title = \"title\"", "title = \"text\""])
-//             .execute()
-//             .await?;
-//         assert_eq!(results.hits.len(), 10);
+    #[meilisearch_test]
+    async fn test_query_filter_with_array(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_vector_index(&client, &index).await?;
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        let results: SimilarResults<Document> = query
+            .with_array_filter(vec!["title = \"title\"", "title = \"text\""])
+            .execute()
+            .await?;
+        assert_eq!(results.hits.len(), 10);
 
-//         Ok(())
-//     }
+        Ok(())
+    }
 
-//     #[meilisearch_test]
-//     async fn test_query_attributes_to_retrieve(client: Client, index: Index) -> Result<(), Error> {
-//         setup_test_vector_index(&client, &index).await?;
-//         let mut query = SimilarQuery::new(&index, "1", "default");
-//         let results: SimilarResults<Document> = query
-//             .with_attributes_to_retrieve(Selectors::All)
-//             .execute()
-//             .await?;
-//         assert_eq!(results.hits.len(), 10);
+    #[meilisearch_test]
+    async fn test_query_attributes_to_retrieve(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_vector_index(&client, &index).await?;
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        let results: SimilarResults<Document> = query
+            .with_attributes_to_retrieve(Selectors::All)
+            .execute()
+            .await?;
+        assert_eq!(results.hits.len(), 10);
 
-//         let mut query = SimilarQuery::new(&index, "1", "default");
-//         query.with_attributes_to_retrieve(Selectors::Some(&["title", "id"])); // omit the "value" field
-//         assert!(query.execute::<Document>().await.is_err()); // error: missing "value" field
-//         Ok(())
-//     }
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        query.with_attributes_to_retrieve(Selectors::Some(&["title", "id"])); // omit the "value" field
+        assert!(query.execute::<Document>().await.is_err()); // error: missing "value" field
+        Ok(())
+    }
 
-//     #[meilisearch_test]
-//     async fn test_query_show_ranking_score(client: Client, index: Index) -> Result<(), Error> {
-//         setup_test_vector_index(&client, &index).await?;
+    #[meilisearch_test]
+    async fn test_query_show_ranking_score(client: Client, index: Index) -> Result<(), Error> {
+        setup_test_vector_index(&client, &index).await?;
 
-//         let mut query = SimilarQuery::new(&index, "1", "default");
-//         query.with_show_ranking_score(true);
-//         let results: SimilarResults<Document> = query.execute().await?;
-//         assert!(results.hits[0].ranking_score.is_some());
-//         Ok(())
-//     }
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        query.with_show_ranking_score(true);
+        let results: SimilarResults<Document> = query.execute().await?;
+        assert!(results.hits[0].ranking_score.is_some());
+        Ok(())
+    }
 
-//     #[meilisearch_test]
-//     async fn test_query_show_ranking_score_details(
-//         client: Client,
-//         index: Index,
-//     ) -> Result<(), Error> {
-//         setup_test_vector_index(&client, &index).await?;
+    #[meilisearch_test]
+    async fn test_query_show_ranking_score_details(
+        client: Client,
+        index: Index,
+    ) -> Result<(), Error> {
+        setup_test_vector_index(&client, &index).await?;
 
-//         let mut query = SimilarQuery::new(&index, "1", "default");
-//         query.with_show_ranking_score_details(true);
-//         let results: SimilarResults<Document> = query.execute().await?;
-//         assert!(results.hits[0].ranking_score_details.is_some());
-//         Ok(())
-//     }
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        query.with_show_ranking_score_details(true);
+        let results: SimilarResults<Document> = query.execute().await?;
+        assert!(results.hits[0].ranking_score_details.is_some());
+        Ok(())
+    }
 
-//     #[meilisearch_test]
-//     async fn test_query_show_ranking_score_threshold(
-//         client: Client,
-//         index: Index,
-//     ) -> Result<(), Error> {
-//         setup_test_vector_index(&client, &index).await?;
-//         let mut query = SimilarQuery::new(&index, "1", "default");
-//         query.with_ranking_score_threshold(1.0);
-//         let results: SimilarResults<Document> = query.execute().await?;
-//         assert!(results.hits.is_empty());
-//         Ok(())
-//     }
-// }
+    #[meilisearch_test]
+    async fn test_query_show_ranking_score_threshold(
+        client: Client,
+        index: Index,
+    ) -> Result<(), Error> {
+        setup_test_vector_index(&client, &index).await?;
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        query.with_ranking_score_threshold(1.0);
+        let results: SimilarResults<Document> = query.execute().await?;
+        assert!(results.hits.is_empty());
+        Ok(())
+    }
+}

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::Error,
     indexes::Index,
     request::HttpClient,
-    search::{serialize_with_wildcard, Filter, Selectors},
+    search::{Filter, Selectors},
 };
 use either::Either;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -100,7 +100,6 @@ pub struct SimilarQuery<'a, Http: HttpClient> {
     ///
     /// **Default: all attributes found in the documents.**
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(serialize_with = "serialize_with_wildcard")]
     pub attributes_to_retrieve: Option<Selectors<&'a [&'a str]>>,
 
     /// Defines whether to display the global ranking score of a document

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -47,34 +47,28 @@ pub struct SimilarResults<T> {
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// # use serde::{Serialize, Deserialize};
-/// # use meilisearch_sdk::{client::Client, search::*, indexes::Index};
+/// # use meilisearch_sdk::{client::Client, search::*, indexes::Index, similar::SimilarQuery};
 /// #
 /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
 /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
 /// #
-/// #[derive(Serialize, Deserialize, Debug)]
-/// struct Movie {
-///     name: String,
-///     description: String,
-/// }
+/// # #[derive(Serialize, Deserialize, Debug)]
+/// # struct Movie {
+/// #    name: String,
+/// #    description: String,
+/// # }
+/// #
 /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
 /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
-/// # let index = client
-/// #  .create_index("similar_query_builder", None)
-/// #  .await
-/// #  .unwrap()
-/// #  .wait_for_completion(&client, None, None)
-/// #  .await.unwrap()
-/// #  .try_make_index(&client)
-/// #  .unwrap();
-///
+/// # let index = client.index("similar_query_builder");
+/// #
 /// let mut res = SimilarQuery::new(&index, "100", "default")
 ///     .execute::<Movie>()
 ///     .await
 ///     .unwrap();
-///
+/// #
 /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
 /// # });
 /// ```

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -77,7 +77,6 @@ pub struct SimilarResults<T> {
 ///
 /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
 /// # });
-
 /// ```
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -78,32 +78,21 @@ pub struct SimilarQuery<'a, Http: HttpClient> {
     #[serde(skip_serializing)]
     index: &'a Index<Http>,
 
-    /// Document id
+    /// Identifier of the target document
     pub id: &'a str,
 
-    /// embedder name
+    /// Embedder to use when computing recommendations
     pub embedder: &'a str,
 
-    /// The number of documents to skip.
-    /// If the value of the parameter `offset` is `n`, the `n` first documents (ordered by relevance) will not be returned.
-    /// This is helpful for pagination.
-    ///
-    /// Example: If you want to skip the first document, set offset to `1`.
+    /// Number of documents to skip
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<usize>,
 
-    /// The maximum number of documents returned.
-    ///
-    /// If the value of the parameter `limit` is `n`, there will never be more than `n` documents in the response.
-    /// This is helpful for pagination.
-    ///
-    /// Example: If you don't want to get more than two documents, set limit to `2`.
-    ///
-    /// **Default: `20`**
+    /// Maximum number of documents returned
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
 
-    /// Filter applied to documents.
+    /// Filter queries by an attribute’s value
     ///
     /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting) to learn the syntax.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -118,22 +107,26 @@ pub struct SimilarQuery<'a, Http: HttpClient> {
     #[serde(serialize_with = "serialize_with_wildcard")]
     pub attributes_to_retrieve: Option<Selectors<&'a [&'a str]>>,
 
-    /// Defines whether to show the relevancy score of the match.
+    /// Defines whether to display the global ranking score of a document
     ///
     /// **Default: `false`**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_ranking_score: Option<bool>,
 
-    ///Adds a detailed global ranking score field to each document.
+    /// Defines whether to display the detailed ranking score information
     ///
     /// **Default: `false`**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_ranking_score_details: Option<bool>,
 
-    ///Excludes results below the specified ranking score.
+    /// Defines whether to exclude results with low ranking scores
+    ///
+    /// **Default: `None`**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ranking_score_threshold: Option<f64>,
 
+    /// Defines whether to return document vector data
+    ///
     /// **Default: `false`**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retrieve_vectors: Option<bool>,

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -210,10 +210,6 @@ impl<'a, Http: HttpClient> SimilarQuery<'a, Http> {
         self
     }
 
-    pub fn build(&mut self) -> SimilarQuery<'a, Http> {
-        self.clone()
-    }
-
     /// Execute the query and fetch the results.
     pub async fn execute<T: 'static + DeserializeOwned + Send + Sync>(
         &'a self,

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -8,13 +8,10 @@ use either::Either;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{Map, Value};
 
-/// A single result.
 #[derive(Deserialize, Debug, Clone)]
 pub struct SimilarResult<T> {
-    /// The full result.
     #[serde(flatten)]
     pub result: T,
-    /// The relevancy score of the match.
     #[serde(rename = "_rankingScore")]
     pub ranking_score: Option<f64>,
     #[serde(rename = "_rankingScoreDetails")]
@@ -23,19 +20,18 @@ pub struct SimilarResult<T> {
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-/// A struct containing search results and other information about the search.
 pub struct SimilarResults<T> {
-    /// Results of the query.
+    /// Results of the query
     pub hits: Vec<SimilarResult<T>>,
-    /// Number of documents skipped.
+    /// Number of documents skipped
     pub offset: Option<usize>,
-    /// Number of results returned.
+    /// Number of results returned
     pub limit: Option<usize>,
-    /// Estimated total number of matches.
+    /// Estimated total number of matches
     pub estimated_total_hits: Option<usize>,
-    /// Processing time of the query.
+    /// Processing time of the query
     pub processing_time_ms: usize,
-    /// Search Doc ID
+    /// Identifier of the target document
     pub id: String,
 }
 

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -399,4 +399,16 @@ mod tests {
         assert!(results.hits.is_empty());
         Ok(())
     }
+
+    #[meilisearch_test]
+    async fn test_query_retrieve_vectors(client: Client, index: Index) -> Result<(), Error> {
+        setup_embedder(&client, &index).await?;
+        setup_test_index(&client, &index).await?;
+
+        let mut query = SimilarQuery::new(&index, "1", "default");
+        query.with_retrieve_vectors(true);
+        let results: SimilarResults<Document> = query.execute().await?;
+        assert!(results.hits[0].result._vectors.is_some());
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #646 

## What does this PR do?
- Add support for similar docs queries with v1.13 version api #646. It works for my project.
- Completed but commented on the test cases; I will finish the remaining parts after the PR #554  is merged.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced similarity search capabilities to find documents similar to a specified one within an index.
  - Added configurable options for similarity queries, including pagination, filtering, attribute selection, ranking score visibility, and detailed ranking score information in results.

- **Documentation**
  - Included example usage and detailed documentation for the similarity search functionality.
  - Updated filtering documentation links for improved guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->