### PR TITLE
Pin Meilisearch to v1.46 and deflake UUID error tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Build
         run: cargo build --verbose
-      - name: Meilisearch (latest version) setup with Docker
-        run: docker run -d -p 7700:7700 getmeili/meilisearch-enterprise:latest meilisearch --no-analytics --master-key=masterKey
+      - name: Meilisearch (v1.46) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch-enterprise:v1.46 meilisearch --no-analytics --master-key=masterKey
       - name: Run tests
         run: cargo test --verbose
       - name: Cargo check
@@ -89,8 +89,8 @@ jobs:
     name: Code Coverage
     steps:
       - uses: actions/checkout@v6
-      - name: Meilisearch (latest version) setup with Docker
-        run: docker run -d -p 7700:7700 getmeili/meilisearch-enterprise:latest meilisearch --no-analytics --master-key=masterKey
+      - name: Meilisearch (v1.46) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch-enterprise:v1.46 meilisearch --no-analytics --master-key=masterKey
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,8 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        # Avoid --all-features: jwt_aws_lc_rs and jwt_rust_crypto are mutually exclusive.
+        run: cargo llvm-cov --workspace --features futures-unsend --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - cargo:/vendor/cargo
 
   meilisearch:
-    image: getmeili/meilisearch-enterprise:latest
+    image: getmeili/meilisearch-enterprise:v1.46
     ports:
       - "7700"
     environment:

--- a/src/client.rs
+++ b/src/client.rs
@@ -125,7 +125,7 @@ impl<Http: HttpClient> Client<Http> {
     ) -> Result<MultiSearchResponse<T>, Error> {
         self.http_client
             .request::<(), &MultiSearchQuery<Http>, MultiSearchResponse<T>>(
-                &format!("{}/multi-search", &self.host),
+                &format!("{}/multi-search", self.host),
                 Method::Post { body, query: () },
                 200,
             )
@@ -140,7 +140,7 @@ impl<Http: HttpClient> Client<Http> {
     ) -> Result<FederatedMultiSearchResponse<T>, Error> {
         self.http_client
             .request::<(), &FederatedMultiSearchQuery<Http>, FederatedMultiSearchResponse<T>>(
-                &format!("{}/multi-search", &self.host),
+                &format!("{}/multi-search", self.host),
                 Method::Post { body, query: () },
                 200,
             )

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -377,7 +377,10 @@ mod test {
         );
 
         let error = Error::Uuid(Uuid::parse_str("67e55044").unwrap_err());
-        assert_eq!(error.to_string(), "The uid of the token has bit an uuid4 format: invalid length: expected length 32 for simple format, found 8");
+        assert!(matches!(error, Error::Uuid(_)));
+        assert!(error
+            .to_string()
+            .starts_with("The uid of the token has bit an uuid4 format:"));
 
         let data = r#"
         {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -377,7 +377,7 @@ mod test {
         );
 
         let error = Error::Uuid(Uuid::parse_str("67e55044").unwrap_err());
-        assert!(matches!(error, Error::Uuid(_)));
+        assert!(matches!(&error, Error::Uuid(_)));
         assert!(error
             .to_string()
             .starts_with("The uid of the token has bit an uuid4 format:"));

--- a/src/tenant_tokens.rs
+++ b/src/tenant_tokens.rs
@@ -50,6 +50,7 @@ pub fn generate_tenant_token(
 
 #[cfg(test)]
 mod tests {
+    use crate::errors::Error;
     use crate::tenant_tokens::*;
     use big_s::S;
     use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
@@ -163,7 +164,7 @@ mod tests {
         let key = "Ëa1ทt9bVcL-vãUทtP3OpXW5qPc%bWH5ทvw09";
         let token = generate_tenant_token(api_key_uid, json!(SEARCH_RULES), key, None);
 
-        assert!(token.is_err());
+        assert!(matches!(token, Err(Error::Uuid(_))));
     }
 
     #[test]
@@ -172,6 +173,6 @@ mod tests {
         let key = "Ëa1ทt9bVcL-vãUทtP3OpXW5qPc%bWH5ทvw09";
         let token = generate_tenant_token(api_key_uid, json!(SEARCH_RULES), key, None);
 
-        assert!(token.is_err());
+        assert!(matches!(token, Err(Error::InvalidUuid4Version)));
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes tests that were broken since Meilisearch v1.46

## What does this PR do?
- Avoid asserting unstable uuid Display text and make tenant-token failure cases check explicit error variants.
- Pin CI and local env (docker compose) to Meilisearch v1.46 so the codebase actually documents compatibility with Meilisearch

## AI disclosure

Cursor with `grok-4.5-high`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Pinned the search service to a fixed version in automated workflows and local configuration for more consistent results.
  * Strengthened tenant token validation tests to assert specific UUID-related error variants.
  * Made UUID error-message checks less brittle by validating expected prefixes rather than full wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->