### PR TITLE
feat(stats): add StatsQuery for Meilisearch v1.44 showInternalDatabaseSizes and sizeFormat

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -635,14 +635,18 @@ reset_dictionary_1: |-
     .await
     .unwrap();
 get_index_stats_1: |-
+  let mut query = StatsQuery::new();
+  query.with_internal_database_sizes(true).with_size_format(SizeFormat::Human);
   let stats: IndexStats = client
     .index("movies")
-    .get_stats()
+    .get_stats_with(&query)
     .await
     .unwrap();
 get_indexes_stats_1: |-
+  let mut query = StatsQuery::new();
+  query.with_internal_database_sizes(true).with_size_format(SizeFormat::Human);
   let stats: ClientStats = client
-    .get_stats()
+    .get_stats_with(&query)
     .await
     .unwrap();
 get_health_1: |-

--- a/src/client.rs
+++ b/src/client.rs
@@ -577,10 +577,31 @@ impl<Http: HttpClient> Client<Http> {
     /// # });
     /// ```
     pub async fn get_stats(&self) -> Result<ClientStats, Error> {
+        self.get_stats_with(&StatsQuery::new()).await
+    }
+
+    /// Get the stats of all the database, with optional query parameters.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*};
+    /// #
+    /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
+    /// let mut query = StatsQuery::new();
+    /// query.with_internal_database_sizes(true).with_size_format(SizeFormat::Human);
+    /// let stats = client.get_stats_with(&query).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn get_stats_with(&self, query: &StatsQuery) -> Result<ClientStats, Error> {
         self.http_client
-            .request::<(), (), ClientStats>(
+            .request::<&StatsQuery, (), ClientStats>(
                 &format!("{}/stats", self.host),
-                Method::Get { query: () },
+                Method::Get { query },
                 200,
             )
             .await
@@ -1452,11 +1473,15 @@ impl<Http: HttpClient> Client<Http> {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientStats {
-    /// Storage space claimed by Meilisearch and LMDB in bytes
-    pub database_size: usize,
+    /// Storage space claimed by Meilisearch and LMDB.
+    ///
+    /// When `sizeFormat` is `human`, this is a human-readable string instead of a byte count.
+    pub database_size: serde_json::Value,
 
-    /// Storage space used by the database in bytes, excluding unused space claimed by LMDB
-    pub used_database_size: usize,
+    /// Storage space used by the database, excluding unused space claimed by LMDB.
+    ///
+    /// When `sizeFormat` is `human`, this is a human-readable string instead of a byte count.
+    pub used_database_size: serde_json::Value,
 
     /// When the last update was made to the database in the `RFC 3339` format
     #[serde(with = "time::serde::rfc3339::option")]

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1509,11 +1509,34 @@ impl<Http: HttpClient> Index<Http> {
     /// # });
     /// ```
     pub async fn get_stats(&self) -> Result<IndexStats, Error> {
+        self.get_stats_with(&StatsQuery::new()).await
+    }
+
+    /// Get stats of an index, with optional query parameters.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, indexes::*};
+    /// #
+    /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// #
+    /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
+    /// # let index = client.create_index("get_stats_with", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
+    /// let mut query = StatsQuery::new();
+    /// query.with_internal_database_sizes(true);
+    /// let stats = index.get_stats_with(&query).await.unwrap();
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn get_stats_with(&self, query: &StatsQuery) -> Result<IndexStats, Error> {
         self.client
             .http_client
-            .request::<(), (), IndexStats>(
+            .request::<&StatsQuery, (), IndexStats>(
                 &format!("{}/indexes/{}/stats", self.client.host, self.uid),
-                Method::Get { query: () },
+                Method::Get { query },
                 200,
             )
             .await
@@ -1957,6 +1980,58 @@ impl<'a, Http: HttpClient> AsRef<IndexUpdater<'a, Http>> for IndexUpdater<'a, Ht
     }
 }
 
+/// Size format for stats responses.
+///
+/// Controls whether size fields are returned as raw byte counts or
+/// human-readable strings (e.g. `"2.3 MiB"`).
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum SizeFormat {
+    /// Return sizes as raw byte counts (default).
+    #[default]
+    Raw,
+    /// Return sizes as human-readable strings with appropriate units.
+    Human,
+}
+
+/// Query parameters for the stats endpoints.
+///
+/// Used with [`Index::get_stats_with`] and [`Client::get_stats_with`].
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct StatsQuery {
+    /// When `true`, index stat objects include an `internal_database_sizes` map.
+    ///
+    /// **Note:** The keys in `internal_database_sizes` are subject to change.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_internal_database_sizes: Option<bool>,
+
+    /// Controls the format of size fields in the response.
+    ///
+    /// Defaults to [`SizeFormat::Raw`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_format: Option<SizeFormat>,
+}
+
+impl StatsQuery {
+    /// Create a new [`StatsQuery`].
+    pub fn new() -> StatsQuery {
+        StatsQuery::default()
+    }
+
+    /// Request internal database sizes in the response.
+    pub fn with_internal_database_sizes(&mut self, show: bool) -> &mut StatsQuery {
+        self.show_internal_database_sizes = Some(show);
+        self
+    }
+
+    /// Set the size format for the response.
+    pub fn with_size_format(&mut self, format: SizeFormat) -> &mut StatsQuery {
+        self.size_format = Some(format);
+        self
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexStats {
@@ -1969,17 +2044,28 @@ pub struct IndexStats {
     /// Total number of embeddings in an index
     pub number_of_embeddings: usize,
 
-    /// Storage space claimed by all documents in the index in bytes
-    pub raw_document_db_size: usize,
+    /// Storage space claimed by all documents in the index in bytes.
+    ///
+    /// When `sizeFormat` is `human`, this is a human-readable string instead of a byte count.
+    pub raw_document_db_size: serde_json::Value,
 
-    /// Total size of the documents stored in an index divided by the number of documents in that same index
-    pub avg_document_size: usize,
+    /// Total size of the documents stored in an index divided by the number of documents in that same index.
+    ///
+    /// When `sizeFormat` is `human`, this is a human-readable string instead of a byte count.
+    pub avg_document_size: serde_json::Value,
 
     /// If `true`, the index is still processing documents and attempts to search will yield impredictable results
     pub is_indexing: bool,
 
     /// Shows every field in the index along with the total number of documents containing that field in said index
     pub field_distribution: HashMap<String, usize>,
+
+    /// Internal database sizes for the index.
+    ///
+    /// Present only when `show_internal_database_sizes` is `true`.
+    /// Keys are subject to change.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub internal_database_sizes: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// An [`IndexesQuery`] containing filter and pagination parameters when searching for [Indexes](Index).


### PR DESCRIPTION
Closes #789.

Adds support for the two new query parameters introduced in [Meilisearch v1.44.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.44.0) for the stats endpoints.

## Changes

**`src/indexes.rs`**
- New `SizeFormat` enum (`Raw` / `Human`)
- New `StatsQuery` struct with builder methods `with_internal_database_sizes` and `with_size_format`
- `IndexStats.raw_document_db_size` and `avg_document_size` widened to `serde_json::Value` to accommodate human-readable strings
- New `internal_database_sizes: Option<HashMap<String, serde_json::Value>>` field (present only when requested; keys subject to change per spec)
- `Index::get_stats` now delegates to a new `Index::get_stats_with(&StatsQuery)`

**`src/client.rs`**
- `ClientStats.database_size` and `used_database_size` widened to `serde_json::Value`
- `Client::get_stats` now delegates to a new `Client::get_stats_with(&StatsQuery)`

**`.code-samples.meilisearch.yaml`** — updated `get_index_stats_1` and `get_indexes_stats_1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds support for two new query parameters introduced in Meilisearch v1.44.0 for the stats endpoints: `showInternalDatabaseSizes` and `sizeFormat`. It introduces a new `StatsQuery` builder for configuring these parameters and updates the stats API to support human-readable size formats.

## Key Changes

### New Public API Additions
- **`SizeFormat` enum** in `src/indexes.rs`: Defines size format options (`Raw` for bytes, `Human` for human-readable strings)
- **`StatsQuery` struct** in `src/indexes.rs`: Builder for constructing stats queries with methods:
  - `with_internal_database_sizes(bool)`: Include internal database sizes mapping
  - `with_size_format(SizeFormat)`: Set the size format for responses
- **`Index::get_stats_with(&StatsQuery)`** in `src/indexes.rs`: New method to retrieve stats with query parameters
- **`Client::get_stats_with(&StatsQuery)`** in `src/client.rs`: New method to retrieve global stats with query parameters

### Type Changes
- `IndexStats.raw_document_db_size`: Changed from `usize` to `serde_json::Value` (supports both numeric bytes and human-readable strings)
- `IndexStats.avg_document_size`: Changed from `usize` to `serde_json::Value`
- `ClientStats.database_size`: Changed from `usize` to `serde_json::Value`
- `ClientStats.used_database_size`: Changed from `usize` to `serde_json::Value`

### New Fields
- `IndexStats.internal_database_sizes`: New optional field of type `Option<HashMap<String, serde_json::Value>>` - included in responses only when explicitly requested via `StatsQuery`, allowing flexible mapping of internal database names to their sizes

### Backward Compatibility
- Existing `Index::get_stats()` and `Client::get_stats()` methods now delegate to their `*_with()` variants, calling them with a default `StatsQuery::new()`
- Method behavior preserved - existing code continues to work without modification

### Documentation Updates
- `.code-samples.meilisearch.yaml`: Updated `get_index_stats_1` and `get_indexes_stats_1` examples to demonstrate the new `StatsQuery` API with internal database sizes and human-readable formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->