### PR TITLE
Lighten `futures` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,10 @@ pin-project-lite = { version = "0.2.16", optional = true }
 reqwest = { version = "0.12.22", optional = true, default-features = false, features = ["rustls-tls", "http2", "stream"] }
 bytes = { version = "1.10.1", optional = true }
 uuid = { version = "1.17.0", features = ["v4"] }
+futures-core = "0.3.31"
 futures-io = "0.3.31"
-futures = "0.3.31"
+futures-channel = "0.3.31"
+futures-util = { version = "0.3.31", default-features = false, features = ["io"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 jsonwebtoken = { version = "9.3.1", default-features = false }

--- a/src/request.rs
+++ b/src/request.rs
@@ -79,7 +79,7 @@ pub trait HttpClient: Clone + Send + Sync {
         Body: Serialize + Send + Sync,
         Output: DeserializeOwned + 'static + Send,
     {
-        use futures::io::Cursor;
+        use futures_util::io::Cursor;
 
         self.stream_request(
             url,

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -5,7 +5,8 @@ use std::{
 
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
-use futures::{AsyncRead, Stream};
+use futures_core::Stream;
+use futures_io::AsyncRead;
 use pin_project_lite::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -90,10 +91,10 @@ impl HttpClient for ReqwestClient {
             }
             #[cfg(target_arch = "wasm32")]
             {
-                use futures::{pin_mut, AsyncReadExt};
+                use futures_util::AsyncReadExt;
 
                 let mut buf = Vec::new();
-                pin_mut!(body);
+                let mut body = std::pin::pin!(body);
                 body.read_to_end(&mut buf)
                     .await
                     .map_err(|err| Error::Other(Box::new(err)))?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) async fn async_sleep(interval: Duration) {
-    let (sender, receiver) = futures::channel::oneshot::channel::<()>();
+    let (sender, receiver) = futures_channel::oneshot::channel::<()>();
     std::thread::spawn(move || {
         std::thread::sleep(interval);
         let _ = sender.send(());


### PR DESCRIPTION
# Pull Request

## Related issue

None

## What does this PR do?

- This PR replaces `futures` with `futures-core` + `futures-channel` + `futures-util` with reduced features. This reduces the dependency tree making projects using `meilisearch-sdk` faster to compile.

## PR checklist

- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management for futures crates to use more granular components.
  * Adjusted internal import paths to reflect new dependency structure.
  * No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->