### PR TITLE
fix: add missing Action enum variants

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -814,9 +814,6 @@ pub enum Action {
     /// Provides access to the delete webhooks endpoint.
     #[serde(rename = "webhooks.delete")]
     WebhooksDelete,
-    /// Provides access to the fields post endpoint.
-    #[serde(rename = "fields.post")]
-    FieldsPost,
     /// Any other value that might be added to Meilisearch in the future but that is not supported by this SDK.
     /// If you see one, please open a PR
     #[serde(untagged)]


### PR DESCRIPTION
## Summary

This PR adds all missing Action enum variants that exist in Meilisearch server (v1.22.2+), fixing the issue where the SDK fails to deserialize keys that use newer actions like \*.get\.

## Problem

As reported in #746, the SDK fails when reading keys because many Action enum values are missing, especially:
- \*.get\ (AllGet) - used by the Default Read-Only Admin API Key
- Various wildcard actions (\documents.*\, \indexes.*\, etc.)
- Many new actions added in recent Meilisearch versions

This caused errors like:
\\\
unknown variant \*.get\, expected one of \*\, \search\, ...
\\\

## Changes

### New Actions Added

| Action | Serde Name | Description |
|--------|------------|-------------|
| AllGet | \*.get\ | Read-only access to all get endpoints |
| DocumentsAll | \documents.*\ | All document operations |
| IndexesAll | \indexes.*\ | All index operations |
| IndexesSwap | \indexes.swap\ | Swap indexes |
| IndexesCompact | \indexes.compact\ | Compact index |
| TasksAll | \	asks.*\ | All task operations |
| TasksCancel | \	asks.cancel\ | Cancel tasks |
| TasksDelete | \	asks.delete\ | Delete tasks |
| SettingsAll | \settings.*\ | All settings operations |
| StatsAll | \stats.*\ | All stats operations |
| MetricsAll | \metrics.*\ | All metrics operations |
| MetricsGet | \metrics.get\ | Get metrics |
| DumpsAll | \dumps.*\ | All dump operations |
| SnapshotsAll | \snapshots.*\ | All snapshot operations |
| SnapshotsCreate | \snapshots.create\ | Create snapshot |
| ExperimentalFeaturesGet | \experimental.get\ | Get experimental features |
| ExperimentalFeaturesUpdate | \experimental.update\ | Update experimental features |
| Export | \export\ | Export data |
| NetworkGet | \
etwork.get\ | Get network config |
| NetworkUpdate | \
etwork.update\ | Update network config |
| ChatsAll | \chats.*\ | All chat operations |
| ChatsGet | \chats.get\ | Get chats |
| ChatsDelete | \chats.delete\ | Delete chats |
| ChatsSettingsAll | \chatsSettings.*\ | All chat settings |
| ChatsSettingsGet | \chatsSettings.get\ | Get chat settings |
| ChatsSettingsUpdate | \chatsSettings.update\ | Update chat settings |
| WebhooksAll | \webhooks.*\ | All webhook operations |
| WebhooksGet | \webhooks.get\ | Get webhooks |
| WebhooksCreate | \webhooks.create\ | Create webhook |
| WebhooksUpdate | \webhooks.update\ | Update webhook |
| WebhooksDelete | \webhooks.delete\ | Delete webhook |
| FieldsPost | \ields.post\ | Fields post endpoint |

### Breaking Changes

The following variants were renamed to match the Meilisearch server naming convention:

| Old Name | New Name | Serde Name |
|----------|----------|------------|
| KeyGet | KeysGet | \keys.get\ |
| KeyCreate | KeysCreate | \keys.create\ |
| KeyUpdate | KeysUpdate | \keys.update\ |
| KeyDelete | KeysDelete | \keys.delete\ |

### Removed

- \DumpsGet\ - This action does not exist in the Meilisearch server

## Fixes

Fixes #746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive management controls for chats, webhooks, export, network, and experimental features
  * Expanded granular permission options across documents, indexes (swap/compact), tasks (get/cancel/delete), settings, metrics, stats, dumps and snapshots, fields, and metrics endpoints

* **Breaking Changes**
  * Renamed key-related permissions to a consistent plural form
  * Removed legacy dump/get permission in favor of consolidated dump/snapshot permissions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->