### PR TITLE
Update reqwest from v0.12.22 to v0.13.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ either = { version = "1.15.0", features = ["serde"] }
 thiserror = "2.0.12"
 meilisearch-index-setting-macro = { path = "meilisearch-index-setting-macro", version = "0.33.0" }
 pin-project-lite = { version = "0.2.16", optional = true }
-reqwest = { version = "0.12.22", optional = true, default-features = false, features = ["http2", "stream"] }
+reqwest = { version = "0.13.3", optional = true, default-features = false, features = ["http2", "stream"] }
 bytes = { version = "1.10.1", optional = true }
 uuid = { version = "1.17.0", features = ["v4", "serde"] }
 futures-core = "0.3.31"
@@ -44,7 +44,7 @@ wasm-bindgen-futures = "0.4"
 [features]
 default = ["reqwest", "tls", "jwt_aws_lc_rs"]
 reqwest = ["dep:reqwest", "dep:tokio", "pin-project-lite", "bytes"]
-tls = ["reqwest/rustls-tls"]
+tls = ["reqwest/rustls"]
 futures-unsend = []
 jwt_aws_lc_rs = ["jsonwebtoken/aws_lc_rs"]
 jwt_rust_crypto = ["jsonwebtoken/rust_crypto"]


### PR DESCRIPTION
# Pull Request

## Related issue

- Supersedes: https://github.com/meilisearch/meilisearch-rust/pull/749

## What does this PR do?

Update reqwest dependency from v0.12.22 to v0.13.3
Dependabot doesn't know the feature was renamed from `rustls-tls` to `rustls`.

AI Disclosure: I used Claude Code with Opus 4.7 to figure out how to get tests to run locally

## PR checklist

Please check if your PR fulfills the following requirements:
- [X] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP client dependency to v0.13.3
  * Updated TLS encryption feature configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meilisearch/meilisearch-rust/pull/788)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->