### PR TITLE
Add Code Coverage GH action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,50 @@
+name: Code Coverage
+
+on:
+  pull_request:
+  push:
+    # trying and staging branches are for BORS config
+    branches:
+      - trying
+      - staging
+      - main
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    # Will not run if the actor is Dependabot (dependabot PRs)
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v') ||  github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    name: Code Coverage
+    steps:
+      - uses: actions/checkout@v4
+      # Nightly Rust is used for cargo llvm-cov --doc below.
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Meilisearch (latest version) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --no-analytics --master-key=masterKey
+      - name: Collect coverage data
+        # Generate separate reports for tests and doctests, and combine them.
+        run: |
+          cargo llvm-cov --no-report --all-features --workspace
+          cargo llvm-cov --no-report --doc --all-features --workspace
+          cargo llvm-cov report --doctests --codecov --output-path codecov.json
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          fail_ci_if_error: true


### PR DESCRIPTION
# Pull Request

Rework of #654 

## Related issue
Fixes #507 

## What does this PR do?

This pull request introduces a new GitHub Actions workflow for measuring and reporting code coverage. The workflow is configured to run on specific branches and includes steps to set up the environment, install necessary tools, and upload coverage reports to Codecov.

Key changes:

* Added a new GitHub Actions workflow named `coverage.yml` to measure code coverage on `trying`, `staging`, and `main` branches.
* Configured permissions to allow reading contents and writing issues.
* Set up the environment to use Nightly Rust and installed `cargo-llvm-cov` for coverage data collection.
* Added steps to run Meilisearch using Docker, collect coverage data, and upload the reports to Codecov.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

