### PR TITLE
Add headers in embedder

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1298,11 +1298,9 @@ pub(crate) mod tests {
 
     pub(crate) async fn setup_embedder(client: &Client, index: &Index) -> Result<(), Error> {
         use crate::settings::Embedder;
-        let embedder_setting = Embedder {
-            source: EmbedderSource::UserProvided,
-            dimensions: Some(11),
-            ..Embedder::default()
-        };
+        let mut embedder_setting = Embedder::default();
+        embedder_setting.source = EmbedderSource::UserProvided;
+        embedder_setting.dimensions = Some(11);
         index
             .set_settings(&crate::settings::Settings {
                 embedders: Some(HashMap::from([("default".to_string(), embedder_setting)])),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -187,6 +187,14 @@ pub struct Embedder {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response: Option<serde_json::Value>,
 
+    /// Headers is a JSON object whose keys represent the name of additional headers to send in
+    /// requests to embedders, and whose values represent the value of these additional headers.
+    ///
+    /// This field is optional when using the rest embedder.
+    /// This field is incompatible with all other embedders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    headers: Option<HashMap<String, String>>,
+
     /// Once set to true, irreversibly converts all vector dimensions to 1-bit values
     #[serde(skip_serializing_if = "Option::is_none")]
     pub binary_quantized: Option<bool>,
@@ -206,6 +214,39 @@ pub struct Embedder {
     /// Configures incoming media fragments for multimodal search queries.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub search_fragments: Option<HashMap<String, EmbedderFragment>>,
+}
+
+impl Embedder {
+    /// This function allows you to set headers for `Rest` embedders. If used with other embedders,
+    /// it *WILL* panic.
+    ///
+    /// If the header argument is `None`, the default value for headers is used:
+    ///
+    /// ```text
+    /// Authorization: Bearer EMBEDDER_API_KEY (only if apiKey was provided)
+    ///
+    /// Content-Type: application/json
+    /// ```
+    pub fn with_headers(mut self, headers: Option<HashMap<String, String>>) -> Self {
+        if self.source == EmbedderSource::Rest {
+            self.headers = if let Some(headers) = headers {
+                Some(headers)
+            } else if let Some(api_key) = self.api_key.clone() {
+                Some(HashMap::from([
+                    (String::from("Authorization"), format!("Bearer {}", api_key)),
+                    ("Content-Type".to_string(), "application/json".to_string()),
+                ]))
+            } else {
+                Some(HashMap::from([(
+                    "Content-Type".to_string(),
+                    "application/json".to_string(),
+                )]))
+            };
+        } else {
+            panic!("Headers are only supported for Rest embedders");
+        }
+        self
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
@@ -3480,6 +3521,93 @@ mod tests {
                 ]
             }))
         );
+    }
+
+    #[test]
+    fn embedder_with_headers_custom_headers_rest() {
+        let mut custom_headers = HashMap::new();
+        custom_headers.insert("X-Custom-Header".to_string(), "my-value".to_string());
+
+        let embedder = Embedder {
+            source: EmbedderSource::Rest,
+            url: Some("https://example.com/embed".to_string()),
+            ..Default::default()
+        }
+        .with_headers(Some(custom_headers));
+
+        let serialized = serde_json::to_value(&embedder).unwrap();
+        assert_eq!(
+            serialized
+                .get("headers")
+                .and_then(|h| h.get("X-Custom-Header")),
+            Some(&json!("my-value"))
+        );
+    }
+
+    #[test]
+    fn embedder_with_headers_none_with_api_key_sets_defaults() {
+        let embedder = Embedder {
+            source: EmbedderSource::Rest,
+            url: Some("https://example.com/embed".to_string()),
+            api_key: Some("secret-key".to_string()),
+            ..Default::default()
+        }
+        .with_headers(None);
+
+        let serialized = serde_json::to_value(&embedder).unwrap();
+        let headers = serialized
+            .get("headers")
+            .expect("headers should be present");
+        assert_eq!(
+            headers.get("Authorization"),
+            Some(&json!("Bearer secret-key"))
+        );
+        assert_eq!(
+            headers.get("Content-Type"),
+            Some(&json!("application/json"))
+        );
+    }
+
+    #[test]
+    fn embedder_with_headers_none_without_api_key_sets_content_type_only() {
+        let embedder = Embedder {
+            source: EmbedderSource::Rest,
+            url: Some("https://example.com/embed".to_string()),
+            ..Default::default()
+        }
+        .with_headers(None);
+
+        let serialized = serde_json::to_value(&embedder).unwrap();
+        let headers = serialized
+            .get("headers")
+            .expect("headers should be present");
+        assert_eq!(
+            headers.get("Content-Type"),
+            Some(&json!("application/json"))
+        );
+        assert_eq!(headers.get("Authorization"), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "Headers are only supported for Rest embedders")]
+    fn embedder_with_headers_panics_for_non_rest_source() {
+        let _embedder = Embedder {
+            source: EmbedderSource::OpenAi,
+            ..Default::default()
+        }
+        .with_headers(Some(HashMap::new()));
+    }
+
+    #[test]
+    fn embedder_headers_not_present_when_unset() {
+        let embedder = Embedder {
+            source: EmbedderSource::Rest,
+            url: Some("https://example.com/embed".to_string()),
+            ..Default::default()
+        };
+
+        let serialized = serde_json::to_value(&embedder).unwrap();
+        assert_eq!(serialized.get("headers"), None);
     }
 
     #[meilisearch_test]


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #720.

## What does this PR do?

- Added a private `headers` field to embedder settings.
- Added a `with_headers` function on the `Embedder` struct to add headers. Headers should only be added with Rest embedder.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST embedders now support custom HTTP header configuration, with automatic handling of Authorization (Bearer token) and Content-Type when appropriate.

* **Tests**
  * Added tests covering custom headers, default header generation, omission when unset, and non-REST behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->