### PR TITLE
fix(docs): replace futures::executor::block_on with tokio runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Using this crate is possible without [serde](https://crates.io/crates/serde), bu
 ```rust
 use meilisearch_sdk::client::*;
 use serde::{Serialize, Deserialize};
-use futures::executor::block_on;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Movie {

--- a/examples/cli-app/Cargo.toml
+++ b/examples/cli-app/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 meilisearch-sdk = {path="../.."}
-futures = "0.3"
+tokio = { version = "1", features = ["full"] }
 serde = { version="1.0",   features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.4.0"

--- a/examples/cli-app/src/main.rs
+++ b/examples/cli-app/src/main.rs
@@ -1,4 +1,3 @@
-use futures::executor::block_on;
 use lazy_static::lazy_static;
 use meilisearch_sdk::client::Client;
 use meilisearch_sdk::settings::Settings;
@@ -11,31 +10,30 @@ lazy_static! {
     static ref CLIENT: Client = Client::new("http://localhost:7700", Some("masterKey")).unwrap();
 }
 
-fn main() {
-    block_on(async move {
-        // build the index
-        build_index().await;
+#[tokio::main]
+async fn main() {
+    // build the index
+    build_index().await;
 
-        // enter in search queries or quit
-        loop {
-            println!("Enter a search query or type \"q\" or \"quit\" to quit:");
-            let mut input_string = String::new();
-            stdin()
-                .read_line(&mut input_string)
-                .expect("Failed to read line");
-            match input_string.trim() {
-                "quit" | "q" | "" => {
-                    println!("exiting...");
-                    break;
-                }
-                _ => {
-                    search(input_string.trim()).await;
-                }
+    // enter in search queries or quit
+    loop {
+        println!("Enter a search query or type \"q\" or \"quit\" to quit:");
+        let mut input_string = String::new();
+        stdin()
+            .read_line(&mut input_string)
+            .expect("Failed to read line");
+        match input_string.trim() {
+            "quit" | "q" | "" => {
+                println!("exiting...");
+                break;
+            }
+            _ => {
+                search(input_string.trim()).await;
             }
         }
-        // get rid of the index at the end, doing this only so users don't have the index without knowing
-        let _ = CLIENT.delete_index("clothes").await.unwrap();
-    })
+    }
+    // get rid of the index at the end, doing this only so users don't have the index without knowing
+    let _ = CLIENT.delete_index("clothes").await.unwrap();
 }
 
 async fn search(query: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //! ```
 //! use meilisearch_sdk::client::*;
 //! use serde::{Serialize, Deserialize};
-//! use futures::executor::block_on;
 //!
 //! #[derive(Serialize, Deserialize, Debug)]
 //! struct Movie {


### PR DESCRIPTION
## Related issue
Fixes #770

## What does this PR do?
- Removes unused `futures::executor::block_on` import from `README.md` and `src/lib.rs` 
  that was left over but never used (the examples already use `#[tokio::main]`)
- Fixes `examples/cli-app/src/main.rs` to use `#[tokio::main]` instead of 
  `futures::executor::block_on`, which panicked at runtime due to missing Tokio reactor
- Replaces `futures = "0.3"` with `tokio = { version = "1", features = ["full"] }` 
  in `examples/cli-app/Cargo.toml`

## PR checklist
- [x] Did you use any AI tool while implementing this PR? Yes — used Claude to help 
      identify the affected files and understand the root cause (missing Tokio reactor 
      when using futures::executor::block_on with async libraries that depend on Tokio internals)
- [x] Does this PR fix an existing issue? Yes, fixes #770
- [x] Have you read the contributing guidelines? Yes
- [x] Have you made sure that the title is accurate and descriptive of the changes? Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes documentation and example code that used `futures::executor::block_on`, which caused runtime panics due to the absence of a Tokio reactor.

## Changes

**README.md**
- Removed unused `futures::executor::block_on` import from the "Add Documents" code example

**examples/cli-app/Cargo.toml**
- Added `tokio = { version = "1", features = ["full"] }` dependency
- Removed `futures = "0.3"` dependency

**examples/cli-app/src/main.rs**
- Converted the CLI example from a synchronous `main` function using `futures::executor::block_on` to an async entry point with `#[tokio::main]`
- Moved the search-query loop and index cleanup operations into the async `main` function
- Removed the explicit `block_on(async move { ... })` wrapper and its related import

**src/lib.rs**
- Removed the `futures::executor::block_on` import from the crate-level "Getting started" doctest

## Context

This PR addresses issue `#770`, which reported that the Rust "Getting started with self-hosted Meilisearch" tutorial failed at runtime because `futures::executor::block_on` does not provide a full Tokio reactor, which is required by the meilisearch-sdk and its dependencies. Using `#[tokio::main]` instead provides the necessary async runtime context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->