### PR TITLE
Update outdated documentation links

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -843,7 +843,7 @@ add_movies_json_1: |-
   use futures::executor::block_on;
 
   fn main() { block_on(async move {
-    let client = Client::new("MEILISEARCH_URL", Some("masterKey"));
+    let client = Client::new("MEILISEARCH_URL", Some("MEILISEARCH_KEY"));
 
     // reading and parsing the file
     let mut file = File::open("movies.json")

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1188,7 +1188,7 @@ delete_a_key_1: |-
     .delete_key(&key)
     .await?;
 authorization_header_1:
-  let client = Client::new("MEILISEARCH_URL", Some("MASTER_KEY"));
+  let client = Client::new("MEILISEARCH_URL", Some("MEILISEARCH_KEY"));
   let keys = client
   .get_keys()
   .await

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://discord.meilisearch.com">Discord</a> |
   <a href="https://roadmap.meilisearch.com/tabs/1-under-consideration">Roadmap</a> |
   <a href="https://www.meilisearch.com">Website</a> |
-  <a href="https://www.meilisearch.com/docs/faq">FAQ</a>
+  <a href="https://www.meilisearch.com/docs/learn/resources/faq">FAQ</a>
 </h4>
 
 <p align="center">
@@ -111,7 +111,7 @@ async fn main() {
 }
 ```
 
-With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/reference/api/tasks#get-task).
+With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-task).
 
 #### Basic Search <!-- omit in TOC -->
 
@@ -189,7 +189,7 @@ client.index("movies_4").set_filterable_attributes(&filterable_attributes).await
 
 You only need to perform this operation once.
 
-Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [tasks](https://www.meilisearch.com/docs/reference/api/tasks#get-task).
+Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [tasks](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-task).
 
 Then, you can perform the search:
 

--- a/README.tpl
+++ b/README.tpl
@@ -15,7 +15,7 @@
   <a href="https://discord.meilisearch.com">Discord</a> |
   <a href="https://roadmap.meilisearch.com/tabs/1-under-consideration">Roadmap</a> |
   <a href="https://www.meilisearch.com">Website</a> |
-  <a href="https://www.meilisearch.com/docs/faq">FAQ</a>
+  <a href="https://www.meilisearch.com/docs/learn/resources/faq">FAQ</a>
 </h4>
 
 <p align="center">

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -21,7 +21,7 @@ async fn main() {
         .expect("An error happened with the index creation.");
 
     // And now we can update the settings!
-    // You can read more about the available options here: https://www.meilisearch.com/docs/learn/configuration/settings#index-settings
+    // You can read more about the available options here: https://www.meilisearch.com/docs/learn/configuration/configuring_index_settings#index-settings
     let settings: Settings = Settings::new()
         .with_searchable_attributes(["name", "title"])
         .with_filterable_attributes(["created_at"]);

--- a/src/batches.rs
+++ b/src/batches.rs
@@ -5,7 +5,7 @@ use crate::{client::Client, errors::Error, request::HttpClient};
 
 /// Types and queries for the Meilisearch Batches API.
 ///
-/// See: https://www.meilisearch.com/docs/reference/api/batches
+/// See: https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Batch {

--- a/src/client.rs
+++ b/src/client.rs
@@ -39,7 +39,7 @@ impl Client {
     ///
     /// Don't put a '/' at the end of the host.
     ///
-    /// In production mode, see [the documentation about authentication](https://www.meilisearch.com/docs/learn/security/master_api_keys#authentication).
+    /// In production mode, see [the documentation about authentication](https://www.meilisearch.com/docs/learn/security/basic_security#authentication).
     ///
     /// # Example
     ///
@@ -640,7 +640,7 @@ impl<Http: HttpClient> Client<Http> {
 
     /// Get the API [Keys](Key) from Meilisearch with parameters.
     ///
-    /// See [`Client::create_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys#get-all-keys).
+    /// See [`Client::create_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-all-keys).
     ///
     /// # Example
     ///
@@ -675,7 +675,7 @@ impl<Http: HttpClient> Client<Http> {
 
     /// Get the API [Keys](Key) from Meilisearch.
     ///
-    /// See [`Client::create_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys#get-all-keys).
+    /// See [`Client::create_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-all-keys).
     ///
     /// # Example
     ///
@@ -707,7 +707,7 @@ impl<Http: HttpClient> Client<Http> {
 
     /// Get one API [Key] from Meilisearch.
     ///
-    /// See also [`Client::create_key`], [`Client::get_keys`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys#get-one-key).
+    /// See also [`Client::create_key`], [`Client::get_keys`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-one-key).
     ///
     /// # Example
     ///
@@ -739,7 +739,7 @@ impl<Http: HttpClient> Client<Http> {
 
     /// Delete an API [Key] from Meilisearch.
     ///
-    /// See also [`Client::create_key`], [`Client::update_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys#delete-a-key).
+    /// See also [`Client::create_key`], [`Client::update_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#delete-a-key).
     ///
     /// # Example
     ///
@@ -774,7 +774,7 @@ impl<Http: HttpClient> Client<Http> {
 
     /// Create an API [Key] in Meilisearch.
     ///
-    /// See also [`Client::update_key`], [`Client::delete_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys#create-a-key).
+    /// See also [`Client::update_key`], [`Client::delete_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#create-a-key).
     ///
     /// # Example
     ///
@@ -811,7 +811,7 @@ impl<Http: HttpClient> Client<Http> {
 
     /// Update an API [Key] in Meilisearch.
     ///
-    /// See also [`Client::create_key`], [`Client::delete_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys#update-a-key).
+    /// See also [`Client::create_key`], [`Client::delete_key`], [`Client::get_key`], and the [meilisearch documentation](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#update-a-key).
     ///
     /// # Example
     ///
@@ -1114,7 +1114,7 @@ impl<Http: HttpClient> Client<Http> {
 
     /// List batches using the Batches API.
     ///
-    /// See: https://www.meilisearch.com/docs/reference/api/batches
+    /// See: https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches
     ///
     /// # Example
     ///

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -199,7 +199,7 @@ pub struct DocumentsQuery<'a, Http: HttpClient> {
     /// Filters to apply.
     ///
     /// Available since v1.2 of Meilisearch
-    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting) to learn the syntax.
+    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results) to learn the syntax.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<&'a str>,
 
@@ -391,7 +391,7 @@ pub struct DocumentDeletionQuery<'a, Http: HttpClient> {
 
     /// Filters to apply.
     ///
-    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/fine_tuning_results/filtering#filter-basics) to learn the syntax.
+    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results#filter-basics) to learn the syntax.
     pub filter: Option<&'a str>,
 }
 

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -11,7 +11,7 @@
 //! - During a dump import, all indexes contained in the indicated `.dump` file are imported along with their associated documents and [settings](crate::settings::Settings).
 //! Any existing [index](crate::indexes::Index) with the same uid as an index in the dump file will be overwritten.
 //!
-//! - Dump imports are [performed at launch](https://www.meilisearch.com/docs/learn/configuration/instance_options#import-dump) using an option.
+//! - Dump imports are [performed at launch](https://www.meilisearch.com/docs/learn/self_hosted/configure_meilisearch_at_launch#import-dump) using an option.
 //!
 //! # Example
 //!
@@ -45,7 +45,7 @@ use crate::{client::Client, errors::Error, request::*, task_info::TaskInfo};
 impl<Http: HttpClient> Client<Http> {
     /// Triggers a dump creation process.
     ///
-    /// Once the process is complete, a dump is created in the [dumps directory](https://www.meilisearch.com/docs/learn/configuration/instance_options#dump-directory).
+    /// Once the process is complete, a dump is created in the [dumps directory](https://www.meilisearch.com/docs/learn/self_hosted/configure_meilisearch_at_launch#dump-directory).
     /// If the dumps directory does not exist yet, it will be created.
     ///
     /// # Example

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -13,7 +13,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display, time::Duration};
 use time::OffsetDateTime;
 
-/// A Meilisearch [index](https://www.meilisearch.com/docs/learn/core_concepts/indexes).
+/// A Meilisearch [index](https://www.meilisearch.com/docs/learn/getting_started/indexes).
 ///
 /// # Example
 ///
@@ -1374,7 +1374,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get a [Task] from a specific [Index] to keep track of [asynchronous operations](https://www.meilisearch.com/docs/learn/advanced/asynchronous_operations).
+    /// Get a [Task] from a specific [Index] to keep track of [asynchronous operations](https://www.meilisearch.com/docs/learn/async/asynchronous_operations).
     ///
     /// # Example
     ///

--- a/src/key.rs
+++ b/src/key.rs
@@ -3,7 +3,7 @@ use time::OffsetDateTime;
 
 use crate::{client::Client, errors::Error, request::HttpClient};
 
-/// Represents a [meilisearch key](https://www.meilisearch.com/docs/reference/api/keys#returned-fields).
+/// Represents a [meilisearch key](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#returned-fields).
 ///
 /// You can get a [Key] from the [`Client::get_key`] method, or you can create a [Key] with the [`KeyBuilder::new`] or [`Client::create_key`] methods.
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -656,61 +656,61 @@ pub enum Action {
     /// Provides access to everything.
     #[serde(rename = "*")]
     All,
-    /// Provides access to both [`POST`](https://www.meilisearch.com/docs/reference/api/search#search-in-an-index-with-post-route) and [`GET`](https://www.meilisearch.com/docs/reference/api/search#search-in-an-index-with-get-route) search endpoints on authorized indexes.
+    /// Provides access to both [`POST`](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-in-an-index-with-post-route) and [`GET`](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-in-an-index-with-get-route) search endpoints on authorized indexes.
     #[serde(rename = "search")]
     Search,
-    /// Provides access to the [add documents](https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents) and [update documents](https://www.meilisearch.com/docs/reference/api/documents#add-or-update-documents) endpoints on authorized indexes.
+    /// Provides access to the [add documents](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents) and [update documents](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-update-documents) endpoints on authorized indexes.
     #[serde(rename = "documents.add")]
     DocumentsAdd,
-    /// Provides access to the [get one document](https://www.meilisearch.com/docs/reference/api/documents#get-one-document) and [get documents](https://www.meilisearch.com/docs/reference/api/documents#get-documents) endpoints on authorized indexes.
+    /// Provides access to the [get one document](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-one-document) and [get documents](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-documents) endpoints on authorized indexes.
     #[serde(rename = "documents.get")]
     DocumentsGet,
-    /// Provides access to the [delete one document](https://www.meilisearch.com/docs/reference/api/documents#delete-one-document), [delete all documents](https://www.meilisearch.com/docs/reference/api/documents#delete-all-documents), and [batch delete](https://www.meilisearch.com/docs/reference/api/documents#delete-documents-by-batch) endpoints on authorized indexes.
+    /// Provides access to the [delete one document](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-one-document), [delete all documents](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-all-documents), and [batch delete](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-documents-by-batch) endpoints on authorized indexes.
     #[serde(rename = "documents.delete")]
     DocumentsDelete,
-    /// Provides access to the [create index](https://www.meilisearch.com/docs/reference/api/indexes#create-an-index) endpoint.
+    /// Provides access to the [create index](https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#create-an-index) endpoint.
     #[serde(rename = "indexes.create")]
     IndexesCreate,
-    /// Provides access to the [get one index](https://www.meilisearch.com/docs/reference/api/indexes#get-one-index) and [list all indexes](https://www.meilisearch.com/docs/reference/api/indexes#list-all-indexes) endpoints. **Non-authorized `indexes` will be omitted from the response**.
+    /// Provides access to the [get one index](https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#get-one-index) and [list all indexes](https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#list-all-indexes) endpoints. **Non-authorized `indexes` will be omitted from the response**.
     #[serde(rename = "indexes.get")]
     IndexesGet,
-    /// Provides access to the [update index](https://www.meilisearch.com/docs/reference/api/indexes#update-an-index) endpoint.
+    /// Provides access to the [update index](https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#update-an-index) endpoint.
     #[serde(rename = "indexes.update")]
     IndexesUpdate,
-    /// Provides access to the [delete index](https://www.meilisearch.com/docs/reference/api/indexes#delete-an-index) endpoint.
+    /// Provides access to the [delete index](https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#delete-an-index) endpoint.
     #[serde(rename = "indexes.delete")]
     IndexesDelete,
-    /// Provides access to the [get one task](https://www.meilisearch.com/docs/reference/api/tasks#get-task) and [get all tasks](https://www.meilisearch.com/docs/reference/api/tasks#get-all-tasks) endpoints. **Tasks from non-authorized `indexes` will be omitted from the response**. Also provides access to the [get one task by index](https://www.meilisearch.com/docs/reference/api/tasks#get-task-by-index) and [get all tasks by index](https://www.meilisearch.com/docs/reference/api/tasks#get-all-tasks-by-index) endpoints on authorized indexes.
+    /// Provides access to the [get one task](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-task) and [get all tasks](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-all-tasks) endpoints. **Tasks from non-authorized `indexes` will be omitted from the response**. Also provides access to the [get one task by index](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-task-by-index) and [get all tasks by index](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-all-tasks-by-index) endpoints on authorized indexes.
     #[serde(rename = "tasks.get")]
     TasksGet,
-    /// Provides access to the [get settings](https://www.meilisearch.com/docs/reference/api/settings#get-settings) endpoint and equivalents for all subroutes on authorized indexes.
+    /// Provides access to the [get settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-settings) endpoint and equivalents for all subroutes on authorized indexes.
     #[serde(rename = "settings.get")]
     SettingsGet,
-    /// Provides access to the [update settings](https://www.meilisearch.com/docs/reference/api/settings#update-settings) and [reset settings](https://www.meilisearch.com/docs/reference/api/settings#reset-settings) endpoints and equivalents for all subroutes on authorized indexes.
+    /// Provides access to the [update settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-settings) and [reset settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-settings) endpoints and equivalents for all subroutes on authorized indexes.
     #[serde(rename = "settings.update")]
     SettingsUpdate,
-    /// Provides access to the [get stats of an index](https://www.meilisearch.com/docs/reference/api/stats#get-stats-of-an-index) endpoint and the [get stats of all indexes](https://www.meilisearch.com/docs/reference/api/stats#get-stats-of-all-indexes) endpoint. For the latter, **non-authorized `indexes` are omitted from the response**.
+    /// Provides access to the [get stats of an index](https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes#get-stats-of-an-index) endpoint and the [get stats of all indexes](https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes#get-stats-of-all-indexes) endpoint. For the latter, **non-authorized `indexes` are omitted from the response**.
     #[serde(rename = "stats.get")]
     StatsGet,
-    /// Provides access to the [create dump](https://www.meilisearch.com/docs/reference/api/dump#create-a-dump) endpoint. **Not restricted by `indexes`.**
+    /// Provides access to the [create dump](https://www.meilisearch.com/docs/reference/api/backups/create-dump#create-a-dump) endpoint. **Not restricted by `indexes`.**
     #[serde(rename = "dumps.create")]
     DumpsCreate,
-    /// Provides access to the [get dump status](https://www.meilisearch.com/docs/reference/api/dump#get-dump-status) endpoint. **Not restricted by `indexes`.**
+    /// Provides access to the [get dump status](https://www.meilisearch.com/docs/reference/api/backups/create-dump#get-dump-status) endpoint. **Not restricted by `indexes`.**
     #[serde(rename = "dumps.get")]
     DumpsGet,
-    /// Provides access to the [get Meilisearch version](https://www.meilisearch.com/docs/reference/api/version#get-version-of-meilisearch) endpoint.
+    /// Provides access to the [get Meilisearch version](https://www.meilisearch.com/docs/reference/api/version/get-version#get-version-of-meilisearch) endpoint.
     #[serde(rename = "version")]
     Version,
-    /// Provides access to the [get Key](https://www.meilisearch.com/docs/reference/api/keys#get-one-key) and [get Keys](https://www.meilisearch.com/docs/reference/api/keys#get-all-keys) endpoints.
+    /// Provides access to the [get Key](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-one-key) and [get Keys](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-all-keys) endpoints.
     #[serde(rename = "keys.get")]
     KeyGet,
-    /// Provides access to the [create key](https://www.meilisearch.com/docs/reference/api/keys#create-a-key) endpoint.
+    /// Provides access to the [create key](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#create-a-key) endpoint.
     #[serde(rename = "keys.create")]
     KeyCreate,
-    /// Provides access to the [update key](https://www.meilisearch.com/docs/reference/api/keys#update-a-key) endpoint.
+    /// Provides access to the [update key](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#update-a-key) endpoint.
     #[serde(rename = "keys.update")]
     KeyUpdate,
-    /// Provides access to the [delete key](https://www.meilisearch.com/docs/reference/api/keys#delete-a-key) endpoint.
+    /// Provides access to the [delete key](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#delete-a-key) endpoint.
     #[serde(rename = "keys.delete")]
     KeyDelete,
     /// Provides access to chat completions endpoints.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! }
 //! ```
 //!
-//! With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/reference/api/tasks#get-task).
+//! With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-task).
 //!
 //! ### Basic Search <!-- omit in TOC -->
 //!
@@ -156,7 +156,7 @@
 //!
 //! You only need to perform this operation once.
 //!
-//! Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [tasks](https://www.meilisearch.com/docs/reference/api/tasks#get-task).
+//! Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [tasks](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-task).
 //!
 //! Then, you can perform the search:
 //!

--- a/src/search.rs
+++ b/src/search.rs
@@ -202,7 +202,7 @@ type AttributeToCrop<'a> = (&'a str, Option<usize>);
 ///
 /// You can add search parameters using the builder syntax.
 ///
-/// See [this page](https://www.meilisearch.com/docs/reference/api/search#query-q) for the official list and description of all parameters.
+/// See [this page](https://www.meilisearch.com/docs/reference/api/search/search-with-post#query-q) for the official list and description of all parameters.
 ///
 /// # Examples
 ///
@@ -297,7 +297,7 @@ pub struct SearchQuery<'a, Http: HttpClient> {
     pub hits_per_page: Option<usize>,
     /// Filter applied to documents.
     ///
-    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting) to learn the syntax.
+    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results) to learn the syntax.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<Filter<'a>>,
     /// Facets for which to retrieve the matching count.
@@ -880,7 +880,7 @@ pub struct MergeFacets {
 }
 
 /// The `federation` field of the multi search API.
-/// See [the docs](https://www.meilisearch.com/docs/reference/api/multi_search#federation).
+/// See [the docs](https://www.meilisearch.com/docs/reference/api/multi-search/perform-a-multi-search#federation).
 #[derive(Debug, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct FederationOptions {
@@ -941,13 +941,13 @@ pub struct FederatedMultiSearchResponse<T> {
     /// Processing time of the query.
     pub processing_time_ms: usize,
 
-    /// [Data for facets present in the search results](https://www.meilisearch.com/docs/reference/api/multi_search#facetsbyindex)
+    /// [Data for facets present in the search results](https://www.meilisearch.com/docs/reference/api/multi-search/perform-a-multi-search#facetsbyindex)
     pub facets_by_index: Option<ComputedFacets>,
 
-    /// [Distribution of the given facets](https://www.meilisearch.com/docs/reference/api/multi_search#mergefacets)
+    /// [Distribution of the given facets](https://www.meilisearch.com/docs/reference/api/multi-search/perform-a-multi-search#mergefacets)
     pub facet_distribution: Option<HashMap<String, HashMap<String, usize>>>,
 
-    /// [The numeric `min` and `max` values per facet](https://www.meilisearch.com/docs/reference/api/multi_search#mergefacets)
+    /// [The numeric `min` and `max` values per facet](https://www.meilisearch.com/docs/reference/api/multi-search/perform-a-multi-search#mergefacets)
     pub facet_stats: Option<HashMap<String, FacetStats>>,
 
     /// Indicates which remote requests failed and why
@@ -978,7 +978,7 @@ pub struct FederationHitInfo {
 ///
 /// You can add search parameters using the builder syntax.
 ///
-/// See [this page](https://www.meilisearch.com/docs/reference/api/facet_search) for the official list and description of all parameters.
+/// See [this page](https://www.meilisearch.com/docs/reference/api/facet-search/search-in-facets) for the official list and description of all parameters.
 ///
 /// # Examples
 ///
@@ -1039,7 +1039,7 @@ pub struct FacetSearchQuery<'a, Http: HttpClient = DefaultHttpClient> {
     pub search_query: Option<&'a str>,
     /// Filter applied to documents.
     ///
-    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting) to learn the syntax.
+    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results) to learn the syntax.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<Filter<'a>>,
     /// Defines the strategy on how to handle search queries containing multiple words.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -255,10 +255,10 @@ pub struct Settings {
     /// List of words ignored by Meilisearch when present in search queries.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_words: Option<Vec<String>>,
-    /// List of [ranking rules](https://www.meilisearch.com/docs/learn/core_concepts/relevancy#order-of-the-rules) sorted by order of importance.
+    /// List of [ranking rules](https://www.meilisearch.com/docs/learn/relevancy/relevancy#order-of-the-rules) sorted by order of importance.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ranking_rules: Option<Vec<String>>,
-    /// Attributes to use for [filtering](https://www.meilisearch.com/docs/learn/advanced/filtering).
+    /// Attributes to use for [filtering](https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results).
     ///
     /// Supports both plain attribute names and settings objects.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -527,7 +527,7 @@ impl Settings {
         }
     }
 
-    /// Set the [embedders](https://www.meilisearch.com/docs/learn/vector_search) of the [Index].
+    /// Set the [embedders](https://www.meilisearch.com/docs/learn/ai_powered_search/getting_started_with_ai_search) of the [Index].
     #[must_use]
     pub fn with_embedders<S>(self, embedders: HashMap<S, Embedder>) -> Settings
     where
@@ -626,7 +626,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [synonyms](https://www.meilisearch.com/docs/reference/api/settings#get-synonyms) of the [Index].
+    /// Get [synonyms](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-synonyms) of the [Index].
     ///
     /// # Example
     ///
@@ -660,7 +660,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [pagination](https://www.meilisearch.com/docs/reference/api/settings#pagination) of the [Index].
+    /// Get [pagination](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#pagination) of the [Index].
     ///
     /// # Example
     ///
@@ -694,7 +694,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [stop-words](https://www.meilisearch.com/docs/reference/api/settings#stop-words) of the [Index].
+    /// Get [stop-words](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#stop-words) of the [Index].
     ///
     /// # Example
     ///
@@ -727,7 +727,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [ranking rules](https://www.meilisearch.com/docs/reference/api/settings#ranking-rules) of the [Index].
+    /// Get [ranking rules](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#ranking-rules) of the [Index].
     ///
     /// # Example
     ///
@@ -761,7 +761,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [filterable attributes](https://www.meilisearch.com/docs/reference/api/settings#filterable-attributes) of the [Index].
+    /// Get [filterable attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#filterable-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -815,7 +815,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [sortable attributes](https://www.meilisearch.com/docs/reference/api/settings#sortable-attributes) of the [Index].
+    /// Get [sortable attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#sortable-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -849,7 +849,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get the [distinct attribute](https://www.meilisearch.com/docs/reference/api/settings#distinct-attribute) of the [Index].
+    /// Get the [distinct attribute](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#distinct-attribute) of the [Index].
     ///
     /// # Example
     ///
@@ -883,7 +883,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [searchable attributes](https://www.meilisearch.com/docs/reference/api/settings#searchable-attributes) of the [Index].
+    /// Get [searchable attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#searchable-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -917,7 +917,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [displayed attributes](https://www.meilisearch.com/docs/reference/api/settings#displayed-attributes) of the [Index].
+    /// Get [displayed attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#displayed-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -951,7 +951,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [faceting](https://www.meilisearch.com/docs/reference/api/settings#faceting) settings of the [Index].
+    /// Get [faceting](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#faceting) settings of the [Index].
     ///
     /// # Example
     ///
@@ -985,7 +985,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [dictionary](https://www.meilisearch.com/docs/reference/api/settings#dictionary) of the [Index].
+    /// Get [dictionary](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#dictionary) of the [Index].
     ///
     /// # Example
     ///
@@ -1018,7 +1018,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [proximity_precision](https://www.meilisearch.com/docs/reference/api/settings#proximity-precision) of the [Index].
+    /// Get [proximity_precision](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#proximity-precision) of the [Index].
     ///
     /// # Example
     ///
@@ -1051,7 +1051,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [facet-search settings](https://www.meilisearch.com/docs/reference/api/settings#facet-search) of the [Index].
+    /// Get [facet-search settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#facet-search) of the [Index].
     ///
     /// # Example
     ///
@@ -1084,7 +1084,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [prefix-search settings](https://www.meilisearch.com/docs/reference/api/settings#prefix-search) of the [Index].
+    /// Get [prefix-search settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#prefix-search) of the [Index].
     ///
     /// # Example
     ///
@@ -1117,7 +1117,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [typo tolerance](https://www.meilisearch.com/docs/reference/api/settings#typo-tolerance) of the [Index].
+    /// Get [typo tolerance](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#typo-tolerance) of the [Index].
     ///
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
@@ -1148,7 +1148,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [embedders](https://www.meilisearch.com/docs/learn/vector_search) of the [Index].
+    /// Get [embedders](https://www.meilisearch.com/docs/learn/ai_powered_search/getting_started_with_ai_search) of the [Index].
     ///
     /// ```
     /// # use std::collections::HashMap;
@@ -1191,7 +1191,7 @@ impl<Http: HttpClient> Index<Http> {
             .map(|r| r.unwrap_or_default())
     }
 
-    /// Set [embedders](https://www.meilisearch.com/docs/learn/vector_search) of the [Index].
+    /// Set [embedders](https://www.meilisearch.com/docs/learn/ai_powered_search/getting_started_with_ai_search) of the [Index].
     ///
     /// ```
     /// # use std::collections::HashMap;
@@ -1239,7 +1239,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [search cutoff](https://www.meilisearch.com/docs/reference/api/settings#search-cutoff) settings of the [Index].
+    /// Get [search cutoff](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#search-cutoff) settings of the [Index].
     ///
     /// # Example
     ///
@@ -1272,7 +1272,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [separator token](https://www.meilisearch.com/docs/reference/api/settings#separator-tokens) of the [Index].
+    /// Get [separator token](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#separator-tokens) of the [Index].
     ///
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
@@ -1303,7 +1303,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [non separator token](https://www.meilisearch.com/docs/reference/api/settings#non-separator-tokens) of the [Index].
+    /// Get [non separator token](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#non-separator-tokens) of the [Index].
     ///
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*};
@@ -1334,7 +1334,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Get [localized attributes](https://www.meilisearch.com/docs/reference/api/settings#localized-attributes-object) settings of the [Index].
+    /// Get [localized attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#localized-attributes-object) settings of the [Index].
     ///
     /// ```
     /// # use meilisearch_sdk::{client::*, indexes::*, settings::LocalizedAttributes};
@@ -1408,7 +1408,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [synonyms](https://www.meilisearch.com/docs/reference/api/settings#synonyms) of the [Index].
+    /// Update [synonyms](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#synonyms) of the [Index].
     ///
     /// # Example
     ///
@@ -1452,7 +1452,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [pagination](https://www.meilisearch.com/docs/reference/api/settings#pagination) of the [Index].
+    /// Update [pagination](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#pagination) of the [Index].
     ///
     /// # Example
     ///
@@ -1489,7 +1489,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [stop-words](https://www.meilisearch.com/docs/reference/api/settings#stop-words) of the [Index].
+    /// Update [stop-words](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#stop-words) of the [Index].
     ///
     /// # Example
     ///
@@ -1532,7 +1532,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [ranking rules](https://www.meilisearch.com/docs/reference/api/settings#ranking-rules) of the [Index].
+    /// Update [ranking rules](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#ranking-rules) of the [Index].
     ///
     /// # Example
     ///
@@ -1584,7 +1584,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [filterable attributes](https://www.meilisearch.com/docs/reference/api/settings#filterable-attributes) of the [Index].
+    /// Update [filterable attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#filterable-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -1649,7 +1649,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [sortable attributes](https://www.meilisearch.com/docs/reference/api/settings#sortable-attributes) of the [Index].
+    /// Update [sortable attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#sortable-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -1692,7 +1692,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update the [distinct attribute](https://www.meilisearch.com/docs/reference/api/settings#distinct-attribute) of the [Index].
+    /// Update the [distinct attribute](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#distinct-attribute) of the [Index].
     ///
     /// # Example
     ///
@@ -1731,7 +1731,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [searchable attributes](https://www.meilisearch.com/docs/reference/api/settings#searchable-attributes) of the [Index].
+    /// Update [searchable attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#searchable-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -1773,7 +1773,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [displayed attributes](https://www.meilisearch.com/docs/reference/api/settings#displayed-attributes) of the [Index].
+    /// Update [displayed attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#displayed-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -1815,7 +1815,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [faceting](https://www.meilisearch.com/docs/reference/api/settings#faceting) settings of the [Index].
+    /// Update [faceting](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#faceting) settings of the [Index].
     ///
     /// # Example
     ///
@@ -1856,7 +1856,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [dictionary](https://www.meilisearch.com/docs/reference/api/settings#dictionary) of the [Index].
+    /// Update [dictionary](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#dictionary) of the [Index].
     ///
     /// # Example
     ///
@@ -1898,7 +1898,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [typo tolerance](https://www.meilisearch.com/docs/reference/api/settings#typo-tolerance) settings of the [Index].
+    /// Update [typo tolerance](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#typo-tolerance) settings of the [Index].
     ///
     /// # Example
     ///
@@ -1945,7 +1945,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [separator tokens](https://www.meilisearch.com/docs/reference/api/settings#separator-tokens) settings of the [Index].
+    /// Update [separator tokens](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#separator-tokens) settings of the [Index].
     ///
     /// # Example
     ///
@@ -1986,7 +1986,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [non separator tokens](https://www.meilisearch.com/docs/reference/api/settings#non-separator-tokens) settings of the [Index].
+    /// Update [non separator tokens](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#non-separator-tokens) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2027,7 +2027,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [proximity-precision](https://www.meilisearch.com/docs/reference/api/settings#proximity-precision) settings of the [Index].
+    /// Update [proximity-precision](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#proximity-precision) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2066,7 +2066,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [facet-search settings](https://www.meilisearch.com/docs/reference/api/settings#facet-search) settings of the [Index].
+    /// Update [facet-search settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#facet-search) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2102,7 +2102,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// update [prefix-search settings](https://www.meilisearch.com/docs/reference/api/settings#prefix-search) settings of the [Index].
+    /// update [prefix-search settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#prefix-search) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2141,7 +2141,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [search cutoff](https://www.meilisearch.com/docs/reference/api/settings#search-cutoff) settings of the [Index].
+    /// Update [search cutoff](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#search-cutoff) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2177,7 +2177,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Update [localized attributes](https://www.meilisearch.com/docs/reference/api/settings#localized-attributes-object) settings of the [Index].
+    /// Update [localized attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#localized-attributes-object) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2223,7 +2223,7 @@ impl<Http: HttpClient> Index<Http> {
 
     /// Reset [Settings] of the [Index].
     ///
-    /// All settings will be reset to their [default value](https://www.meilisearch.com/docs/reference/api/settings#reset-settings).
+    /// All settings will be reset to their [default value](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-settings).
     ///
     /// # Example
     ///
@@ -2253,7 +2253,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [synonyms](https://www.meilisearch.com/docs/reference/api/settings#synonyms) of the [Index].
+    /// Reset [synonyms](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#synonyms) of the [Index].
     ///
     /// # Example
     ///
@@ -2286,7 +2286,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [pagination](https://www.meilisearch.com/docs/learn/configuration/settings#pagination) of the [Index].
+    /// Reset [pagination](https://www.meilisearch.com/docs/learn/configuration/configuring_index_settings#pagination) of the [Index].
     ///
     /// # Example
     ///
@@ -2318,7 +2318,7 @@ impl<Http: HttpClient> Index<Http> {
             )
             .await
     }
-    /// Reset [stop-words](https://www.meilisearch.com/docs/reference/api/settings#stop-words) of the [Index].
+    /// Reset [stop-words](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#stop-words) of the [Index].
     ///
     /// # Example
     ///
@@ -2351,7 +2351,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [ranking rules](https://www.meilisearch.com/docs/learn/core_concepts/relevancy#ranking-rules) of the [Index] to default value.
+    /// Reset [ranking rules](https://www.meilisearch.com/docs/learn/relevancy/relevancy#ranking-rules) of the [Index] to default value.
     ///
     /// **Default value: `["words", "typo", "proximity", "attribute", "sort", "exactness"]`.**
     ///
@@ -2386,7 +2386,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [filterable attributes](https://www.meilisearch.com/docs/reference/api/settings#filterable-attributes) of the [Index].
+    /// Reset [filterable attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#filterable-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -2419,7 +2419,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [sortable attributes](https://www.meilisearch.com/docs/reference/api/settings#sortable-attributes) of the [Index].
+    /// Reset [sortable attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#sortable-attributes) of the [Index].
     ///
     /// # Example
     ///
@@ -2452,7 +2452,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset the [distinct attribute](https://www.meilisearch.com/docs/reference/api/settings#distinct-attribute) of the [Index].
+    /// Reset the [distinct attribute](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#distinct-attribute) of the [Index].
     ///
     /// # Example
     ///
@@ -2485,7 +2485,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [searchable attributes](https://www.meilisearch.com/docs/reference/api/settings#searchable-attributes) of
+    /// Reset [searchable attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#searchable-attributes) of
     /// the [Index] (enable all attributes).
     ///
     /// # Example
@@ -2519,7 +2519,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [displayed attributes](https://www.meilisearch.com/docs/reference/api/settings#displayed-attributes) of the [Index] (enable all attributes).
+    /// Reset [displayed attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#displayed-attributes) of the [Index] (enable all attributes).
     ///
     /// # Example
     ///
@@ -2552,7 +2552,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [faceting](https://www.meilisearch.com/docs/reference/api/settings#faceting) settings of the [Index].
+    /// Reset [faceting](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#faceting) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2585,7 +2585,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [dictionary](https://www.meilisearch.com/docs/reference/api/settings#dictionary) of the [Index].
+    /// Reset [dictionary](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#dictionary) of the [Index].
     ///
     /// # Example
     ///
@@ -2618,7 +2618,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [typo tolerance](https://www.meilisearch.com/docs/reference/api/settings#typo-tolerance) settings of the [Index].
+    /// Reset [typo tolerance](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#typo-tolerance) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2651,7 +2651,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [proximity precision](https://www.meilisearch.com/docs/reference/api/settings#proximity-precision) settings of the [Index].
+    /// Reset [proximity precision](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#proximity-precision) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2684,7 +2684,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [embedders](https://www.meilisearch.com/docs/learn/vector_search) of the [Index].
+    /// Reset [embedders](https://www.meilisearch.com/docs/learn/ai_powered_search/getting_started_with_ai_search) of the [Index].
     ///
     /// # Example
     ///
@@ -2717,7 +2717,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [facet-search settings](https://www.meilisearch.com/docs/reference/api/settings#facet-search) settings of the [Index].
+    /// Reset [facet-search settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#facet-search) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2750,7 +2750,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [prefix-search settings](https://www.meilisearch.com/docs/reference/api/settings#prefix-search) settings of the [Index].
+    /// Reset [prefix-search settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#prefix-search) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2783,7 +2783,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [search cutoff](https://www.meilisearch.com/docs/reference/api/settings#search-cutoff) settings of the [Index].
+    /// Reset [search cutoff](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#search-cutoff) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2816,7 +2816,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [search cutoff](https://www.meilisearch.com/docs/reference/api/settings#search-cutoff) settings of the [Index].
+    /// Reset [search cutoff](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#search-cutoff) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2849,7 +2849,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [non separator tokens](https://www.meilisearch.com/docs/reference/api/settings#non-separator-tokens) settings of the [Index].
+    /// Reset [non separator tokens](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#non-separator-tokens) settings of the [Index].
     ///
     /// # Example
     ///
@@ -2882,7 +2882,7 @@ impl<Http: HttpClient> Index<Http> {
             .await
     }
 
-    /// Reset [localized attributes](https://www.meilisearch.com/docs/reference/api/settings#localized-attributes-object) settings of the [Index].
+    /// Reset [localized attributes](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#localized-attributes-object) settings of the [Index].
     ///
     /// # Example
     ///

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -41,7 +41,7 @@ pub struct SimilarResults<T> {
 ///
 /// You can add similar parameters using the builder syntax.
 ///
-/// See [this page](https://www.meilisearch.com/docs/reference/api/similar#get-similar-documents-with-post) for the official list and description of all parameters.
+/// See [this page](https://www.meilisearch.com/docs/reference/api/similar-documents/get-similar-documents-with-post#get-similar-documents-with-post) for the official list and description of all parameters.
 ///
 /// # Examples
 ///
@@ -92,7 +92,7 @@ pub struct SimilarQuery<'a, Http: HttpClient> {
 
     /// Filter queries by an attribute’s value
     ///
-    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting) to learn the syntax.
+    /// Read the [dedicated guide](https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results) to learn the syntax.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<Filter<'a>>,
 


### PR DESCRIPTION
## Summary
- Updated `meilisearch.com/docs` links to match the current sitemap URLs
- Old paths were either redirecting (308) or returning 404s

## Test plan
- [ ] Verify all updated links resolve correctly (no 404s or extra redirects)
- [ ] No code logic changed — only documentation URLs