### PR TITLE
Use `tokio` sleep instead of blocking thread when using `reqwest` client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ futures-util = { version = "0.3.31", default-features = false, features = ["io"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 jsonwebtoken = { version = "9.3.1", default-features = false }
+tokio = { version = "1.38", optional = true, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.17.0", default-features = false, features = ["v4", "js"] }
@@ -42,7 +43,7 @@ wasm-bindgen-futures = "0.4"
 
 [features]
 default = ["reqwest"]
-reqwest = ["dep:reqwest", "pin-project-lite", "bytes"]
+reqwest = ["dep:reqwest", "dep:tokio", "pin-project-lite", "bytes"]
 futures-unsend = []
 
 [dev-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ use crate::{
     search::*,
     task_info::TaskInfo,
     tasks::{Task, TasksCancelQuery, TasksDeleteQuery, TasksResults, TasksSearchQuery},
-    utils::async_sleep,
+    utils::SleepBackend,
     DefaultHttpClient,
 };
 
@@ -933,7 +933,7 @@ impl<Http: HttpClient> Client<Http> {
                     }
                     Task::Enqueued { .. } | Task::Processing { .. } => {
                         elapsed_time += interval;
-                        async_sleep(interval).await;
+                        self.sleep_backend().sleep(interval).await;
                     }
                 },
                 Err(error) => return Err(error),
@@ -1143,6 +1143,10 @@ impl<Http: HttpClient> Client<Http> {
         };
 
         crate::tenant_tokens::generate_tenant_token(api_key_uid, search_rules, api_key, expires_at)
+    }
+
+    fn sleep_backend(&self) -> SleepBackend {
+        SleepBackend::infer()
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1146,7 +1146,7 @@ impl<Http: HttpClient> Client<Http> {
     }
 
     fn sleep_backend(&self) -> SleepBackend {
-        SleepBackend::infer()
+        SleepBackend::infer(self.http_client.is_tokio())
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -101,6 +101,10 @@ pub trait HttpClient: Clone + Send + Sync {
         content_type: &str,
         expected_status_code: u16,
     ) -> Result<Output, Error>;
+
+    fn is_tokio(&self) -> bool {
+        false
+    }
 }
 
 pub fn parse_response<Output: DeserializeOwned>(

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -112,6 +112,10 @@ impl HttpClient for ReqwestClient {
 
         parse_response(status, expected_status_code, &body, url.to_string())
     }
+
+    fn is_tokio(&self) -> bool {
+        true
+    }
 }
 
 fn verb<Q, B>(method: &Method<Q, B>) -> reqwest::Method {


### PR DESCRIPTION
# Pull Request

## Related issue

None

## What does this PR do?

This PR makes meilisearch-sdk use the much more efficient tokio sleep machinery when the `reqwest` HTTP client is used to make requests (we assume `reqwest` means that the user is using `tokio` because it only works with `tokio`) instead of spawing a new ad hoc blocking thread for each sleep request.

## PR checklist

- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of asynchronous sleep operations, dynamically selecting the sleep mechanism based on the runtime environment.
  * Enhanced compatibility with different platforms, supporting both Tokio-based and non-Tokio environments.
* **Bug Fixes**
  * More reliable sleep behavior across various platforms and runtimes.
* **Tests**
  * Added and updated tests to ensure correct sleep functionality for each supported backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->