### PR TITLE
Add distinct field to FederationOptions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -903,6 +903,10 @@ pub struct FederationOptions {
     /// Request performance details in the response.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_performance_details: Option<bool>,
+
+    /// Attribute whose values must be unique among returned documents
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distinct: Option<String>,
 }
 
 impl<'a, Http: HttpClient> FederatedMultiSearchQuery<'a, '_, Http> {


### PR DESCRIPTION
## Summary

Adds the `distinct` field to `FederationOptions`, enabling deduplication by attribute in federated multi-index search (available since Meilisearch v1.12).

Closes #777

## Changes

- Added `distinct: Option<String>` field to `FederationOptions` with `skip_serializing_if`

## Usage

```rust
let response = multi_query
    .with_federation(FederationOptions {
        distinct: Some("title".to_string()),
        ..Default::default()
    })
    .execute::<Movie>()
    .await?;
```