### PR TITLE
Add support for  `distinct` in multi search federation

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -903,6 +903,10 @@ pub struct FederationOptions {
     /// Request performance details in the response.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_performance_details: Option<bool>,
+
+    /// global distinct computation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distinct: Option<String>,
 }
 
 impl<'a, Http: HttpClient> FederatedMultiSearchQuery<'a, '_, Http> {
@@ -2394,6 +2398,29 @@ pub(crate) mod tests {
             .await?;
 
         assert!(response.performance_details.is_some());
+
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_federated_multi_search_with_distinct(
+        client: Client,
+        index: Index,
+    ) -> Result<(), Error> {
+        setup_test_index(&client, &index).await?;
+        let search_query = SearchQuery::new(&index).build();
+
+        let mut multi_search = client.multi_search();
+        multi_search.with_search_query(search_query);
+
+        let federated_multi_search = multi_search.with_federation(FederationOptions {
+            distinct: Some("kind".to_string()),
+            ..Default::default()
+        });
+
+        let response = federated_multi_search.execute::<Document>().await.unwrap();
+
+        assert_eq!(response.hits.len(), 2);
 
         Ok(())
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #777 

## What does this PR do?
- Added `distinct` as a federation parameter

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.

AI was not used
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Federated multi-search operations now support distinct parameters, enabling advanced deduplication and result filtering across multiple indexes. Users can specify distinct field values to optimize and control their result sets.

* **Tests**
  * Added integration test for federated multi-search with distinct parameter support, validating correct behavior and result aggregation across multiple indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->