### PR TITLE
Add genres field to "add or update document" code sample

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -168,7 +168,8 @@ add_or_update_documents_1: |-
   #[derive(Serialize, Deserialize)]
   struct IncompleteMovie {
     id: usize,
-    title: String
+    title: String,
+    genres: String
   }
 
   let task: TaskInfo = client
@@ -176,7 +177,8 @@ add_or_update_documents_1: |-
     .add_or_update(&[
       IncompleteMovie {
         id: 287947,
-        title: "Shazam ⚡️".to_string()
+        title: "Shazam ⚡️".to_string(),
+        genres: "comedy".to_string()
       }
     ], None)
     .await


### PR DESCRIPTION
Add the missing genres field to the code samples

# Pull Request

## Related issue
Fixes #734 

## What does this PR do?
- Add the field genres to the rust sample as the samples for the other languages for "add or update document" have the field.

## PR checklist
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples to include genres attribute support in movie data structures, enabling developers to reference more complete sample implementations demonstrating how to properly handle extended movie metadata including genre information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->