### PR TITLE
Add queryVector to search responses and support index renaming

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -94,6 +94,11 @@ update_an_index_1: |-
     .execute()
     .await
     .unwrap();
+rename_an_index_1: |-
+  curl \
+    -X PATCH 'MEILISEARCH_URL/indexes/INDEX_A' \
+    -H 'Content-Type: application/json' \
+    --data-binary '{ "uid": "INDEX_B" }'
 delete_an_index_1: |-
   client.index("movies")
     .delete()

--- a/src/client.rs
+++ b/src/client.rs
@@ -1376,6 +1376,8 @@ mod tests {
 
         let new_index = client.get_index(&to).await?;
         assert_eq!(new_index.uid, to);
+        // Optional: old uid should no longer resolve
+        assert!(client.get_raw_index(&from).await.is_err());
 
         new_index
             .delete()

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,6 +27,8 @@ pub struct Client<Http: HttpClient = DefaultHttpClient> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SwapIndexes {
     pub indexes: (String, String),
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rename: Option<bool>,
 }
 
 #[cfg(feature = "reqwest")]
@@ -202,7 +204,7 @@ impl<Http: HttpClient> Client<Http> {
     ///
     /// [1]: https://www.meilisearch.com/docs/learn/multi_search/multi_search_vs_federated_search#what-is-federated-search
     #[must_use]
-    pub fn multi_search(&self) -> MultiSearchQuery<Http> {
+    pub fn multi_search(&self) -> MultiSearchQuery<'_, '_, Http> {
         MultiSearchQuery::new(self)
     }
 
@@ -532,6 +534,7 @@ impl<Http: HttpClient> Client<Http> {
     ///             "swap_index_1".to_string(),
     ///             "swap_index_2".to_string(),
     ///         ),
+    ///         rename: None,
     ///     }])
     ///     .await
     ///     .unwrap();
@@ -1249,6 +1252,7 @@ mod tests {
                     "test_swapping_two_indexes_1".to_string(),
                     "test_swapping_two_indexes_2".to_string(),
                 ),
+                rename: None,
             }])
             .await
             .unwrap();
@@ -1349,6 +1353,37 @@ mod tests {
     async fn test_get_tasks(client: Client) {
         let tasks = client.get_tasks().await.unwrap();
         assert_eq!(tasks.limit, 20);
+    }
+
+    #[meilisearch_test]
+    async fn test_rename_index_via_swap(client: Client, name: String) -> Result<(), Error> {
+        let from = format!("{name}_from");
+        let to = format!("{name}_to");
+
+        client
+            .create_index(&from, None)
+            .await?
+            .wait_for_completion(&client, None, None)
+            .await?;
+
+        let task = client
+            .swap_indexes([&SwapIndexes {
+                indexes: (from.clone(), to.clone()),
+                rename: Some(true),
+            }])
+            .await?;
+        task.wait_for_completion(&client, None, None).await?;
+
+        let new_index = client.get_index(&to).await?;
+        assert_eq!(new_index.uid, to);
+
+        new_index
+            .delete()
+            .await?
+            .wait_for_completion(&client, None, None)
+            .await?;
+
+        Ok(())
     }
 
     #[meilisearch_test]

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -86,7 +86,7 @@ pub struct DocumentQuery<'a, Http: HttpClient> {
 
 impl<'a, Http: HttpClient> DocumentQuery<'a, Http> {
     #[must_use]
-    pub fn new(index: &Index<Http>) -> DocumentQuery<Http> {
+    pub fn new(index: &Index<Http>) -> DocumentQuery<'_, Http> {
         DocumentQuery {
             index,
             fields: None,
@@ -200,7 +200,7 @@ pub struct DocumentsQuery<'a, Http: HttpClient> {
 
 impl<'a, Http: HttpClient> DocumentsQuery<'a, Http> {
     #[must_use]
-    pub fn new(index: &Index<Http>) -> DocumentsQuery<Http> {
+    pub fn new(index: &Index<Http>) -> DocumentsQuery<'_, Http> {
         DocumentsQuery {
             index,
             offset: None,
@@ -332,7 +332,7 @@ pub struct DocumentDeletionQuery<'a, Http: HttpClient> {
 
 impl<'a, Http: HttpClient> DocumentDeletionQuery<'a, Http> {
     #[must_use]
-    pub fn new(index: &Index<Http>) -> DocumentDeletionQuery<Http> {
+    pub fn new(index: &Index<Http>) -> DocumentDeletionQuery<'_, Http> {
         DocumentDeletionQuery {
             index,
             filter: None,

--- a/src/search.rs
+++ b/src/search.rs
@@ -128,6 +128,7 @@ pub struct SearchResults<T> {
         alias = "query_vector",
         alias = "queryEmbedding",
         alias = "query_embedding",
+        alias = "vector",
         skip_serializing_if = "Option::is_none"
     )]
     pub query_vector: Option<Vec<f32>>,
@@ -2041,7 +2042,9 @@ pub(crate) mod tests {
 
         let results: SearchResults<Document> = index.execute_query(&query).await?;
 
-        if results.query_vector.is_none() {
+        if std::env::var("MSDK_DEBUG_RAW_SEARCH").ok().as_deref() == Some("1")
+            && results.query_vector.is_none()
+        {
             use crate::request::Method;
             let url = format!("{}/indexes/{}/search", index.client.get_host(), index.uid);
             let raw: serde_json::Value = index


### PR DESCRIPTION
# Pull Request

Add `queryVector` to search responses and support index renaming.

## Related issue
Fixes #703 

## What does this PR do?

As discussed in the open issue we wanted to update the SDK such that when search requests include the `retrieveVectors` parameters, API responses  include a `queryVector` field.


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - You can now rename indexes via both update and swap operations.
  - Search results can optionally include the query vector when requested, enabling easier debugging and vector-aware workflows.

- Documentation
  - Added a REST example demonstrating how to rename an index using a PATCH request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->