### PR TITLE
Add variant to TaskType enum (as well as associated details struct) for document edit tasks

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -15,6 +15,9 @@ pub enum TaskType {
     DocumentAdditionOrUpdate {
         details: Option<DocumentAdditionOrUpdate>,
     },
+    DocumentEdition {
+        details: Option<DocumentEdition>,
+    },
     DocumentDeletion {
         details: Option<DocumentDeletion>,
     },
@@ -68,6 +71,16 @@ pub struct TasksResults {
 pub struct DocumentAdditionOrUpdate {
     pub indexed_documents: Option<usize>,
     pub received_documents: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentEdition {
+    pub edited_documents: Option<usize>,
+    pub deleted_documents: Option<usize>,
+    pub original_filter: Option<String>,
+    pub context: Option<Map<String, Value>>,
+    pub function: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #805 

## What does this PR do?
- This PR adds a variant to the `TaskType` enum, as well as an associated "details" struct", for document edit tasks. The change will enable the client to receive information about these tasks (via the initial response payload, or any `/tasks`-based operations, including `TaskInfo#wait_for_completion` method invocations) without panicking.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? No.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)? Yes
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking document-edition tasks.
  - Edition details can include edited and deleted document counts, the original filter, contextual data, and the associated function name.
  - Edition details are optional, allowing tasks to be created with or without additional metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->