### PR TITLE
chore: Bump jsonwebtoken crate to 10.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ futures-channel = "0.3.31"
 futures-util = { version = "0.3.31", default-features = false, features = ["io"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-jsonwebtoken = { version = "9.3.1", default-features = false }
+jsonwebtoken = { version = "10.0.0", default-features = false, features = ["aws_lc_rs"]}
 tokio = { version = "1.38", optional = true, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/tenant_tokens.rs
+++ b/src/tenant_tokens.rs
@@ -6,6 +6,7 @@ use time::OffsetDateTime;
 #[cfg(not(target_arch = "wasm32"))]
 use uuid::Uuid;
 
+#[cfg_attr(test, derive(Clone))]
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct TenantTokenClaim {


### PR DESCRIPTION
# Pull Request

Bump `jsonwebtoken` crate to `10.0.0` to add the "aws_lc_rs" feature which will allow in reducing the double compilation.

## Related issue
Fixes #715 

## What does this PR do?

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the underlying token processing library to a new major release with non-blocking support and enhanced cryptography options, improving performance and security posture.

* **Tests**
  * Improved test build configuration for token-related structures to streamline test scenarios; no impact on runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->