### PR TITLE
Add sharding support for Network methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,8 @@ pub mod features;
 pub mod indexes;
 /// Module containing the [`Key`](key::Key) struct.
 pub mod key;
+/// Module for Network configuration API (sharding/remotes).
+pub mod network;
 pub mod request;
 /// Module related to search queries and results.
 pub mod search;

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteConfig {
+    pub url: String,
+    #[serde(rename = "searchApiKey")]
+    pub search_api_key: String,
+    #[serde(rename = "writeApiKey", skip_serializing_if = "Option::is_none")]
+    // present in responses since 1.19
+    pub write_api_key: Option<String>,
+}
+
+pub type RemotesMap = HashMap<String, RemoteConfig>;
+
+/// Full network state returned by GET /network
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkState {
+    pub remotes: Option<RemotesMap>,
+    #[serde(rename = "self")]
+    pub self_name: Option<String>,
+    pub sharding: Option<bool>,
+}
+
+/// Partial update body for PATCH /network
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remotes: Option<RemotesMap>,
+    #[serde(rename = "self", skip_serializing_if = "Option::is_none")]
+    pub self_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sharding: Option<bool>,
+}

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoteConfig {
     pub url: String,
@@ -15,7 +15,7 @@ pub struct RemoteConfig {
 pub type RemotesMap = HashMap<String, RemoteConfig>;
 
 /// Full network state returned by GET /network
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkState {
     pub remotes: Option<RemotesMap>,
@@ -25,7 +25,7 @@ pub struct NetworkState {
 }
 
 /// Partial update body for PATCH /network
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/search.rs
+++ b/src/search.rs
@@ -415,8 +415,12 @@ pub struct SearchQuery<'a, Http: HttpClient> {
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryFederationOptions {
+    /// Weight multiplier for this query when merging federated results
     #[serde(skip_serializing_if = "Option::is_none")]
     pub weight: Option<f32>,
+    /// Remote instance name to target when sharding; corresponds to a key in network.remotes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote: Option<String>,
 }
 
 #[allow(missing_docs)]
@@ -766,6 +770,7 @@ impl<'a, 'b, Http: HttpClient> MultiSearchQuery<'a, 'b, Http> {
             search_query,
             QueryFederationOptions {
                 weight: Some(weight),
+                remote: None,
             },
         )
     }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -748,7 +748,6 @@ impl<'a, Http: HttpClient> TasksQuery<'a, TasksPaginationFilters, Http> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
 
     #[test]
     fn test_deserialize_enqueued_task_with_remotes() {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -753,13 +753,13 @@ mod test {
     #[test]
     fn test_deserialize_enqueued_task_with_remotes() {
         let json = r#"{
-  "enqueuedAt": "2022-02-03T13:02:38.369634Z",
-  "indexUid": "movies",
-  "status": "enqueued",
-  "type": "indexUpdate",
-  "uid": 12,
-  "remotes": { "ms-00": { "status": "ok" } }
-}"#;
+          "enqueuedAt": "2022-02-03T13:02:38.369634Z",
+          "indexUid": "movies",
+          "status": "enqueued",
+          "type": "indexUpdate",
+          "uid": 12,
+          "remotes": { "ms-00": { "status": "ok" } }
+        }"#;
         let task: Task = serde_json::from_str(json).unwrap();
         match task {
             Task::Enqueued { content } => {
@@ -773,20 +773,20 @@ mod test {
     #[test]
     fn test_deserialize_processing_task_with_remotes() {
         let json = r#"{
-  "details": {
-    "indexedDocuments": null,
-    "receivedDocuments": 10
-  },
-  "duration": null,
-  "enqueuedAt": "2022-02-03T15:17:02.801341Z",
-  "finishedAt": null,
-  "indexUid": "movies",
-  "startedAt": "2022-02-03T15:17:02.812338Z",
-  "status": "processing",
-  "type": "documentAdditionOrUpdate",
-  "uid": 14,
-  "remotes": { "ms-00": { "status": "ok" } }
-}"#;
+          "details": {
+            "indexedDocuments": null,
+            "receivedDocuments": 10
+          },
+          "duration": null,
+          "enqueuedAt": "2022-02-03T15:17:02.801341Z",
+          "finishedAt": null,
+          "indexUid": "movies",
+          "startedAt": "2022-02-03T15:17:02.812338Z",
+          "status": "processing",
+          "type": "documentAdditionOrUpdate",
+          "uid": 14,
+          "remotes": { "ms-00": { "status": "ok" } }
+        }"#;
         let task: Task = serde_json::from_str(json).unwrap();
         match task {
             Task::Processing { content } => {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::{Map, Value};
 use std::time::Duration;
 use time::OffsetDateTime;
 
@@ -157,6 +158,9 @@ pub struct SucceededTask {
     pub canceled_by: Option<usize>,
     pub index_uid: Option<String>,
     pub error: Option<MeilisearchError>,
+    /// Remotes object returned by the server for this task (present since Meilisearch 1.19)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remotes: Option<Map<String, Value>>,
     #[serde(flatten)]
     pub update_type: TaskType,
     pub uid: u32,
@@ -174,6 +178,9 @@ pub struct EnqueuedTask {
     #[serde(with = "time::serde::rfc3339")]
     pub enqueued_at: OffsetDateTime,
     pub index_uid: Option<String>,
+    /// Remotes object returned by the server for this enqueued task
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remotes: Option<Map<String, Value>>,
     #[serde(flatten)]
     pub update_type: TaskType,
     pub uid: u32,
@@ -193,6 +200,9 @@ pub struct ProcessingTask {
     #[serde(with = "time::serde::rfc3339")]
     pub started_at: OffsetDateTime,
     pub index_uid: Option<String>,
+    /// Remotes object returned by the server for this processing task
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remotes: Option<Map<String, Value>>,
     #[serde(flatten)]
     pub update_type: TaskType,
     pub uid: u32,
@@ -739,6 +749,55 @@ impl<'a, Http: HttpClient> TasksQuery<'a, TasksPaginationFilters, Http> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_deserialize_enqueued_task_with_remotes() {
+        let json = r#"{
+  "enqueuedAt": "2022-02-03T13:02:38.369634Z",
+  "indexUid": "movies",
+  "status": "enqueued",
+  "type": "indexUpdate",
+  "uid": 12,
+  "remotes": { "ms-00": { "status": "ok" } }
+}"#;
+        let task: Task = serde_json::from_str(json).unwrap();
+        match task {
+            Task::Enqueued { content } => {
+                let remotes = content.remotes.expect("remotes should be present");
+                assert!(remotes.contains_key("ms-00"));
+            }
+            _ => panic!("expected enqueued task"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_processing_task_with_remotes() {
+        let json = r#"{
+  "details": {
+    "indexedDocuments": null,
+    "receivedDocuments": 10
+  },
+  "duration": null,
+  "enqueuedAt": "2022-02-03T15:17:02.801341Z",
+  "finishedAt": null,
+  "indexUid": "movies",
+  "startedAt": "2022-02-03T15:17:02.812338Z",
+  "status": "processing",
+  "type": "documentAdditionOrUpdate",
+  "uid": 14,
+  "remotes": { "ms-00": { "status": "ok" } }
+}"#;
+        let task: Task = serde_json::from_str(json).unwrap();
+        match task {
+            Task::Processing { content } => {
+                let remotes = content.remotes.expect("remotes should be present");
+                assert!(remotes.contains_key("ms-00"));
+            }
+            _ => panic!("expected processing task"),
+        }
+    }
+
+    use super::*;
     use crate::{
         client::*,
         errors::{ErrorCode, ErrorType},
@@ -782,8 +841,7 @@ mod test {
                     enqueued_at,
                     index_uid: Some(index_uid),
                     update_type: TaskType::DocumentAdditionOrUpdate { details: None },
-                    uid: 12,
-                }
+                    uid: 12, .. }
             }
         if enqueued_at == datetime && index_uid == "meili"));
 


### PR DESCRIPTION
# Pull Request

This PR aims to bring the SDK close to the Mealisearch [Meilisearch 1.19](https://github.com/meilisearch/meilisearch/releases/tag/v1.19.0) features and add support for sharding .

## Related issue
Fixes #700 

## What does this PR do?

As per the tasks described in the origina issue #700 

- Update the Network methods to accept sending the sharding parameter

- Update the Network methods to include `remotes.[remoteName].writeApiKey` in the responses

- Update the Tasks methods to include remotes objects in the tasks reponse index update method to allow renaming

- Add new test cases to test implementation

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage network configuration from the client: view/update network state, toggle sharding, and set the local remote.
  * Public Network module exposing remotes, self identity, and sharding configuration.
  * Multi-search federation options can target a specific remote.

* **Improvements**
  * Task details (enqueued, processing, succeeded) now include remotes information when available.

* **Tests**
  * Added tests for network updates and task deserialization with remotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->