### PR TITLE
add support for experimental search personalization

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -377,7 +377,7 @@ mod test {
         );
 
         let error = Error::Uuid(Uuid::parse_str("67e55044").unwrap_err());
-        assert_eq!(error.to_string(), "The uid of the token has bit an uuid4 format: invalid length: expected length 32 for simple format, found 8");
+        assert_eq!(error.to_string(), "The uid of the token has bit an uuid4 format: invalid length: found 8");
 
         let data = r#"
         {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -377,7 +377,10 @@ mod test {
         );
 
         let error = Error::Uuid(Uuid::parse_str("67e55044").unwrap_err());
-        assert_eq!(error.to_string(), "The uid of the token has bit an uuid4 format: invalid length: found 8");
+        assert_eq!(
+            error.to_string(),
+            "The uid of the token has bit an uuid4 format: invalid length: found 8"
+        );
 
         let data = r#"
         {

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1002,13 +1002,12 @@ impl<Http: HttpClient> Index<Http> {
     /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
     /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
     /// let movie_index = client.index("add_or_replace_unchecked_payload");
-    ///
     /// let task = movie_index.add_or_update_unchecked_payload(
-    ///     r#"{ "id": 1, "body": "doggo" }
-    ///     { "id": 2, "body": "catto" }"#.as_bytes(),
-    ///     "application/x-ndjson",
-    ///     Some("id"),
-    /// ).await.unwrap();
+    ///        "{ \"id\": 1, \"body\": \"doggo\" }\n{ \"id\": 2, \"body\": \"catto\" }".as_bytes(),
+    ///        "application/x-ndjson",
+    ///        Some("id"),
+    ///    ).await.unwrap();
+    /// 
     /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed
     /// client.wait_for_task(task, None, None).await.unwrap();
     ///

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -1007,7 +1007,7 @@ impl<Http: HttpClient> Index<Http> {
     ///        "application/x-ndjson",
     ///        Some("id"),
     ///    ).await.unwrap();
-    /// 
+    ///
     /// // Meilisearch may take some time to execute the request so we are going to wait till it's completed
     /// client.wait_for_task(task, None, None).await.unwrap();
     ///

--- a/src/search.rs
+++ b/src/search.rs
@@ -433,7 +433,12 @@ pub struct SearchQuery<'a, Http: HttpClient> {
     /// **Default: `false`**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_performance_details: Option<bool>,
+
+    // Defines search personalization for the user profile context 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personalize: Option<Personalize<'a>>,
 }
+
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -445,6 +450,14 @@ pub struct QueryFederationOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote: Option<String>,
 }
+
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Personalize<'a> {
+    pub user_context: &'a str
+}
+
 
 #[allow(missing_docs)]
 impl<'a, Http: HttpClient> SearchQuery<'a, Http> {
@@ -483,6 +496,7 @@ impl<'a, Http: HttpClient> SearchQuery<'a, Http> {
             locales: None,
             federation_options: None,
             show_performance_details: None,
+            personalize: None,
         }
     }
 
@@ -768,6 +782,13 @@ impl<'a, Http: HttpClient> SearchQuery<'a, Http> {
         show_performance_details: bool,
     ) -> &'b mut SearchQuery<'a, Http> {
         self.show_performance_details = Some(show_performance_details);
+        self
+    }
+
+    pub fn with_personalization<'b>(
+        &'b mut self, user_context: &'a str,
+    ) -> &'b mut SearchQuery<'a, Http> {
+        self.personalize = Some(Personalize { user_context: user_context });
         self
     }
 
@@ -2394,6 +2415,20 @@ pub(crate) mod tests {
             .await?;
 
         assert!(response.performance_details.is_some());
+
+        Ok(())
+    }
+
+    #[meilisearch_test]
+    async fn test_search_with_personalization(
+        client: Client, 
+        index: Index,
+    ) -> Result<(), Error> {
+        setup_test_index(&client, &index).await?;
+        let resp: SearchResults<Document> = index.search().with_query("Harry Potter").with_personalization(
+            "User likes fantasy movies"
+        ).execute().await?;
+        assert!(!resp.hits.is_empty());
 
         Ok(())
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -434,11 +434,10 @@ pub struct SearchQuery<'a, Http: HttpClient> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_performance_details: Option<bool>,
 
-    // Defines search personalization for the user profile context 
+    // Defines search personalization for the user profile context
     #[serde(skip_serializing_if = "Option::is_none")]
     pub personalize: Option<Personalize<'a>>,
 }
-
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -451,13 +450,11 @@ pub struct QueryFederationOptions {
     pub remote: Option<String>,
 }
 
-
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Personalize<'a> {
-    pub user_context: &'a str
+    pub user_context: &'a str,
 }
-
 
 #[allow(missing_docs)]
 impl<'a, Http: HttpClient> SearchQuery<'a, Http> {
@@ -786,7 +783,8 @@ impl<'a, Http: HttpClient> SearchQuery<'a, Http> {
     }
 
     pub fn with_personalization<'b>(
-        &'b mut self, user_context: &'a str,
+        &'b mut self,
+        user_context: &'a str,
     ) -> &'b mut SearchQuery<'a, Http> {
         self.personalize = Some(Personalize { user_context });
         self
@@ -2419,11 +2417,8 @@ pub(crate) mod tests {
         Ok(())
     }
 
-   #[meilisearch_test]
-    async fn test_search_with_personalization(
-        client: Client,
-        index: Index,
-    ) -> Result<(), Error> {
+    #[meilisearch_test]
+    async fn test_search_with_personalization(client: Client, index: Index) -> Result<(), Error> {
         setup_test_index(&client, &index).await?;
 
         let res = index
@@ -2437,9 +2432,9 @@ pub(crate) mod tests {
 
         let err_msg = format!("{:?}", res.err().unwrap());
         assert!(
-            err_msg.contains("personalization") 
-            && err_msg.contains("reranking search"),
-            "Unexpected error message: {}", err_msg
+            err_msg.contains("personalization") && err_msg.contains("reranking search"),
+            "Unexpected error message: {}",
+            err_msg
         );
 
         Ok(())

--- a/src/search.rs
+++ b/src/search.rs
@@ -788,7 +788,7 @@ impl<'a, Http: HttpClient> SearchQuery<'a, Http> {
     pub fn with_personalization<'b>(
         &'b mut self, user_context: &'a str,
     ) -> &'b mut SearchQuery<'a, Http> {
-        self.personalize = Some(Personalize { user_context: user_context });
+        self.personalize = Some(Personalize { user_context });
         self
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -2419,16 +2419,28 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[meilisearch_test]
+   #[meilisearch_test]
     async fn test_search_with_personalization(
-        client: Client, 
+        client: Client,
         index: Index,
     ) -> Result<(), Error> {
         setup_test_index(&client, &index).await?;
-        let resp: SearchResults<Document> = index.search().with_query("Harry Potter").with_personalization(
-            "User likes fantasy movies"
-        ).execute().await?;
-        assert!(!resp.hits.is_empty());
+
+        let res = index
+            .search()
+            .with_query("Harry Potter")
+            .with_personalization("User likes fantasy movies")
+            .execute::<Value>()
+            .await;
+
+        assert!(matches!(res, Err(Error::Meilisearch(_))));
+
+        let err_msg = format!("{:?}", res.err().unwrap());
+        assert!(
+            err_msg.contains("personalization") 
+            && err_msg.contains("reranking search"),
+            "Unexpected error message: {}", err_msg
+        );
 
         Ok(())
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #793

## What does this PR do?
- add personalization search support for SearchQuery (`personalize` parameter)
- add integration test `test_search_with_personalization`  - this check that Meilisearch server sees and know personalize parameter in query.
- update `test_error_message_parsing` assert to support new uuid parse error text message (because this test is falling)
(https://github.com/uuid-rs/uuid/compare/v1.23.1...main)

**Note on testing:** The integration test is designed to assert for a `feature_not_enabled` Meilisearch error. Since search personalization requires a launch-time infrastructure configuration (`MEILI_EXPERIMENTAL_PERSONALIZATION_API_KEY`), the test validates the feature by ensuring the SDK correctly serializes the request and that the server successfully parses it. This prevents the test from failing in environments without external Cohere AI keys.
https://github.com/orgs/meilisearch/discussions/866

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
*Used Gemini web to brainstorm Meilisearch server error behavior and assist with structuring personalization test structure.*
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds experimental search personalization support to the Meilisearch Rust SDK, enabling support for Meilisearch 1.47.0's new personalized search capability. 

### Main Changes

**Search Personalization Support (`src/search.rs`)**
- Added a new `personalize` field to the `SearchQuery` struct that accepts an optional `Personalize<'a>` parameter
- Introduced a new public `Personalize<'a>` struct with a `user_context: &'a str` field, serialized as `userContext` in camelCase
- Added a `with_personalization(user_context)` builder method to set personalization context
- Added an integration test `test_search_with_personalization` that validates the feature by verifying the Meilisearch server correctly receives and parses the personalize parameter, checking for the expected `feature_not_enabled` error response to confirm proper handling in environments without personalization setup

**Supporting Changes**
- Updated `test_error_message_parsing` test in `src/errors.rs` to handle new UUID ParseLength error text from recent uuid crate updates
- Updated the documentation example in `src/indexes.rs` for `add_or_update_unchecked_payload` with a different payload format

### Implementation Notes
- The implementation discloses use of Gemini AI for brainstorming Meilisearch server error behavior and assisting with test structure design
- No external Cohere AI infrastructure configuration is required for the integration test

<!-- end of auto-generated comment: release notes by coderabbit.ai -->