### PR TITLE
Update examples to use the Tokio runtime and update README

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -814,10 +814,14 @@ add_movies_json_1: |-
   };
   use serde::{Serialize, Deserialize};
   use std::{io::prelude::*, fs::File};
-  use futures::executor::block_on;
 
-  fn main() { block_on(async move {
-    let client = Client::new("MEILISEARCH_URL", Some("masterKey"));
+  #[tokio::main]
+  async fn main() {
+    let client = Client::new(
+      "MEILISEARCH_URL",
+      Some("masterKey"),
+    )
+    .unwrap();
 
     // reading and parsing the file
     let mut file = File::open("movies.json")
@@ -835,7 +839,7 @@ add_movies_json_1: |-
       .add_documents(&movies_docs, None)
       .await
       .unwrap();
-  })}
+  }
 primary_field_guide_update_document_primary_key: |-
   let task = IndexUpdater::new("books", &client)
     .with_primary_key("title")
@@ -874,8 +878,8 @@ getting_started_add_documents: |-
   // In your .toml file:
     [dependencies]
     meilisearch-sdk = "0.33.0"
-    # futures: because we want to block on futures
-    futures = "0.3"
+    # tokio: async runtime required by the Meilisearch SDK
+    tokio = { version = "1", features = ["full"] }
     # serde: required if you are going to use documents
     serde = { version="1.0",   features = ["derive"] }
     # serde_json: required in some parts of this guide
@@ -912,10 +916,14 @@ getting_started_add_documents: |-
   };
   use serde::{Serialize, Deserialize};
   use std::{io::prelude::*, fs::File};
-  use futures::executor::block_on;
 
-  fn main() { block_on(async move {
-    let client = Client::new("MEILISEARCH_URL", Some("aSampleMasterKey"));
+  #[tokio::main]
+  async fn main() {
+    let client = Client::new(
+      "MEILISEARCH_URL",
+      Some("aSampleMasterKey"),
+    )
+    .unwrap();
 
     // Reading and parsing the file
     let mut file = File::open("movies.json")
@@ -933,7 +941,7 @@ getting_started_add_documents: |-
       .add_documents(&movies_docs, None)
       .await
       .unwrap();
-  })}
+  }
 getting_started_search: |-
   // You can build a `SearchQuery` and execute it later:
   let query: SearchQuery = SearchQuery::new(&movies)

--- a/README.tpl
+++ b/README.tpl
@@ -63,7 +63,7 @@ futures = "0.3" # To be able to block on async functions if you are not using an
 serde = { version = "1.0", features = ["derive"] }
 ```
 
-This crate is `async` but you can choose to use an async runtime like [tokio](https://crates.io/crates/tokio) or just [block on futures](https://docs.rs/futures/latest/futures/executor/fn.block_on.html).
+This crate is `async`. You can use it with an async runtime such as [tokio](https://crates.io/crates/tokio), or just [block on futures](https://docs.rs/futures/latest/futures/executor/fn.block_on.html). When blocking, provide your own HttpClient (see [Customize the `HttpClient`](#customize-the-httpclient)) - since the default reqwest client needs tokio.
 You can enable the `sync` feature to make most structs `Sync`. It may be a bit slower.
 
 Using this crate is possible without [serde](https://crates.io/crates/serde), but a lot of features require serde.

--- a/examples/cli-app/Cargo.toml
+++ b/examples/cli-app/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 meilisearch-sdk = {path="../.."}
-futures = "0.3"
+tokio = { version = "1", features = ["full"] }
 serde = { version="1.0",   features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.4.0"

--- a/examples/cli-app/src/main.rs
+++ b/examples/cli-app/src/main.rs
@@ -1,4 +1,3 @@
-use futures::executor::block_on;
 use lazy_static::lazy_static;
 use meilisearch_sdk::client::Client;
 use meilisearch_sdk::settings::Settings;
@@ -11,31 +10,30 @@ lazy_static! {
     static ref CLIENT: Client = Client::new("http://localhost:7700", Some("masterKey")).unwrap();
 }
 
-fn main() {
-    block_on(async move {
-        // build the index
-        build_index().await;
+#[tokio::main]
+async fn main() {
+    // build the index
+    build_index().await;
 
-        // enter in search queries or quit
-        loop {
-            println!("Enter a search query or type \"q\" or \"quit\" to quit:");
-            let mut input_string = String::new();
-            stdin()
-                .read_line(&mut input_string)
-                .expect("Failed to read line");
-            match input_string.trim() {
-                "quit" | "q" | "" => {
-                    println!("exiting...");
-                    break;
-                }
-                _ => {
-                    search(input_string.trim()).await;
-                }
+    // enter in search queries or quit
+    loop {
+        println!("Enter a search query or type \"q\" or \"quit\" to quit:");
+        let mut input_string = String::new();
+        stdin()
+            .read_line(&mut input_string)
+            .expect("Failed to read line");
+        match input_string.trim() {
+            "quit" | "q" | "" => {
+                println!("exiting...");
+                break;
+            }
+            _ => {
+                search(input_string.trim()).await;
             }
         }
-        // get rid of the index at the end, doing this only so users don't have the index without knowing
-        let _ = CLIENT.delete_index("clothes").await.unwrap();
-    })
+    }
+    // get rid of the index at the end, doing this only so users don't have the index without knowing
+    let _ = CLIENT.delete_index("clothes").await.unwrap();
 }
 
 async fn search(query: &str) {


### PR DESCRIPTION
Fixes #770 

Fixes the Rust documentation examples in [Get started](https://www.meilisearch.com/docs/resources/self_hosting/getting_started/quick_start#add-documents) and [Working with tasks](https://www.meilisearch.com/docs/capabilities/indexing/tasks_and_batches/monitor_tasks#adding-a-task-to-the-task-queue) pages. Additionally, the `examples/cli-app` is also fixed on the same lines.

Replaces `futures::executor::block_on` with `#[tokio::main]` and adds the required Tokio dependency.
Along with it, i also added the missing `.unwrap()` to `Client::new()` in the examples.

The README is updated and now clarifies the runtime requirement

Tested it locally by:
- running `generate-code-sample-snippets-file` against this branch in `meilisearch/documentation` repo
- running the checks `check-*` in `meilisearch/documentation` repo
- verifying the updated documentation on localhost

I used AI to understand how this repo and the `meilisearch/documentation` repo are linked, how the documentation is generated and little bit about the npm commands

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
