### PR TITLE
 Add documents and embbedings database metrics to stats response

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="https://github.com/meilisearch/meilisearch-rust/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-informational" alt="License"></a>
   <a href="https://github.com/meilisearch/meilisearch/discussions" alt="Discussions"><img src="https://img.shields.io/badge/github-discussions-red" /></a>
   <a href="https://ms-bors.herokuapp.com/repositories/62"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
-  <a href="https://codecov.io/gh/meilisearch/meilisearch-rust" ><img src="https://codecov.io/gh/meilisearch/meilisearch-rust/graph/badge.svg?token=NVO9OI8JMG"/></a>
+  <a href="https://codecov.io/gh/meilisearch/meilisearch-rust"><img src="https://codecov.io/gh/meilisearch/meilisearch-rust/graph/badge.svg?token=NVO9OI8JMG"/></a>
 </p>
 
 <p align="center">⚡ The Meilisearch API client written for Rust 🦀</p>

--- a/README.tpl
+++ b/README.tpl
@@ -24,6 +24,7 @@
   <a href="https://github.com/meilisearch/meilisearch-rust/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-informational" alt="License"></a>
   <a href="https://github.com/meilisearch/meilisearch/discussions" alt="Discussions"><img src="https://img.shields.io/badge/github-discussions-red" /></a>
   <a href="https://ms-bors.herokuapp.com/repositories/62"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
+  <a href="https://codecov.io/gh/meilisearch/meilisearch-rust"><img src="https://codecov.io/gh/meilisearch/meilisearch-rust/graph/badge.svg?token=NVO9OI8JMG"/></a>
 </p>
 
 <p align="center">⚡ The Meilisearch API client written for Rust 🦀</p>

--- a/src/client.rs
+++ b/src/client.rs
@@ -1123,11 +1123,11 @@ pub struct ClientStats {
 
     /// Storage space used by the database in bytes, excluding unused space claimed by LMDB
     pub used_database_size: usize,
-    
+
     /// When the last update was made to the database in the `RFC 3339` format
     #[serde(with = "time::serde::rfc3339::option")]
     pub last_update: Option<OffsetDateTime>,
-    
+
     /// The statistics for each index found in the database
     pub indexes: HashMap<String, IndexStats>,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1118,10 +1118,17 @@ impl<Http: HttpClient> Client<Http> {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientStats {
+    /// Storage space claimed by Meilisearch and LMDB in bytes
     pub database_size: usize,
+
+    /// Storage space used by the database in bytes, excluding unused space claimed by LMDB
     pub used_database_size: usize,
+    
+    /// When the last update was made to the database in the `RFC 3339` format
     #[serde(with = "time::serde::rfc3339::option")]
     pub last_update: Option<OffsetDateTime>,
+    
+    /// The statistics for each index found in the database
     pub indexes: HashMap<String, IndexStats>,
 }
 

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1798,6 +1798,10 @@ pub struct IndexStats {
     pub number_of_documents: usize,
     pub is_indexing: bool,
     pub field_distribution: HashMap<String, usize>,
+    pub raw_document_db_size: usize,
+    pub avg_document_size: usize,
+    pub number_of_embedded_documents: usize,
+    pub number_of_embeddings: usize,
 }
 
 /// An [`IndexesQuery`] containing filter and pagination parameters when searching for [Indexes](Index).

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1795,12 +1795,19 @@ impl<'a, Http: HttpClient> AsRef<IndexUpdater<'a, Http>> for IndexUpdater<'a, Ht
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexStats {
+    /// Total number of documents in an index
     pub number_of_documents: usize,
+    /// If `true`, the index is still processing documents and attempts to search will result in undefined behavior
     pub is_indexing: bool,
+    /// Shows every field in the index along with the total number of documents containing that field in said index
     pub field_distribution: HashMap<String, usize>,
+    /// Storage space claimed by all documents in the index in bytes
     pub raw_document_db_size: usize,
+    /// Total size of the documents stored in an index divided by the number of documents in that same index
     pub avg_document_size: usize,
+    /// Total number of documents with at least one embedding
     pub number_of_embedded_documents: usize,
+    /// Total number of embeddings in an index
     pub number_of_embeddings: usize,
 }
 

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1849,18 +1849,24 @@ impl<'a, Http: HttpClient> AsRef<IndexUpdater<'a, Http>> for IndexUpdater<'a, Ht
 pub struct IndexStats {
     /// Total number of documents in an index
     pub number_of_documents: usize,
-    /// If `true`, the index is still processing documents and attempts to search will result in undefined behavior
-    pub is_indexing: bool,
-    /// Shows every field in the index along with the total number of documents containing that field in said index
-    pub field_distribution: HashMap<String, usize>,
-    /// Storage space claimed by all documents in the index in bytes
-    pub raw_document_db_size: usize,
-    /// Total size of the documents stored in an index divided by the number of documents in that same index
-    pub avg_document_size: usize,
+
     /// Total number of documents with at least one embedding
     pub number_of_embedded_documents: usize,
+
     /// Total number of embeddings in an index
     pub number_of_embeddings: usize,
+
+    /// Storage space claimed by all documents in the index in bytes
+    pub raw_document_db_size: usize,
+
+    /// Total size of the documents stored in an index divided by the number of documents in that same index
+    pub avg_document_size: usize,
+
+    /// If `true`, the index is still processing documents and attempts to search will yield impredictable results
+    pub is_indexing: bool,
+
+    /// Shows every field in the index along with the total number of documents containing that field in said index
+    pub field_distribution: HashMap<String, usize>,
 }
 
 /// An [`IndexesQuery`] containing filter and pagination parameters when searching for [Indexes](Index).

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -299,7 +299,7 @@ impl<Http: HttpClient> Index<Http> {
     /// }
     /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
     /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
-    /// let movies = client.index("execute_query");
+    /// let movies = client.index("execute_query2");
     ///
     /// // add some documents
     /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), genre:String::from("scifi")},Movie{name:String::from("Inception"), genre:String::from("drama")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1843,7 +1843,6 @@ impl<'a, Http: HttpClient> AsRef<IndexUpdater<'a, Http>> for IndexUpdater<'a, Ht
     }
 }
 
-#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexStats {

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1843,6 +1843,7 @@ impl<'a, Http: HttpClient> AsRef<IndexUpdater<'a, Http>> for IndexUpdater<'a, Ht
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexStats {

--- a/src/search.rs
+++ b/src/search.rs
@@ -765,7 +765,7 @@ pub struct MultiSearchResponse<T> {
 /// }
 /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
 /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
-/// let movies = client.index("execute_query");
+/// let movies = client.index("execute_query3");
 ///
 /// // add some documents
 /// # movies.add_or_replace(&[Movie{name:String::from("Interstellar"), genre:String::from("scifi")},Movie{name:String::from("Inception"), genre:String::from("drama")}], Some("name")).await.unwrap().wait_for_completion(&client, None, None).await.unwrap();


### PR DESCRIPTION
# Pull Request

Rework on top of #652

## Related issue
Fixes #650
Fixes #649

## What does this PR do?

This pull request includes an update to the `IndexStats` struct in the `src/indexes.rs` file to add several new fields for more detailed tracking of index statistics.

Changes in `IndexStats` struct:

* Added `raw_document_db_size` field to track the size of the raw document database.
* Added `avg_document_size` field to track the average size of documents.
* Added `number_of_embedded_documents` field to track the number of embedded documents.
* Added `number_of_embeddings` field to track the number of embeddings.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

