### PR TITLE
add shards field to NetworkState

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -13,14 +13,24 @@ pub struct RemoteConfig {
     pub write_api_key: Option<String>,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShardsConfig {
+    pub remotes: Vec<String>,
+    pub add_remotes: Vec<String>,
+    pub remove_remotes: Vec<String>,
+}
 pub type RemotesMap = HashMap<String, RemoteConfig>;
+pub type ShardsMap = HashMap<String, Vec<String>>;
 pub type RemotesUpdateMap = HashMap<String, Option<RemoteConfig>>;
+pub type ShardsUpdateMap = HashMap<String, Option<ShardsConfig>>;
 
 /// Full network state returned by GET /network
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkState {
     pub remotes: Option<RemotesMap>,
+    pub shards: Option<ShardsMap>,
     #[serde(rename = "self")]
     pub self_name: Option<String>,
     pub leader: Option<String>,
@@ -33,6 +43,8 @@ pub struct NetworkState {
 pub struct NetworkUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remotes: Option<RemotesUpdateMap>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shards: Option<ShardsUpdateMap>,
     #[serde(rename = "self", skip_serializing_if = "Option::is_none")]
     pub self_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Adds newly introduced `shards` to `NetworkState` in meilisearch 1.37.0.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for shard configuration management, enabling configuration of remote nodes for network shards with the ability to add and remove remote configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->