### PR TITLE
Add get_task_documents method 

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -228,6 +228,8 @@ get_task_1: |-
     .get_task(1)
     .await
     .unwrap();
+get_task_documents_1: |-
+  let documents = client.get_task_documents(task).await.unwrap();
 async_guide_multiple_filters_1: |-
   let mut query = TasksQuery::new(&client);
   let tasks = query

--- a/examples/cli-app-with-awc/src/main.rs
+++ b/examples/cli-app-with-awc/src/main.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use meilisearch_sdk::errors::Error;
-use meilisearch_sdk::request::{parse_response, HttpClient, Method};
+use meilisearch_sdk::request::{parse_response, parse_response_ndjson, HttpClient, Method};
 use meilisearch_sdk::{client::*, settings::Settings};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -82,6 +82,63 @@ impl HttpClient for AwcClient {
         }
 
         parse_response(status, expected_status_code, &body, url.to_string())
+    }
+
+    async fn stream_request_ndjson<
+        Query: Serialize + Send + Sync,
+        Body: futures::AsyncRead + Send + Sync + 'static,
+    >(
+        &self,
+        url: &str,
+        method: Method<Query, Body>,
+        content_type: &str,
+        expected_status_code: u16,
+    ) -> Result<Vec<serde_json::Value>, Error> {
+        let mut builder = awc::ClientBuilder::new();
+        if let Some(ref api_key) = self.api_key {
+            builder = builder.bearer_auth(api_key);
+        }
+        builder = builder.add_default_header(("User-Agent", "Rust client with Awc"));
+        let client = builder.finish();
+
+        let query = method.query();
+        let query = yaup::to_string(query)?;
+
+        let url = if query.is_empty() {
+            url.to_string()
+        } else {
+            format!("{url}?{query}")
+        };
+
+        let url = add_query_parameters(&url, method.query())?;
+        let request = client.request(verb(&method), &url);
+
+        let mut response = if let Some(body) = method.into_body() {
+            let reader = tokio_util::compat::FuturesAsyncReadCompatExt::compat(body);
+            let stream = tokio_util::io::ReaderStream::new(reader);
+            request
+                .content_type(content_type)
+                .send_stream(stream)
+                .await
+                .map_err(|err| Error::Other(anyhow::anyhow!(err.to_string()).into()))?
+        } else {
+            request
+                .send()
+                .await
+                .map_err(|err| Error::Other(anyhow::anyhow!(err.to_string()).into()))?
+        };
+
+        let status = response.status().as_u16();
+        let body = String::from_utf8(
+            response
+                .body()
+                .await
+                .map_err(|err| Error::Other(anyhow::anyhow!(err.to_string()).into()))?
+                .to_vec(),
+        )
+        .map_err(|err| Error::Other(anyhow::anyhow!(err.to_string()).into()))?;
+
+        parse_response_ndjson(status, expected_status_code, &body, url.to_string())
     }
 }
 

--- a/examples/cli-app-with-awc/src/main.rs
+++ b/examples/cli-app-with-awc/src/main.rs
@@ -107,7 +107,7 @@ impl HttpClient for AwcClient {
         let url = if query.is_empty() {
             url.to_string()
         } else {
-            format!("{url}?{query}")
+            format!("{url}{query}")
         };
 
         let url = add_query_parameters(&url, method.query())?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1011,6 +1011,47 @@ impl<Http: HttpClient> Client<Http> {
         Ok(tasks)
     }
 
+    /// Get the documents associated with a task.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use meilisearch_sdk::{client::*, tasks::*};
+    /// # use serde::{Serialize, Deserialize};
+    /// #
+    /// # let MEILISEARCH_URL = option_env!("MEILISEARCH_URL").unwrap_or("http://localhost:7700");
+    /// # let MEILISEARCH_API_KEY = option_env!("MEILISEARCH_API_KEY").unwrap_or("masterKey");
+    /// # #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    /// # struct Document {
+    /// #    id: usize,
+    /// #    value: String,
+    /// #    kind: String,
+    /// # }
+    /// #
+    /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+    /// # let client = Client::new(MEILISEARCH_URL, Some(MEILISEARCH_API_KEY)).unwrap();
+    /// # let index = client.create_index("movies_get_task_documents", None).await.unwrap().wait_for_completion(&client, None, None).await.unwrap().try_make_index(&client).unwrap();
+    /// let task = index.add_documents(&[
+    ///     Document { id: 0, kind: "title".into(), value: "The Social Network".to_string() },
+    ///     Document { id: 1, kind: "title".into(), value: "Harry Potter and the Sorcerer's Stone".to_string() },
+    /// ], None).await.unwrap();
+    ///
+    ///
+    /// let documents = client.get_task_documents(task).await.unwrap();
+    /// println!("DOCUMENTS: {:?}", documents);
+    ///
+    /// # index.delete().await.unwrap().wait_for_completion(&client, None, None).await.unwrap();
+    /// # });
+    pub async fn get_task_documents(&self, task_id: impl AsRef<u32>) -> Result<Vec<Value>, Error> {
+        self.http_client
+            .request_ndjson::<(), ()>(
+                &format!("{}/tasks/{}/documents", self.host, task_id.as_ref()),
+                Method::Get { query: () },
+                200,
+            )
+            .await
+    }
+
     /// Cancel tasks with filters [`TasksCancelQuery`].
     ///
     /// # Example
@@ -1755,6 +1796,34 @@ mod tests {
     async fn test_get_tasks(client: Client) {
         let tasks = client.get_tasks().await.unwrap();
         assert_eq!(tasks.limit, 20);
+    }
+
+    #[meilisearch_test]
+    async fn test_get_task_documents() {
+        let mut s = mockito::Server::new_async().await;
+        let base = s.url();
+
+        let response_body = r#"{"id":1,"title":"Book 1"}
+        {"id":2,"title":"Book 2"}"#;
+
+        let _m = s
+            .mock("GET", "/tasks/1/documents")
+            .with_status(200)
+            .with_header("content-type", "application/x-ndjson")
+            .with_body(response_body)
+            .create_async()
+            .await;
+
+        let client = Client::new(base, None::<String>).unwrap();
+
+        let task_id = Box::new(1u32);
+
+        let documents = client.get_task_documents(task_id).await.unwrap();
+        assert_eq!(documents.len(), 2);
+        assert_eq!(documents[0]["id"], 1);
+        assert_eq!(documents[0]["title"], "Book 1");
+        assert_eq!(documents[1]["id"], 2);
+        assert_eq!(documents[1]["title"], "Book 2");
     }
 
     #[meilisearch_test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1827,6 +1827,28 @@ mod tests {
     }
 
     #[meilisearch_test]
+    async fn test_get_task_documents_empty_response() {
+        let mut s = mockito::Server::new_async().await;
+        let base = s.url();
+
+        let _m = s
+            .mock("GET", "/tasks/1/documents")
+            .with_status(200)
+            .with_header("content-type", "application/x-ndjson")
+            .with_body("")
+            .create_async()
+            .await;
+
+        let client = Client::new(base, None::<String>).unwrap();
+
+        let task_id = Box::new(1u32);
+
+        let documents = client.get_task_documents(task_id).await.unwrap();
+
+        assert!(documents.is_empty());
+    }
+
+    #[meilisearch_test]
     async fn test_rename_index_via_swap(client: Client, name: String) -> Result<(), Error> {
         let from = format!("{name}_from");
         let to = format!("{name}_to");

--- a/src/features.rs
+++ b/src/features.rs
@@ -16,6 +16,8 @@ pub struct ExperimentalFeaturesResult {
     pub edit_documents_by_function: bool,
     #[serde(default)]
     pub multimodal: bool,
+    #[serde(default)]
+    pub get_task_documents_route: bool,
 }
 
 /// Struct representing the experimental features request.
@@ -49,6 +51,8 @@ pub struct ExperimentalFeatures<'a, Http: HttpClient> {
     pub edit_documents_by_function: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multimodal: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub get_task_documents_route: Option<bool>,
 }
 
 impl<'a, Http: HttpClient> ExperimentalFeatures<'a, Http> {
@@ -62,6 +66,7 @@ impl<'a, Http: HttpClient> ExperimentalFeatures<'a, Http> {
             contains_filter: None,
             edit_documents_by_function: None,
             multimodal: None,
+            get_task_documents_route: None,
         }
     }
 
@@ -150,6 +155,11 @@ impl<'a, Http: HttpClient> ExperimentalFeatures<'a, Http> {
         self.multimodal = Some(multimodal);
         self
     }
+
+    pub fn set_get_task_documents_route(&mut self, get_task_documents_route: bool) -> &mut Self {
+        self.get_task_documents_route = Some(get_task_documents_route);
+        self
+    }
 }
 
 #[cfg(test)]
@@ -166,6 +176,7 @@ mod tests {
         features.set_network(true);
         features.set_edit_documents_by_function(true);
         features.set_multimodal(true);
+        features.set_get_task_documents_route(true);
         let _ = features.update().await.unwrap();
 
         let res = features.get().await.unwrap();
@@ -175,5 +186,6 @@ mod tests {
         assert!(res.network);
         assert!(res.edit_documents_by_function);
         assert!(res.multimodal);
+        assert!(res.get_task_documents_route);
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,9 +1,9 @@
-use std::convert::Infallible;
+use std::{convert::Infallible, unreachable};
 
 use async_trait::async_trait;
 use log::{error, trace, warn};
 use serde::{de::DeserializeOwned, Serialize};
-use serde_json::{from_str, to_vec};
+use serde_json::{from_str, to_vec, Value};
 
 use crate::errors::{Error, MeilisearchCommunicationError, MeilisearchError};
 
@@ -90,6 +90,27 @@ pub trait HttpClient: Clone + Send + Sync {
         .await
     }
 
+    async fn request_ndjson<Query, Body, Output>(
+        &self,
+        url: &str,
+        method: Method<Query, Body>,
+        expected_status_code: u16,
+    ) -> Result<Vec<serde_json::Value>, Error>
+    where
+        Query: Serialize + Send + Sync,
+        Body: Serialize + Send + Sync,
+    {
+        use futures_util::io::Cursor;
+
+        self.stream_request_ndjson(
+            url,
+            method.map_body(|body| Cursor::new(to_vec(&body).unwrap())),
+            "application/x-ndjson",
+            expected_status_code,
+        )
+        .await
+    }
+
     async fn stream_request<
         Query: Serialize + Send + Sync,
         Body: futures_io::AsyncRead + Send + Sync + 'static,
@@ -101,6 +122,17 @@ pub trait HttpClient: Clone + Send + Sync {
         content_type: &str,
         expected_status_code: u16,
     ) -> Result<Output, Error>;
+
+    async fn stream_request_ndjson<
+        Query: Serialize + Send + Sync,
+        Body: futures_io::AsyncRead + Send + Sync + 'static,
+    >(
+        &self,
+        url: &str,
+        method: Method<Query, Body>,
+        content_type: &str,
+        expected_status_code: u16,
+    ) -> Result<Vec<serde_json::Value>, Error>;
 
     fn is_tokio(&self) -> bool {
         false
@@ -198,6 +230,19 @@ impl HttpClient for Infallible {
         unreachable!()
     }
 
+    async fn request_ndjson<Query, Body, Output>(
+        &self,
+        _url: &str,
+        _method: Method<Query, Body>,
+        _expected_status_code: u16,
+    ) -> Result<Vec<Value>, Error>
+    where
+        Query: Serialize + Send + Sync,
+        Body: Serialize + Send + Sync,
+    {
+        unreachable!()
+    }
+
     async fn stream_request<
         Query: Serialize + Send + Sync,
         Body: futures_io::AsyncRead + Send + Sync + 'static,
@@ -209,6 +254,19 @@ impl HttpClient for Infallible {
         _content_type: &str,
         _expected_status_code: u16,
     ) -> Result<Output, Error> {
+        unreachable!()
+    }
+
+    async fn stream_request_ndjson<
+        Query: Serialize + Send + Sync,
+        Body: futures_io::AsyncRead + Send + Sync + 'static,
+    >(
+        &self,
+        _url: &str,
+        _method: Method<Query, Body>,
+        _content_type: &str,
+        _expected_status_code: u16,
+    ) -> Result<Vec<serde_json::Value>, Error> {
         unreachable!()
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -90,7 +90,7 @@ pub trait HttpClient: Clone + Send + Sync {
         .await
     }
 
-    async fn request_ndjson<Query, Body, Output>(
+    async fn request_ndjson<Query, Body>(
         &self,
         url: &str,
         method: Method<Query, Body>,
@@ -184,15 +184,14 @@ pub fn parse_response_ndjson(
     url: String,
 ) -> Result<Vec<serde_json::Value>, Error> {
     if status_code == expected_status_code {
-        let output: Vec<serde_json::Value> = body
-            .lines()
-            .map(serde_json::from_str)
-            .collect::<Result<_, _>>()
+        let output = serde_json::Deserializer::from_str(body)
+            .into_iter::<serde_json::Value>()
+            .collect::<Result<Vec<_>, _>>()
             .map_err(Error::ParseError)?;
 
         trace!("Request succeed");
         return Ok(output);
-    };
+    }
 
     warn!("Expected response code {expected_status_code}, got {status_code}");
 
@@ -230,7 +229,7 @@ impl HttpClient for Infallible {
         unreachable!()
     }
 
-    async fn request_ndjson<Query, Body, Output>(
+    async fn request_ndjson<Query, Body>(
         &self,
         _url: &str,
         _method: Method<Query, Body>,

--- a/src/request.rs
+++ b/src/request.rs
@@ -145,6 +145,42 @@ pub fn parse_response<Output: DeserializeOwned>(
     }
 }
 
+pub fn parse_response_ndjson(
+    status_code: u16,
+    expected_status_code: u16,
+    body: &str,
+    url: String,
+) -> Result<Vec<serde_json::Value>, Error> {
+    if status_code == expected_status_code {
+        let output: Vec<serde_json::Value> = body
+            .lines()
+            .map(serde_json::from_str)
+            .collect::<Result<_, _>>()
+            .map_err(Error::ParseError)?;
+
+        trace!("Request succeed");
+        return Ok(output);
+    };
+
+    warn!("Expected response code {expected_status_code}, got {status_code}");
+
+    match from_str::<MeilisearchError>(body) {
+        Ok(e) => Err(Error::from(e)),
+        Err(e) => {
+            if status_code >= 400 {
+                return Err(Error::MeilisearchCommunication(
+                    MeilisearchCommunicationError {
+                        status_code,
+                        message: None,
+                        url,
+                    },
+                ));
+            }
+            Err(Error::ParseError(e))
+        }
+    }
+}
+
 #[cfg_attr(feature = "futures-unsend", async_trait(?Send))]
 #[cfg_attr(not(feature = "futures-unsend"), async_trait)]
 impl HttpClient for Infallible {

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -167,11 +167,7 @@ impl HttpClient for ReqwestClient {
 
         let response = self.client.execute(request.build()?).await?;
         let status = response.status().as_u16();
-        let mut body = response.text().await?;
-
-        if body.is_empty() {
-            body = "null".to_string();
-        }
+        let body = response.text().await?;
 
         parse_response_ndjson(status, expected_status_code, &body, url.to_string())
     }

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -9,10 +9,11 @@ use futures_core::Stream;
 use futures_io::AsyncRead;
 use pin_project_lite::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
 
 use crate::{
     errors::Error,
-    request::{parse_response, HttpClient, Method},
+    request::{parse_response, parse_response_ndjson, HttpClient, Method},
 };
 
 #[derive(Debug, Clone, Default)]
@@ -115,6 +116,64 @@ impl HttpClient for ReqwestClient {
         }
 
         parse_response(status, expected_status_code, &body, url.to_string())
+    }
+
+    async fn stream_request_ndjson<
+        Query: Serialize + Send + Sync,
+        Body: futures_io::AsyncRead + Send + Sync + 'static,
+    >(
+        &self,
+        url: &str,
+        method: Method<Query, Body>,
+        content_type: &str,
+        expected_status_code: u16,
+    ) -> Result<Vec<Value>, Error> {
+        use reqwest::header;
+
+        let query = method.query();
+        let query = yaup::to_string(query)?;
+
+        let url = if query.is_empty() {
+            url.to_string()
+        } else {
+            format!("{url}{query}")
+        };
+
+        let mut request = self.client.request(verb(&method), &url);
+
+        if let Some(body) = method.into_body() {
+            // TODO: Currently reqwest doesn't support streaming data in wasm so we need to collect everything in RAM
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let stream = ReaderStream::new(body);
+                let body = reqwest::Body::wrap_stream(stream);
+
+                request = request
+                    .header(header::CONTENT_TYPE, content_type)
+                    .body(body);
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                use futures_util::AsyncReadExt;
+
+                let mut buf = Vec::new();
+                let mut body = std::pin::pin!(body);
+                body.read_to_end(&mut buf)
+                    .await
+                    .map_err(|err| Error::Other(Box::new(err)))?;
+                request = request.header(header::CONTENT_TYPE, content_type).body(buf);
+            }
+        }
+
+        let response = self.client.execute(request.build()?).await?;
+        let status = response.status().as_u16();
+        let mut body = response.text().await?;
+
+        if body.is_empty() {
+            body = "null".to_string();
+        }
+
+        parse_response_ndjson(status, expected_status_code, &body, url.to_string())
     }
 
     fn is_tokio(&self) -> bool {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #776 

## What does this PR do?

Adds support for retrieving the documents associated with a task through the experimental `GET /tasks/{task_uid}/documents` endpoint.

### Changes

- Added `Client::get_task_documents`, returning the response as `Vec<serde_json::Value>`.
- Added NDJSON response handling through `request_ndjson` and `stream_request_ndjson`.
  - This endpoint returns newline-delimited JSON rather than a single JSON value, so each response line is deserialized independently into a `serde_json::Value`.
- Added NDJSON support to all existing `HttpClient` implementations:
  - `ReqwestClient`
  - the `AwcClient` example
  - the `Infallible`
- Empty successful NDJSON responses are parsed as an empty vector rather than `vec![Value::Null]`.
- Added tests covering successful and empty NDJSON responses.
- Added a documentation example for `get_task_documents`.
- Added the corresponding Meilisearch code sample in .code-samples.meilisearch file.
- Completed all the tasks mentioned in the issue description.
### Notes

The existing request pipeline expects a response to deserialize into a single JSON value. Since this endpoint returns NDJSON, a separate parsing path is used while preserving the existing JSON request/response behavior for other endpoints.

> AI Diclosure: I have used ChatGpt for narrowing the issue scope and have reviewed all the code changes repeatedly.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving documents associated with a task.
  * Added experimental feature configuration for the task documents route.
  * Added support for newline-delimited JSON responses, including streamed responses.
  * Added request examples demonstrating task document retrieval.

* **Bug Fixes**
  * Improved handling of streamed responses and response parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->