### PR TITLE
Implement federated multi search

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,8 +107,8 @@ jobs:
         # Generate separate reports for tests and doctests, and combine them.
         run: |
           set -euo pipefail
-          cargo llvm-cov --no-report --all-features --workspace
-          cargo llvm-cov --no-report --doc --all-features --workspace
+          cargo llvm-cov --no-report --all-features --workspace --exclude 'meilisearch-test-macro'
+          cargo llvm-cov --no-report --doc --all-features --workspace --exclude 'meilisearch-test-macro'
           cargo llvm-cov report --doctests --codecov --output-path codecov.json
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -68,7 +68,7 @@ There are a few rules, though:
 - `String`: It returns the name of the test.
 - `Client`: It creates a client like that: `Client::new("http://localhost:7700", "masterKey")`.
 - `Index`: It creates and deletes an index, as we've seen before.
-  You can include multiple `Index` parameter to automatically create multiple indices.
+  You can include multiple `Index` parameter to automatically create multiple indexes.
 
 2. You only get what you asked for. That means if you don't ask for an index, no index will be created in meilisearch.
    So, if you are testing the creation of indexes, you can ask for a `Client` and a `String` and then create it yourself.

--- a/meilisearch-test-macro/README.md
+++ b/meilisearch-test-macro/README.md
@@ -68,6 +68,7 @@ There are a few rules, though:
 - `String`: It returns the name of the test.
 - `Client`: It creates a client like that: `Client::new("http://localhost:7700", "masterKey")`.
 - `Index`: It creates and deletes an index, as we've seen before.
+  You can include multiple `Index` parameter to automatically create multiple indices.
 
 2. You only get what you asked for. That means if you don't ask for an index, no index will be created in meilisearch.
    So, if you are testing the creation of indexes, you can ask for a `Client` and a `String` and then create it yourself.

--- a/src/client.rs
+++ b/src/client.rs
@@ -128,6 +128,21 @@ impl<Http: HttpClient> Client<Http> {
             .await
     }
 
+    pub async fn execute_federated_multi_search_query<
+        T: 'static + DeserializeOwned + Send + Sync,
+    >(
+        &self,
+        body: &FederatedMultiSearchQuery<'_, '_, Http>,
+    ) -> Result<FederatedMultiSearchResponse<T>, Error> {
+        self.http_client
+            .request::<(), &FederatedMultiSearchQuery<Http>, FederatedMultiSearchResponse<T>>(
+                &format!("{}/multi-search", &self.host),
+                Method::Post { body, query: () },
+                200,
+            )
+            .await
+    }
+
     /// Make multiple search requests.
     ///
     /// # Example
@@ -170,6 +185,22 @@ impl<Http: HttpClient> Client<Http> {
     /// # movies.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
     /// # });
     /// ```
+    ///
+    /// # Federated Search
+    ///
+    /// You can use [`MultiSearchQuery::with_federation`] to perform a [federated
+    /// search][1] where results from different indexes are merged and returned as
+    /// one list.
+    ///
+    /// When executing a federated query, the type parameter `T` is less clear,
+    /// as the documents in the different indexes potentially have different
+    /// fields and you might have one Rust type per index. In most cases, you
+    /// either want to create an enum with one variant per index and `#[serde
+    /// (untagged)]` attribute, or if you need more control, just pass
+    /// `serde_json::Map<String, serde_json::Value>` and then deserialize that
+    /// into the appropriate target types later.
+    ///
+    /// [1]: https://www.meilisearch.com/docs/learn/multi_search/multi_search_vs_federated_search#what-is-federated-search
     #[must_use]
     pub fn multi_search(&self) -> MultiSearchQuery<Http> {
         MultiSearchQuery::new(self)

--- a/src/features.rs
+++ b/src/features.rs
@@ -69,10 +69,10 @@ impl<'a, Http: HttpClient> ExperimentalFeatures<'a, Http> {
     /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
     /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
     /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
-    /// tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
-    ///     let features = ExperimentalFeatures::new(&client);
-    ///     features.get().await.unwrap();
-    /// });
+    /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+    /// let features = ExperimentalFeatures::new(&client);
+    /// features.get().await.unwrap();
+    /// # });
     /// ```
     pub async fn get(&self) -> Result<ExperimentalFeaturesResult, Error> {
         self.client
@@ -148,52 +148,20 @@ mod tests {
     use meilisearch_test_macro::meilisearch_test;
 
     #[meilisearch_test]
-    async fn test_experimental_features_set_metrics(client: Client) {
+    async fn test_experimental_features(client: Client) {
         let mut features = ExperimentalFeatures::new(&client);
         features.set_metrics(true);
-        let _ = features.update().await.unwrap();
-
-        let res = features.get().await.unwrap();
-        assert!(res.metrics)
-    }
-
-    #[meilisearch_test]
-    async fn test_experimental_features_set_logs_route(client: Client) {
-        let mut features = ExperimentalFeatures::new(&client);
         features.set_logs_route(true);
-        let _ = features.update().await.unwrap();
-
-        let res = features.get().await.unwrap();
-        assert!(res.logs_route)
-    }
-
-    #[meilisearch_test]
-    async fn test_experimental_features_set_contains_filter(client: Client) {
-        let mut features = ExperimentalFeatures::new(&client);
         features.set_contains_filter(true);
-        let _ = features.update().await.unwrap();
-
-        let res = features.get().await.unwrap();
-        assert!(res.contains_filter)
-    }
-
-    #[meilisearch_test]
-    async fn test_experimental_features_set_network(client: Client) {
-        let mut features = ExperimentalFeatures::new(&client);
         features.set_network(true);
-        let _ = features.update().await.unwrap();
-
-        let res = features.get().await.unwrap();
-        assert!(res.network)
-    }
-
-    #[meilisearch_test]
-    async fn test_experimental_features_set_edit_documents_by_function(client: Client) {
-        let mut features = ExperimentalFeatures::new(&client);
         features.set_edit_documents_by_function(true);
         let _ = features.update().await.unwrap();
 
         let res = features.get().await.unwrap();
-        assert!(res.edit_documents_by_function)
+        assert!(res.metrics);
+        assert!(res.logs_route);
+        assert!(res.contains_filter);
+        assert!(res.network);
+        assert!(res.edit_documents_by_function);
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -743,6 +743,7 @@ impl<'a, 'b, Http: HttpClient> MultiSearchQuery<'a, 'b, Http> {
             queries: Vec::new(),
         }
     }
+
     pub fn with_search_query(
         &mut self,
         mut search_query: SearchQuery<'b, Http>,
@@ -751,6 +752,7 @@ impl<'a, 'b, Http: HttpClient> MultiSearchQuery<'a, 'b, Http> {
         self.queries.push(search_query);
         self
     }
+
     /// Adds the `federation` parameter, making the search a federated search.
     pub fn with_federation(
         self,
@@ -770,6 +772,7 @@ impl<'a, 'b, Http: HttpClient> MultiSearchQuery<'a, 'b, Http> {
         self.client.execute_multi_search_query::<T>(self).await
     }
 }
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MultiSearchResponse<T> {
     pub results: Vec<SearchResults<T>>,
@@ -791,12 +794,19 @@ pub struct FederatedMultiSearchQuery<'a, 'b, Http: HttpClient = DefaultHttpClien
 #[derive(Debug, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct FederationOptions {
+    /// Number of documents to skip
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<usize>,
+
+    /// Maximum number of documents returned
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
+
+    /// Display facet information for the specified indexes
     #[serde(skip_serializing_if = "Option::is_none")]
     pub facets_by_index: Option<HashMap<String, Vec<String>>>,
+    
+    /// Display facet information for the specified indexes
     #[serde(skip_serializing_if = "Option::is_none")]
     pub merge_facets: Option<bool>,
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -753,15 +753,15 @@ impl<'a, 'b, Http: HttpClient> MultiSearchQuery<'a, 'b, Http> {
 
     pub fn with_search_query_and_weight(
         &mut self,
-        mut search_query: SearchQuery<'b, Http>,
+        search_query: SearchQuery<'b, Http>,
         weight: f32,
     ) -> &mut MultiSearchQuery<'a, 'b, Http> {
-        search_query.with_index_uid();
-        search_query.federation_options = Some(QueryFederationOptions {
-            weight: Some(weight),
-        });
-        self.queries.push(search_query);
-        self
+        self.with_search_query_and_options(
+            search_query,
+            QueryFederationOptions {
+                weight: Some(weight),
+            },
+        )
     }
 
     pub fn with_search_query_and_options(

--- a/src/search.rs
+++ b/src/search.rs
@@ -811,6 +811,13 @@ pub struct FederatedMultiSearchQuery<'a, 'b, Http: HttpClient = DefaultHttpClien
     pub federation: Option<FederationOptions>,
 }
 
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct MergeFacets {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_values_per_facet: Option<usize>,
+}
+
 /// The `federation` field of the multi search API.
 /// See [the docs](https://www.meilisearch.com/docs/reference/api/multi_search#federation).
 #[derive(Debug, Serialize, Clone, Default)]
@@ -828,9 +835,9 @@ pub struct FederationOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub facets_by_index: Option<HashMap<String, Vec<String>>>,
 
-    /// Display facet information for the specified indexes
+    /// Request to merge the facets to enforce a maximum number of values per facet.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub merge_facets: Option<bool>,
+    pub merge_facets: Option<MergeFacets>,
 }
 
 impl<'a, Http: HttpClient> FederatedMultiSearchQuery<'a, '_, Http> {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,9 @@
 use crate::{
-    client::Client, errors::{Error, MeilisearchError}, indexes::Index, request::HttpClient, DefaultHttpClient,
+    client::Client,
+    errors::{Error, MeilisearchError},
+    indexes::Index,
+    request::HttpClient,
+    DefaultHttpClient,
 };
 use either::Either;
 use serde::{de::DeserializeOwned, Deserialize, Serialize, Serializer};
@@ -69,7 +73,10 @@ pub struct SearchResult<T> {
     pub ranking_score: Option<f64>,
 
     /// A detailed global ranking score field
-    #[serde(rename = "_rankingScoreDetails", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "_rankingScoreDetails",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub ranking_score_details: Option<Map<String, Value>>,
 
     /// Only returned for federated multi search.
@@ -382,7 +389,7 @@ pub struct SearchQuery<'a, Http: HttpClient> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) index_uid: Option<&'a str>,
-  
+
     /// Configures Meilisearch to return search results based on a query’s meaning and context.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hybrid: Option<HybridSearch<'a>>,
@@ -744,7 +751,7 @@ impl<'a, 'b, Http: HttpClient> MultiSearchQuery<'a, 'b, Http> {
         self
     }
 
-     pub fn with_search_query_and_options(
+    pub fn with_search_query_and_options(
         &mut self,
         mut search_query: SearchQuery<'b, Http>,
         options: QueryFederationOptions,
@@ -807,7 +814,7 @@ pub struct FederationOptions {
     /// Display facet information for the specified indexes
     #[serde(skip_serializing_if = "Option::is_none")]
     pub facets_by_index: Option<HashMap<String, Vec<String>>>,
-    
+
     /// Display facet information for the specified indexes
     #[serde(skip_serializing_if = "Option::is_none")]
     pub merge_facets: Option<bool>,
@@ -878,7 +885,7 @@ pub struct FederationHitInfo {
     /// The product of the _rankingScore of the hit and the weight of the query of origin.
     pub weighted_ranking_score: f32,
 }
-  
+
 /// A struct representing a facet-search query.
 ///
 /// You can add search parameters using the builder syntax.

--- a/src/search.rs
+++ b/src/search.rs
@@ -700,15 +700,6 @@ impl<'a, Http: HttpClient> SearchQuery<'a, Http> {
         self
     }
 
-    /// Only usable in federated multi search queries.
-    pub fn with_federation_options<'b>(
-        &'b mut self,
-        federation_options: QueryFederationOptions,
-    ) -> &'b mut SearchQuery<'a, Http> {
-        self.federation_options = Some(federation_options);
-        self
-    }
-
     pub fn build(&mut self) -> SearchQuery<'a, Http> {
         self.clone()
     }
@@ -753,7 +744,18 @@ impl<'a, 'b, Http: HttpClient> MultiSearchQuery<'a, 'b, Http> {
         self
     }
 
-    /// Adds the `federation` parameter, making the search a federated search.
+     pub fn with_search_query_and_options(
+        &mut self,
+        mut search_query: SearchQuery<'b, Http>,
+        options: QueryFederationOptions,
+    ) -> &mut MultiSearchQuery<'a, 'b, Http> {
+        search_query.with_index_uid();
+        search_query.federation_options = Some(options);
+        self.queries.push(search_query);
+        self
+    }
+
+    /// Adds the `federation` parameter, turning the search into a federated search.
     pub fn with_federation(
         self,
         federation: FederationOptions,

--- a/src/search.rs
+++ b/src/search.rs
@@ -55,19 +55,25 @@ pub struct SearchResult<T> {
     /// The full result.
     #[serde(flatten)]
     pub result: T,
+
     /// The formatted result.
-    #[serde(rename = "_formatted")]
+    #[serde(rename = "_formatted", skip_serializing_if = "Option::is_none")]
     pub formatted_result: Option<Map<String, Value>>,
+
     /// The object that contains information about the matches.
-    #[serde(rename = "_matchesPosition")]
+    #[serde(rename = "_matchesPosition", skip_serializing_if = "Option::is_none")]
     pub matches_position: Option<HashMap<String, Vec<MatchRange>>>,
+
     /// The relevancy score of the match.
-    #[serde(rename = "_rankingScore")]
+    #[serde(rename = "_rankingScore", skip_serializing_if = "Option::is_none")]
     pub ranking_score: Option<f64>,
-    #[serde(rename = "_rankingScoreDetails")]
+
+    /// A detailed global ranking score field
+    #[serde(rename = "_rankingScoreDetails", skip_serializing_if = "Option::is_none")]
     pub ranking_score_details: Option<Map<String, Value>>,
+
     /// Only returned for federated multi search.
-    #[serde(rename = "_federation")]
+    #[serde(rename = "_federation", skip_serializing_if = "Option::is_none")]
     pub federation: Option<FederationHitInfo>,
 }
 
@@ -832,7 +838,7 @@ pub struct FederatedMultiSearchResponse<T> {
 }
 
 /// Returned for each hit in `_federation` when doing federated multi search.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FederationHitInfo {
     pub index_uid: String,
@@ -1243,6 +1249,7 @@ mod tests {
                 number: 90,
                 value: S("Harry Potter and the Deathly Hallows"),
                 nested: Nested { child: S("tenth") },
+                _vectors: None,
             })
         );
         assert_eq!(

--- a/src/search.rs
+++ b/src/search.rs
@@ -811,7 +811,6 @@ pub struct FederationOptions {
     pub merge_facets: Option<bool>,
 }
 
-#[allow(missing_docs)]
 impl<'a, Http: HttpClient> FederatedMultiSearchQuery<'a, '_, Http> {
     /// Execute the query and fetch the results.
     pub async fn execute<T: 'static + DeserializeOwned + Send + Sync>(


### PR DESCRIPTION
# Pull Request

Rework on top of #625

## Related issue
Fixes #609

## What does this PR do?
This PR adds types and methods to use the federated multi search API. There are multiple ways to add this to this library, depending on how strictly one wants to type everything. I decided to:

- Add a new `FederatedMultiSearchResponse`, which also required a new `Client::execute_federated_multi_search_query`. The response of federated searches is just very different from normal multi searches, and I didn't think having an enum returned by `execute_multi_search_query` was a particularly nice design (and it would have been a breaking change).
- Add a `federation: Option<FederationHitInfo>` to each `SearchResult` (which is `None` for non-federated searches). I don't think it's worth to have a dedicated `FederatedSearchResult`.
- Add `MultiSearchQuery::with_federation` which returns a new `FederatedMultiSearchQuery`. One could also change `MultiSearchQuery` to be able to represent federated queries, but I had a slight preference for my solution. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced federated multi-search functionality, allowing queries across multiple indexes with support for query weighting and merged results.
  * Added new methods and options to customize federated search behavior, including per-query weighting and federation parameters.
  * Enhanced response structure to include merged hits, pagination, facet data, and remote error details.

* **Bug Fixes**
  * Improved handling of multiple index parameters in test macros, ensuring each index is managed independently during tests.

* **Documentation**
  * Updated documentation to clarify usage of federated multi-search and support for multiple index parameters in test macros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->