### PR TITLE
Add get_task_documents method (Meilisearch v1.13)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -233,6 +233,11 @@ get_task_1: |-
     .get_task(1)
     .await
     .unwrap();
+get_task_documents_1: |-
+  let documents = client
+    .get_task_documents(1)
+    .await
+    .unwrap();
 async_guide_multiple_filters_1: |-
   let mut query = TasksQuery::new(&client);
   let tasks = query

--- a/src/client.rs
+++ b/src/client.rs
@@ -977,6 +977,23 @@ impl<Http: HttpClient> Client<Http> {
             .await
     }
 
+    /// Get the documents associated with a task.
+    ///
+    /// This corresponds to the `GET /tasks/{task_id}/documents` endpoint
+    /// introduced in Meilisearch v1.13.
+    pub async fn get_task_documents(
+        &self,
+        task_id: impl AsRef<u32>,
+    ) -> Result<serde_json::Value, Error> {
+        self.http_client
+            .request::<(), (), serde_json::Value>(
+                &format!("{}/tasks/{}/documents", self.host, task_id.as_ref()),
+                Method::Get { query: () },
+                200,
+            )
+            .await
+    }
+
     /// Get all tasks with query parameters from the server.
     ///
     /// # Example


### PR DESCRIPTION
## Summary

Adds `get_task_documents` to retrieve documents associated with a task, corresponding to `GET /tasks/{task_id}/documents` introduced in Meilisearch 1.13.

## Changes

- `src/client.rs`: Added `get_task_documents(task_id)` async method returning `serde_json::Value`
- `.code-samples.meilisearch.yaml`: Added `get_task_documents_1` code sample

## Testing

Follows the same `http_client.request` pattern as `get_task`. Returns `serde_json::Value` for flexibility with varied document structures.

Closes #776

This contribution was developed with AI assistance (Claude Code).