### PR TITLE
Make `reqwest/rustls-tls` an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ either = { version = "1.15.0", features = ["serde"] }
 thiserror = "2.0.12"
 meilisearch-index-setting-macro = { path = "meilisearch-index-setting-macro", version = "0.29.1" }
 pin-project-lite = { version = "0.2.16", optional = true }
-reqwest = { version = "0.12.22", optional = true, default-features = false, features = ["rustls-tls", "http2", "stream"] }
+reqwest = { version = "0.12.22", optional = true, default-features = false, features = ["http2", "stream"] }
 bytes = { version = "1.10.1", optional = true }
 uuid = { version = "1.17.0", features = ["v4"] }
 futures-core = "0.3.31"
@@ -44,6 +44,7 @@ wasm-bindgen-futures = "0.4"
 [features]
 default = ["reqwest"]
 reqwest = ["dep:reqwest", "dep:tokio", "pin-project-lite", "bytes"]
+tls = ["reqwest/rustls-tls"]
 futures-unsend = []
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ web-sys = "0.3.77"
 wasm-bindgen-futures = "0.4"
 
 [features]
-default = ["reqwest"]
+default = ["reqwest", "tls"]
 reqwest = ["dep:reqwest", "dep:tokio", "pin-project-lite", "bytes"]
 tls = ["reqwest/rustls-tls"]
 futures-unsend = []


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #705

## What does this PR do?
- Removes `reqwest/rustls-tls` as a required feature for the `meilisearch/reqwest` feature.
- Adds the feature `meilisearch/tls` which enables `reqwest/rustlts-tls`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "tls" feature (alias to the Rustls TLS provider) and enabled it in the default feature set so HTTPS via Rustls is available by default.

* **Chores**
  * Updated networking dependency features to retain HTTP/2 and streaming while moving TLS behind the new "tls" feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->